### PR TITLE
feat(hpsf): add ability to produce otlp exporter to honeycomb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+GOTESTCMD = $(if $(shell command -v gotestsum),gotestsum --junitfile ./test_results/$(1).xml --format testname --,go test)
+
+.PHONY: test
+#: run all tests
+test: test_with_race test_all
+
+.PHONY: test_with_race
+#: run only tests tagged with potential race conditions
+test_with_race: test_results
+	@echo
+	@echo "+++ testing - race conditions?"
+	@echo
+	$(call GOTESTCMD,$@) -tags race --race --timeout 60s -v ./...
+
+.PHONY: test_all
+#: run all tests, but with no race condition detection
+test_all: test_results
+	@echo
+	@echo "+++ testing - all the tests"
+	@echo
+	$(call GOTESTCMD,$@) -tags all --timeout 60s -v ./...
+
+test_results:
+	@mkdir -p test_results

--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -173,7 +173,7 @@ func main() {
 		}
 		cfg, err := tr.GenerateConfig(hpsf, ct, userdata)
 		if err != nil {
-			log.Fatalf("error translating refinery config: %v", err)
+			log.Fatalf("error translating config: %v", err)
 		}
 		data, _, err := cfg.RenderYAML()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,12 @@ go 1.23.0
 
 require (
 	github.com/jessevdk/go-flags v1.6.1
+	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.21.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/config/collector.go
+++ b/pkg/config/collector.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/yaml"
+)
+
+// This base component is used to make sure that the config will be valid
+// even if it stands alone. This is likely to be a temporary solution until we have a
+// database of components.
+type CollectorBaseComponent struct {
+	Component hpsf.Component
+}
+
+var _ Component = CollectorBaseComponent{}
+
+func (c CollectorBaseComponent) GenerateConfig(ct Type, userdata map[string]any) (yaml.DottedConfig, error) {
+	return yaml.DottedConfig{
+		"processors": map[string]any{},
+		"receivers":  map[string]any{},
+		"extensions": map[string]any{},
+		"service":    map[string]any{},
+	}, nil
+}

