### PR TITLE
maint: update go.mod min version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/hpsf
 
-go 1.23.1
+go 1.23.0
 
 require (
 	github.com/jessevdk/go-flags v1.6.1


### PR DESCRIPTION
Setting this to minimum go 1.23 version to be consistent with other repositories.