### PR TITLE
feat: Calculate hash

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -144,8 +144,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("error translating refinery config: %v", err)
 		}
-		cfgout := cfg.Render()
-		data, err := y.Marshal(cfgout)
+		data, _, err := cfg.RenderYAML()
 		if err != nil {
 			log.Fatalf("error marshaling output file: %v", err)
 		}

--- a/pkg/yaml/dottedconfig.go
+++ b/pkg/yaml/dottedconfig.go
@@ -1,6 +1,12 @@
 package yaml
 
-import "strings"
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+
+	y "gopkg.in/yaml.v3"
+)
 
 // DottedConfig is a map that allows for keys with dots in them;
 // it can convert a regular map into a DottedConfig, and
@@ -30,6 +36,20 @@ func (dc DottedConfig) Render() map[string]any {
 		dc.renderInto(m, k, v)
 	}
 	return m
+}
+
+func (dc DottedConfig) RenderYAML() ([]byte, string, error) {
+	m := dc.Render()
+	data, err := y.Marshal(m)
+	if err != nil {
+		return nil, "", err
+	}
+	// we use md5 here because:
+	// * this is not a security-centric use case, we just want a hash
+	// * it's compatible with command line tools as well as Refinery's existing code
+	h := md5.New()
+	hash := hex.EncodeToString(h.Sum(data))
+	return data, hash, nil
 }
 
 func (dc DottedConfig) Merge(other DottedConfig) DottedConfig {


### PR DESCRIPTION

## Which problem is this PR solving?

- Calculates an md5 hash of the things that are being rendered. It is currently not exposed anywhere, but it's compatible with Refinery's hash calculation.

## Short description of the changes

- Add hash generation
- Change API to return it with a YAML render
- adjust main