--- a/pkg/config/collector_test.go
+++ b/pkg/config/collector_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/hpsf/pkg/yaml"
+)
+
+func TestCollectorBaseComponent(t *testing.T) {
+	c := CollectorBaseComponent{}
+	got, err := c.GenerateConfig(CollectorConfigType, map[string]any{})
+	want := yaml.DottedConfig{
+		"processors": map[string]interface{}{},
+		"receivers":  map[string]interface{}{},
+		"extensions": map[string]interface{}{},
+		"service":    map[string]interface{}{},
+	}
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/pkg/config/components/honeycombExporter.yaml
+++ b/pkg/config/components/honeycombExporter.yaml
@@ -23,6 +23,14 @@ properties:
     type: string
     validations: [nonblank, url]
     default: https://api.honeycomb.io
+  - name: Compression
+    summary: The compression to use when sending data to Honeycomb
+    description: |
+      The compression to use when sending data to Honeycomb.
+      This is normally gzip, but can be overridden.
+    type: string
+    validations: [nonblank]
+    default: gzip
 templates:
   - kind: refinery_config
     name: HoneycombExporter_RefineryConfig
@@ -31,5 +39,17 @@ templates:
       - key: Network.HoneycombAPI
         value: "{{ firstNonblank .User.APIEndpoint .Props.APIEndpoint.Default }}"
       - key: AccessKeys.SendKey
-        value: "{{ .User.APIKey }}"
-
+        value: "{{ .User.API_Key }}"
+  - kind: collector_config
+    name: HoneycombExporter_CollectorConfig
+    format: dottedConfig
+    data:
+      - key: exporters.otlphttp.endpoint
+        value: "{{ firstNonblank .User.API_URL .Props.API_URL.Default }}"
+      - key: exporters.otlphttp.compression
+        value: "{{ firstNonblank .User.Compression .Props.Compression.Default }}"
+      # TODO: headers must be an array
+      - key: exporters.otlphttp.headers
+        value:
+          - name: x-honeycomb-team
+            value: "{{ .User.API_Key }}"

--- a/pkg/config/loadComponents_test.go
+++ b/pkg/config/loadComponents_test.go
@@ -1,7 +1,11 @@
 package config
 
 import (
+	"os"
+	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadTemplateComponents(t *testing.T) {
@@ -11,5 +15,45 @@ func TestLoadTemplateComponents(t *testing.T) {
 	}
 	if len(got) == 0 {
 		t.Errorf("LoadTemplateComponents() = %v, want non-empty", got)
+	}
+}
+
+func TestTemplateComponents(t *testing.T) {
+	components, err := LoadTemplateComponents()
+	require.NoError(t, err)
+	// for test component type
+	tests := []struct {
+		name       string
+		kind       string
+		cType      Type
+		wantOutput string
+	}{
+		{
+			name:       "HoneycombExporter to refinery config",
+			kind:       "HoneycombExporter",
+			cType:      RefineryConfigType,
+			wantOutput: "HoneycombExporter_output_refinery_config.yaml",
+		},
+		{
+			name:       "HoneycombExporter to collector config",
+			kind:       "HoneycombExporter",
+			cType:      CollectorConfigType,
+			wantOutput: "HoneycombExporter_output_collector_config.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, err := os.ReadFile(path.Join("testdata", tt.wantOutput))
+			require.NoError(t, err)
+			c, ok := components[tt.kind]
+			require.True(t, ok)
+			conf, err := c.GenerateConfig(tt.cType, map[string]any{
+				"API_Key": "test",
+			})
+			require.NoError(t, err)
+			got, _, err := conf.RenderYAML()
+			require.NoError(t, err)
+			require.Equal(t, string(want), string(got))
+		})
 	}
 }

--- a/pkg/config/refinery.go
+++ b/pkg/config/refinery.go
@@ -75,10 +75,6 @@ type DeterministicSampler struct {
 var _ Component = DeterministicSampler{}
 
 func (c DeterministicSampler) GenerateConfig(ct Type, userdata map[string]any) (yaml.DottedConfig, error) {
-	if ct != RefineryRulesType {
-		return nil, nil
-	}
-
 	if c.Component.Properties == nil {
 		return nil, nil
 	}
@@ -95,8 +91,18 @@ func (c DeterministicSampler) GenerateConfig(ct Type, userdata map[string]any) (
 	}
 	e := yaml.AsString(env.Value)
 
-	return yaml.DottedConfig{
-		fmt.Sprintf("Samplers.%s.DeterministicSampler.SampleRate", e): r,
-		"Samplers." + e + ".DeterministicSampler.SampleRate":          r,
-	}, nil
+	switch ct {
+	case CollectorConfigType:
+		return yaml.DottedConfig{
+			"probabilistic_sampler": map[string]interface{}{
+				"sampling_percentage": r,
+			},
+		}, nil
+	default:
+		return yaml.DottedConfig{
+			fmt.Sprintf("Samplers.%s.DeterministicSampler.SampleRate", e): r,
+			"Samplers." + e + ".DeterministicSampler.SampleRate":          r,
+		}, nil
+	}
+
 }

--- a/pkg/config/testdata/HoneycombExporter_output_collector_config.yaml
+++ b/pkg/config/testdata/HoneycombExporter_output_collector_config.yaml
@@ -1,0 +1,10 @@
+API_Key: ${HONEYCOMB_TRACES_APIKEY}
+API_URL: https://api.honeycomb.io
+Compression: gzip
+exporters:
+    otlphttp:
+        compression: gzip
+        endpoint: https://api.honeycomb.io
+        headers:
+            - name: x-honeycomb-team
+              value: test

--- a/pkg/config/testdata/HoneycombExporter_output_refinery_config.yaml
+++ b/pkg/config/testdata/HoneycombExporter_output_refinery_config.yaml
@@ -1,0 +1,7 @@
+API_Key: ${HONEYCOMB_TRACES_APIKEY}
+API_URL: https://api.honeycomb.io
+AccessKeys:
+    SendKey: test
+Compression: gzip
+Network:
+    HoneycombAPI: https://api.honeycomb.io

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -44,7 +44,14 @@ func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[s
 	// Add base component to the config so we can make a valid config
 	// this may be temporary until we have a database of components
 	dummy := hpsf.Component{Name: "dummy", Kind: "dummy"}
-	base := config.RefineryBaseComponent{Component: dummy}
+	var base config.Component
+	switch ct {
+	case config.RefineryConfigType, config.RefineryRulesType:
+		base = config.RefineryBaseComponent{Component: dummy}
+	case config.CollectorConfigType:
+		base = config.CollectorBaseComponent{Component: dummy}
+	}
+
 	cfg, err := base.GenerateConfig(ct, userdata)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Which problem is this PR solving?

This PR adds the ability to use the HoneycombExporter component template to produce collector configuration to emit otlphttp to honeycomb.

## Short description of the changes

- adding template for collector_config
- added tests for both refinery and collector config

