### PR TITLE
feat: Add default configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,16 @@
+package config
+
+// DefaultConfiguration is the default HPSF configuration that includes a
+// simple Refinery configuration with a determinisic sampler.
+const DefaultConfiguration = `
+components:
+  - name: DefaultDeterministicSampler
+    kind: DeterministicSampler
+    properties:
+      - name: Environment
+        value: __default__
+        type: string
+      - name: SampleRate
+        value: 1
+        type: number
+`


### PR DESCRIPTION
## Which problem is this PR solving?

When creating pipelines based on HPSF, it's important to start with a simple and valid configuration. This PR adds a configuration that be used as a basis for initial pipeline configurations.

## Short description of the changes

- Adds a simple default valid configuration that includes a simple Refinery configuration with a deterministic sampler

