### PR TITLE
feat: Add base component for valid configs

### DIFF
--- a/pkg/config/refinery.go
+++ b/pkg/config/refinery.go
@@ -7,6 +7,29 @@ import (
 	"github.com/honeycombio/hpsf/pkg/yaml"
 )
 
+// This base component is used to make sure that the config will be valid
+// even if it stands alone. This is likely to be a temporary solution until we have a
+// database of components.
+type RefineryBaseComponent struct {
+	Component hpsf.Component
+}
+
+func (c RefineryBaseComponent) GenerateConfig(ct Type) (yaml.DottedConfig, error) {
+	switch ct {
+	case RefineryConfigType:
+		return yaml.DottedConfig{
+			"General.ConfigurationVersion": 2,
+			"General.MinRefineryVersion":   "v2.0",
+		}, nil
+	case RefineryRulesType:
+		return yaml.DottedConfig{
+			"RulesVersion": 2,
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
 type RefineryInputComponent struct {
 	Component hpsf.Component
 }

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -32,6 +32,17 @@ func (t *Translator) MakeConfigComponent(component hpsf.Component) (config.Compo
 
 func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type) (yaml.DottedConfig, error) {
 	composite := yaml.DottedConfig{}
+
+	// Add base component to the config so we can make a valid config
+	// this may be temporary until we have a database of components
+	dummy := hpsf.Component{Name: "dummy", Kind: "dummy"}
+	base := config.RefineryBaseComponent{Component: dummy}
+	cfg, err := base.GenerateConfig(ct)
+	if err != nil {
+		return nil, err
+	}
+	composite.Merge(cfg)
+
 	for _, c := range h.Components {
 		comp, err := t.MakeConfigComponent(c)
 		if err != nil {


### PR DESCRIPTION
## Which problem is this PR solving?

- Refinery Configs generated by hpsf didn't work without layering them onto another config. This gives us a way to generate something

## Short description of the changes

- Add a base refinery component with the minimum fields for a valid config file
- Use it automatically as the first component when building the configs

