### PR TITLE
feat: a bunch of refactoring and beginnings of collector support

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/honeycombio/hpsf/pkg/config"
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
 	"github.com/honeycombio/hpsf/pkg/translator"
 	"github.com/honeycombio/hpsf/pkg/validator"
-	"github.com/honeycombio/hpsf/pkg/yaml"
 	"github.com/jessevdk/go-flags"
 	y "gopkg.in/yaml.v3"
 )
@@ -151,7 +151,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("error unmarshaling to yaml: %v", err)
 		}
-		dc := yaml.NewDottedConfig(m)
+		dc := tmpl.NewDottedConfig(m)
 		for k, v := range dc {
 			fmt.Fprintf(outf, "%s: %v\n", k, v)
 		}

--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -173,9 +173,9 @@ func main() {
 		}
 		cfg, err := tr.GenerateConfig(hpsf, ct, userdata)
 		if err != nil {
-			log.Fatalf("error translating refinery config: %v", err)
+			log.Fatalf("error translating config: %v", err)
 		}
-		data, _, err := cfg.RenderYAML()
+		data, err := cfg.RenderYAML()
 		if err != nil {
 			log.Fatalf("error marshaling output file: %v", err)
 		}

--- a/pkg/config/collectorTemplate.go
+++ b/pkg/config/collectorTemplate.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+)
+
+// A collectorTemplate implements a template for a collector component. The component
+// should be marked with "format: collector" in the template file and it has more
+// specific fields than a dottedConfigTemplate.
+
+type collectorTemplate struct {
+	componentSection       string
+	signalType             string
+	collectorComponentName string
+	kvs                    map[string][]dottedConfigTemplateKV
+}
+
+func getKV(d any) (*dottedConfigTemplateKV, bool) {
+	kv := &dottedConfigTemplateKV{}
+	m, ok := d.(map[string]any)
+	if !ok {
+		return kv, false
+	}
+	if mk, ok := m["key"]; !ok {
+		return kv, false
+	} else {
+		if _, ok := mk.(string); !ok {
+			return kv, false
+		}
+		kv.key = mk.(string)
+	}
+	if _, ok := m["value"]; !ok {
+		return kv, false
+	} else {
+		if _, ok := m["value"].(string); !ok {
+			return kv, false
+		}
+		kv.value = m["value"].(string)
+	}
+	return kv, true
+}
+
+func buildCollectorTemplate(t TemplateData) (collectorTemplate, error) {
+	c := collectorTemplate{kvs: make(map[string][]dottedConfigTemplateKV)}
+
+	for mk, mv := range t.Meta {
+		switch mk {
+		case "componentSection":
+			c.componentSection = mv
+		case "signalType":
+			c.signalType = mv
+		case "collectorComponentName":
+			c.collectorComponentName = mv
+		default:
+			return c, fmt.Errorf("unknown meta key %s", mk)
+		}
+	}
+	if c.componentSection == "" {
+		return c, fmt.Errorf("missing componentSection in meta")
+	}
+
+	for _, d := range t.Data {
+		kv, ok := getKV(d)
+		if !ok {
+			return c, fmt.Errorf("expected map for data, got %T", d)
+		}
+		c.kvs[c.componentSection] = append(c.kvs[c.componentSection], *kv)
+	}
+	return c, nil
+}

--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -20,7 +20,7 @@ const (
 // the values are any valid YAML value.
 // We will need to convert the dotted paths into real ones later.
 type Component interface {
-	GenerateConfig(Type, map[string]any) (tmpl.TemplateConfig, error)
+	GenerateConfig(cfgType Type, userdata map[string]any) (tmpl.TemplateConfig, error)
 }
 
 type NullComponent struct{}

--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/honeycombio/hpsf/pkg/config/tmpl"
+import (
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
+	"github.com/honeycombio/hpsf/pkg/hpsf"
+)
 
 type Type string
 
@@ -24,4 +27,29 @@ type NullComponent struct{}
 
 func (c NullComponent) GenerateConfig(Type, map[string]any) (tmpl.TemplateConfig, error) {
 	return nil, nil
+}
+
+// This base component is used to make sure that the config will be valid
+// even if it stands alone. This is likely to be a temporary solution until we have a
+// database of components.
+type GenericBaseComponent struct {
+	Component hpsf.Component
+}
+
+func (c GenericBaseComponent) GenerateConfig(ct Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
+	switch ct {
+	case RefineryConfigType:
+		return tmpl.DottedConfig{
+			"General.ConfigurationVersion": 2,
+			"General.MinRefineryVersion":   "v2.0",
+		}, nil
+	case RefineryRulesType:
+		return tmpl.DottedConfig{
+			"RulesVersion": 2,
+		}, nil
+	case CollectorConfigType:
+		return tmpl.NewCollectorConfig(), nil
+	default:
+		return nil, nil
+	}
 }

--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -1,8 +1,6 @@
 package config
 
-import (
-	"github.com/honeycombio/hpsf/pkg/yaml"
-)
+import "github.com/honeycombio/hpsf/pkg/config/tmpl"
 
 type Type string
 
@@ -19,11 +17,11 @@ const (
 // the values are any valid YAML value.
 // We will need to convert the dotted paths into real ones later.
 type Component interface {
-	GenerateConfig(Type, map[string]any) (yaml.DottedConfig, error)
+	GenerateConfig(Type, map[string]any) (tmpl.TemplateConfig, error)
 }
 
 type NullComponent struct{}
 
-func (c NullComponent) GenerateConfig(Type, map[string]any) (yaml.DottedConfig, error) {
+func (c NullComponent) GenerateConfig(Type, map[string]any) (tmpl.TemplateConfig, error) {
 	return nil, nil
 }

--- a/pkg/config/components/OTelGRPCReceiver.yaml
+++ b/pkg/config/components/OTelGRPCReceiver.yaml
@@ -35,5 +35,5 @@ templates:
       collectorComponentName: otlp  # required receiver we'll check against configured collector
     data:
       - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
-        value: "{{ firstNonblank .User.Host .Props.Host.Default }}:{{ firstNonblank .User.Port .Props.Port.Default }}"
+        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelGRPCReceiver.yaml
+++ b/pkg/config/components/OTelGRPCReceiver.yaml
@@ -16,7 +16,7 @@ properties:
       you know what you're doing.
     type: string
     validations: [nonblank]
-    default: ${STRAWS_COLLECTOR_POD_IP}
+    default: ${COLLECTOR_POD_IP}
   - name: Port
     summary: The port on which to listen.
     description: |

--- a/pkg/config/components/OTelGRPCReceiver.yaml
+++ b/pkg/config/components/OTelGRPCReceiver.yaml
@@ -1,0 +1,39 @@
+name: OTel_GRPC_Receiver
+kind: OTelGRPCReceiver
+summary: Receives OpenTelemetry gRPC traces
+description: |
+  Imports telemetry to Honeycomb from OpenTelemetry gRPC traces (not HTTP).
+ports:
+  - name: Traces
+    direction: output
+    type: OTelTraces
+properties:
+  - name: Host
+    summary: The hostname or IP address on which to listen
+    description: |
+      Hostname or IP address on which to listen for incoming traces.
+      It is recommended not to change the default unless
+      you know what you're doing.
+    type: string
+    validations: [nonblank]
+    default: ${STRAWS_COLLECTOR_POD_IP}
+  - name: Port
+    summary: The port on which to listen.
+    description: |
+      The port on which to listen for incoming traces.
+      For gRPC in OTel, this is normally 4317.
+    type: string
+    validations: [nonblank, url]
+    default: 4317
+templates:
+  - kind: collector_config
+    name: OTelGRPCReceiver_CollectorConfig
+    format: collector
+    meta:
+      componentSection: receivers
+      signalType: traces # we'll generate a name for each pipeline if there's more than 1
+      collectorComponentName: otlp  # required receiver we'll check against configured collector
+    data:
+      - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
+        value: "{{ firstNonblank .User.Host .Props.Host.Default }}:{{ firstNonblank .User.Port .Props.Port.Default }}"
+      # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelHTTPReceiver.yaml
+++ b/pkg/config/components/OTelHTTPReceiver.yaml
@@ -35,5 +35,5 @@ templates:
       collectorComponentName: otlp  # required receiver we'll check against configured collector
     data:
       - key: "{{ .ComponentName }}.protocols.http.endpoint"
-        value: "{{ firstNonblank .User.Host .Props.Host.Default }}:{{ firstNonblank .User.Port .Props.Port.Default }}"
+        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelHTTPReceiver.yaml
+++ b/pkg/config/components/OTelHTTPReceiver.yaml
@@ -16,7 +16,7 @@ properties:
       you know what you're doing.
     type: string
     validations: [nonblank]
-    default: ${STRAWS_COLLECTOR_POD_IP}
+    default: ${COLLECTOR_POD_IP}
   - name: Port
     summary: The port on which to listen.
     description: |

--- a/pkg/config/components/OTelHTTPReceiver.yaml
+++ b/pkg/config/components/OTelHTTPReceiver.yaml
@@ -1,0 +1,39 @@
+name: OTel_HTTP_Receiver
+kind: OTelHTTPReceiver
+summary: Receives OpenTelemetry HTTP traces
+description: |
+  Imports telemetry to Honeycomb from OpenTelemetry HTTP traces (not gRPC).
+ports:
+  - name: Traces
+    direction: output
+    type: OTelTraces
+properties:
+  - name: Host
+    summary: The hostname or IP address on which to listen
+    description: |
+      Hostname or IP address on which to listen for incoming traces.
+      It is recommended not to change the default unless
+      you know what you're doing.
+    type: string
+    validations: [nonblank]
+    default: ${STRAWS_COLLECTOR_POD_IP}
+  - name: Port
+    summary: The port on which to listen.
+    description: |
+      The port on which to listen for incoming traces.
+      For HTTP in OTel, this is normally 4318.
+    type: string
+    validations: [nonblank, url]
+    default: 4318
+templates:
+  - kind: collector_config
+    name: OTelHTTPReceiver_CollectorConfig
+    format: collector
+    meta:
+      componentSection: receivers
+      signalType: traces # we'll generate a name for each pipeline if there's more than 1
+      collectorComponentName: otlp  # required receiver we'll check against configured collector
+    data:
+      - key: "{{ .ComponentName }}.protocols.http.endpoint"
+        value: "{{ firstNonblank .User.Host .Props.Host.Default }}:{{ firstNonblank .User.Port .Props.Port.Default }}"
+      # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/emaThroughput.yaml
+++ b/pkg/config/components/emaThroughput.yaml
@@ -68,7 +68,7 @@ properties:
 templates:
   - kind: refinery_rules
     name: EMA_Throughput_Rules
-    format: dottedConfig
+    format: dotted
     data:
       - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.GoalThroughput\" .Props.Environment.Value }}"
         value: "{{ firstNonblank .User.GoalThroughput.Value .Props.GoalThroughput.Default }}"

--- a/pkg/config/components/emaThroughput.yaml
+++ b/pkg/config/components/emaThroughput.yaml
@@ -71,8 +71,8 @@ templates:
     format: dotted
     data:
       - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.GoalThroughput\" .Props.Environment.Value }}"
-        value: "{{ firstNonblank .User.GoalThroughput.Value .Props.GoalThroughput.Default }}"
+        value: "{{ firstNonblank .HProps.GoalThroughput .User.GoalThroughput.Value .Props.GoalThroughput.Default }}"
       - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.AdjustmentInterval\" .Props.Environment.Value }}"
-        value: "{{ firstNonblank .User.AdjustmentInterval.Value .Props.AdjustmentInterval.Default }}"
+        value: "{{ firstNonblank .HProps.AdjustmentInterval .User.AdjustmentInterval.Value .Props.AdjustmentInterval.Default }}"
       - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.FieldList\" .Props.Environment.Value }}"
-        value: "{{ firstNonblank .User.FieldList.Value .Props.FieldList.Default }}"
+        value: "{{ firstNonblank .HProps.FieldList .User.FieldList.Value .Props.FieldList.Default }}"

--- a/pkg/config/components/honeycombExporter.yaml
+++ b/pkg/config/components/honeycombExporter.yaml
@@ -29,7 +29,7 @@ templates:
     format: dotted
     data:
       - key: Network.HoneycombAPI
-        value: "{{ firstNonblank .User.APIEndpoint .Props.APIEndpoint.Default }}"
+        value: "{{ firstNonblank HProps.APIEndpoint .User.APIEndpoint .Props.APIEndpoint.Default }}"
       - key: AccessKeys.SendKey
-        value: "{{ .User.APIKey }}"
+        value: "{{ firstNonblank HProps.APIKey .User.APIKey }}"
 

--- a/pkg/config/components/honeycombExporter.yaml
+++ b/pkg/config/components/honeycombExporter.yaml
@@ -26,7 +26,7 @@ properties:
 templates:
   - kind: refinery_config
     name: HoneycombExporter_RefineryConfig
-    format: dottedConfig
+    format: dotted
     data:
       - key: Network.HoneycombAPI
         value: "{{ firstNonblank .User.APIEndpoint .Props.APIEndpoint.Default }}"

--- a/pkg/config/dotTemplate.go
+++ b/pkg/config/dotTemplate.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
+)
+
+type dottedConfigTemplateKV struct {
+	key   string
+	value string
+}
+
+// dottedConfigTemplate is the type we use for templates that properly modeled by
+// a collection of key-value pairs that may be represented by structure keys (like Refinery config).
+
+type dottedConfigTemplate []dottedConfigTemplateKV
+
+func buildDottedConfigTemplate(data []any) (dottedConfigTemplate, error) {
+	var d dottedConfigTemplate
+	for _, v := range data {
+		m, ok := v.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected map, got %T", v)
+		}
+		var sk, sv string
+		if mk, ok := m["key"]; !ok {
+			return nil, fmt.Errorf("missing key in template data")
+		} else {
+			if _, ok := mk.(string); !ok {
+				return nil, fmt.Errorf("expected string for key, got %T", mk)
+			}
+			sk = mk.(string)
+		}
+		if _, ok := m["value"]; !ok {
+			return nil, fmt.Errorf("missing value in template data")
+		} else {
+			if _, ok := m["value"].(string); !ok {
+				return nil, fmt.Errorf("expected string for v, got %T", m["value"])
+			}
+			sv = m["value"].(string)
+		}
+		d = append(d, dottedConfigTemplateKV{key: sk, value: sv})
+	}
+	return d, nil
+}
+
+func (t *TemplateComponent) generateDottedConfig(dct dottedConfigTemplate, userdata map[string]any) (tmpl.DottedConfig, error) {
+	// we have to fill in the template with the default values
+	// and the values from the properties
+	config := make(tmpl.DottedConfig)
+	for _, kv := range dct {
+		// do the key
+		key, err := t.applyTemplate(kv.key, userdata)
+		if err != nil {
+			return nil, err
+		}
+		// and then the value
+		value, err := t.applyTemplate(kv.value, userdata)
+		if err != nil {
+			return nil, err
+		}
+		config[key] = value
+	}
+	return config, nil
+}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -2,9 +2,9 @@ package config
 
 import (
 	"fmt"
-	"html/template"
 	"regexp"
 	"strings"
+	"text/template"
 	"time"
 )
 
@@ -19,7 +19,6 @@ func helpers() template.FuncMap {
 		"comment":       comment,
 		"firstNonblank": firstNonblank,
 		"indent":        indent,
-		"indentRest":    indentRest,
 		"join":          join,
 		"makeSlice":     makeSlice,
 		"meta":          meta,
@@ -29,10 +28,12 @@ func helpers() template.FuncMap {
 	}
 }
 
+// places a comment in the output file, even if the specified comment has multiple lines
 func comment(s string) string {
 	return strings.TrimRight("## "+strings.Replace(s, "\n", "\n## ", -1), " ")
 }
 
+// returns the first non-blank string from the arguments
 func firstNonblank(s ...any) string {
 	for _, v := range s {
 		if v != nil {
@@ -45,32 +46,33 @@ func firstNonblank(s ...any) string {
 	return ""
 }
 
+// indents a string by the specified number of spaces
 func indent(count int, s string) string {
-	return strings.Repeat(" ", count) + indentRest(count, s)
+	return strings.Repeat(" ", count) + _indentRest(count, s)
 }
 
-func indentRest(count int, s string) string {
-	eolpat := regexp.MustCompile(`[ \t]*\n[ \t]*`)
-	return eolpat.ReplaceAllString(s, "\n"+strings.Repeat(" ", count))
-}
-
+// joins a slice of strings with the specified separator
 func join(a []string, sep string) string {
 	return strings.Join(a, sep)
 }
 
+// creates a slice of strings from the arguments
 func makeSlice(a ...string) []string {
 	return a
 }
 
+// wraps a string in "{{" and "}}" to indicate that it's a template variable
 func meta(s string) string {
 	return "{{ " + s + " }}"
 }
 
+// returns the current date and time in UTC
 func now() string {
 	t := time.Now().UTC()
 	return fmt.Sprintf("on %s at %s UTC", t.Format("2006-01-02"), t.Format("15:04:05"))
 }
 
+// splits a string into a slice of strings using the specified separator
 func split(s, sep string) []string {
 	return strings.Split(s, sep)
 }
@@ -125,6 +127,12 @@ func _formatIntWithUnderscores(i int) string {
 	return strings.Join(output, "_")
 }
 
+// indents a string by the specified number of spaces, but only after newlines (used by indent)
+func _indentRest(count int, s string) string {
+	eolpat := regexp.MustCompile(`[ \t]*\n[ \t]*`)
+	return eolpat.ReplaceAllString(s, "\n"+strings.Repeat(" ", count))
+}
+
 func _isZeroValue(value any) bool {
 	switch v := value.(type) {
 	case string:
@@ -169,8 +177,8 @@ func _fetch(data map[string]any, key string) (any, bool) {
 	return nil, false
 }
 
-// Takes a value that is a slice of strings or any and returns a slice of
-// strings.
+// Takes a value that is a slice of strings or a slice of any and returns a
+// slice of strings.
 func _getStringsFrom(value any) []string {
 	result := make([]string, 0)
 

--- a/pkg/config/loadComponents.go
+++ b/pkg/config/loadComponents.go
@@ -30,7 +30,6 @@ func LoadTemplateComponents() (map[string]TemplateComponent, error) {
 		var component TemplateComponent
 		err = y.Unmarshal(templateData, &component)
 		if err != nil {
-			fmt.Println(comp.Name(), err)
 			return nil, err
 		}
 

--- a/pkg/config/refinery.go
+++ b/pkg/config/refinery.go
@@ -8,29 +8,6 @@ import (
 	"github.com/honeycombio/hpsf/pkg/yaml"
 )
 
-// This base component is used to make sure that the config will be valid
-// even if it stands alone. This is likely to be a temporary solution until we have a
-// database of components.
-type RefineryBaseComponent struct {
-	Component hpsf.Component
-}
-
-func (c RefineryBaseComponent) GenerateConfig(ct Type, userdata map[string]any) (tmpl.DottedConfig, error) {
-	switch ct {
-	case RefineryConfigType:
-		return tmpl.DottedConfig{
-			"General.ConfigurationVersion": 2,
-			"General.MinRefineryVersion":   "v2.0",
-		}, nil
-	case RefineryRulesType:
-		return tmpl.DottedConfig{
-			"RulesVersion": 2,
-		}, nil
-	default:
-		return nil, nil
-	}
-}
-
 type RefineryInputComponent struct {
 	Component hpsf.Component
 }

--- a/pkg/config/refinery.go
+++ b/pkg/config/refinery.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
 	"github.com/honeycombio/hpsf/pkg/yaml"
 )
@@ -14,15 +15,15 @@ type RefineryBaseComponent struct {
 	Component hpsf.Component
 }
 
-func (c RefineryBaseComponent) GenerateConfig(ct Type, userdata map[string]any) (yaml.DottedConfig, error) {
+func (c RefineryBaseComponent) GenerateConfig(ct Type, userdata map[string]any) (tmpl.DottedConfig, error) {
 	switch ct {
 	case RefineryConfigType:
-		return yaml.DottedConfig{
+		return tmpl.DottedConfig{
 			"General.ConfigurationVersion": 2,
 			"General.MinRefineryVersion":   "v2.0",
 		}, nil
 	case RefineryRulesType:
-		return yaml.DottedConfig{
+		return tmpl.DottedConfig{
 			"RulesVersion": 2,
 		}, nil
 	default:
@@ -37,7 +38,7 @@ type RefineryInputComponent struct {
 // ensure RefineryInputComponent implements Component
 var _ Component = RefineryInputComponent{}
 
-func (c RefineryInputComponent) GenerateConfig(ct Type, userdata map[string]any) (yaml.DottedConfig, error) {
+func (c RefineryInputComponent) GenerateConfig(ct Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	if ct != RefineryConfigType {
 		return nil, nil
 	}
@@ -53,12 +54,12 @@ func (c RefineryInputComponent) GenerateConfig(ct Type, userdata map[string]any)
 
 	switch c.Component.Kind {
 	case "RefineryGRPC":
-		return yaml.DottedConfig{
+		return tmpl.DottedConfig{
 			"GRPCServerParameters.Enabled":    true,
 			"GRPCServerParameters.ListenAddr": "0.0.0.0:" + pstr,
 		}, nil
 	case "RefineryHTTP":
-		return yaml.DottedConfig{
+		return tmpl.DottedConfig{
 			"GRPCServerParameters.Enabled": true,
 			"Network.ListenAddr":           "0.0.0.0:" + pstr,
 		}, nil
@@ -74,7 +75,7 @@ type DeterministicSampler struct {
 // ensure DeterministicSampler implements Component
 var _ Component = DeterministicSampler{}
 
-func (c DeterministicSampler) GenerateConfig(ct Type, userdata map[string]any) (yaml.DottedConfig, error) {
+func (c DeterministicSampler) GenerateConfig(ct Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	if ct != RefineryRulesType {
 		return nil, nil
 	}
@@ -95,7 +96,7 @@ func (c DeterministicSampler) GenerateConfig(ct Type, userdata map[string]any) (
 	}
 	e := yaml.AsString(env.Value)
 
-	return yaml.DottedConfig{
+	return tmpl.DottedConfig{
 		fmt.Sprintf("Samplers.%s.DeterministicSampler.SampleRate", e): r,
 		"Samplers." + e + ".DeterministicSampler.SampleRate":          r,
 	}, nil

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -79,7 +79,7 @@ func (t *TemplateComponent) SetHPSF(c hpsf.Component) {
 	t.hpsf = &c
 }
 
-// HProp is a template helper that gets a map of all properties specified in the hpsf document.
+// HProps is a template helper that gets a map of all properties specified in the hpsf document.
 func (t *TemplateComponent) HProps() map[string]any {
 	props := make(map[string]any)
 	if t.hpsf != nil {

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -71,6 +71,24 @@ type TemplateComponent struct {
 	Properties  []TemplateProperty `yaml:"properties,omitempty"`
 	Templates   []TemplateData     `yaml:"templates,omitempty"`
 	User        map[string]any     `yaml:"user,omitempty"`
+	hpsf        *hpsf.Component    // the component from the hpsf document
+}
+
+// we're making a copy here to make sure it doesn't get modified
+func (t *TemplateComponent) SetHPSF(c hpsf.Component) {
+	t.hpsf = &c
+}
+
+// HProp is a template helper that gets a map of all properties specified in the hpsf document.
+func (t *TemplateComponent) HProps() map[string]any {
+	props := make(map[string]any)
+	if t.hpsf != nil {
+		for _, name := range t.hpsf.GetPropertyNames() {
+			p := t.hpsf.GetProperty(name)
+			props[p.Name] = p.Value
+		}
+	}
+	return props
 }
 
 // helper for templates

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -74,7 +74,8 @@ type TemplateComponent struct {
 	hpsf        *hpsf.Component    // the component from the hpsf document
 }
 
-// we're making a copy here to make sure it doesn't get modified
+// SetHPSF is making a copy here (by not taking a pointer argument) to make sure 
+// that the original doesn't get modified.
 func (t *TemplateComponent) SetHPSF(c hpsf.Component) {
 	t.hpsf = &c
 }

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -74,8 +74,8 @@ type TemplateComponent struct {
 	hpsf        *hpsf.Component    // the component from the hpsf document
 }
 
-// SetHPSF is making a copy here (by not taking a pointer argument) to make sure 
-// that the original doesn't get modified.
+// SetHPSF stores the original component's details and may modify their contents. To
+// prevent the original being modified, the argument here should never be changed to a pointer.
 func (t *TemplateComponent) SetHPSF(c hpsf.Component) {
 	t.hpsf = &c
 }

--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -1,0 +1,154 @@
+package tmpl
+
+import (
+	"strings"
+
+	y "gopkg.in/yaml.v3"
+)
+
+// CollectorConfig is a config specifically focused on creating collector
+// YAML configuration files.
+type CollectorConfig struct {
+	Sections map[string]DottedConfig
+	// receivers  DottedConfig
+	// processors DottedConfig
+	// exporters  DottedConfig
+	// extensions DottedConfig
+	// service    DottedConfig
+}
+
+// ensure CollectorConfig implements TemplateConfig
+var _ TemplateConfig = (*CollectorConfig)(nil)
+
+// These types are used to unmarshal the collector config into a struct so that
+// we can marshal it back out in a format that's idiomatic for the collector
+// (i.e. with the sections in the right order and brackets for the lists --
+// that's what the "flow" tag is for).
+
+// signalPipeline is a struct that represents a pipeline in the collector config.
+type signalPipeline struct {
+	Receivers  []string `yaml:"receivers,flow"`
+	Processors []string `yaml:"processors,flow"`
+	Exporters  []string `yaml:"exporters,flow"`
+}
+
+// collectorConfigService is a struct that represents the service section of the collector config.
+type collectorConfigService struct {
+	Extensions []string                  `yaml:"extensions,omitempty,flow"`
+	Pipelines  map[string]signalPipeline `yaml:"pipelines"`
+}
+
+// collectorConfigFormat is a struct that represents the collector config in a
+// format and ordering that's idiomatic for the collector.
+type collectorConfigFormat struct {
+	Receivers  map[string]any         `yaml:"receivers,omitempty"`
+	Processors map[string]any         `yaml:"processors,omitempty"`
+	Exporters  map[string]any         `yaml:"exporters,omitempty"`
+	Extensions map[string]any         `yaml:"extensions,omitempty"`
+	Service    collectorConfigService `yaml:"service"`
+}
+
+// Set sets a key in the config to a value. If the key already exists, it will
+// append the value to the existing value if it's a slice, or overwrite it if
+// it's not a slice.
+// It will create the section if it doesn't exist.
+func (cc *CollectorConfig) Set(section string, key string, value any) {
+
+	if _, ok := cc.Sections[section]; !ok {
+		cc.Sections[section] = make(DottedConfig)
+	}
+	if _, ok := cc.Sections[section][key]; !ok {
+		cc.Sections[section][key] = value
+	} else {
+		switch v := value.(type) {
+		case []any:
+			cc.Sections[section][key] = append(cc.Sections[section][key].([]any), v...)
+		case []string:
+			cc.Sections[section][key] = append(cc.Sections[section][key].([]string), v...)
+		case []int:
+			cc.Sections[section][key] = append(cc.Sections[section][key].([]int), v...)
+		case []float64:
+			cc.Sections[section][key] = append(cc.Sections[section][key].([]float64), v...)
+		default:
+			cc.Sections[section][key] = v // overwrite if not a slice
+		}
+	}
+}
+
+// renderInto is a helper function that recursively renders a dotted key into a
+// map.
+func (cc *CollectorConfig) renderInto(m map[string]any, key string, value any) {
+	// if the key contains a dot, split it into parts
+	if strings.Contains(key, ".") {
+		// split the key into parts
+		parts := strings.SplitN(key, ".", 2)
+		if m[parts[0]] == nil {
+			m[parts[0]] = make(map[string]any)
+		}
+		// recursively call renderInto with the new map
+		cc.renderInto(m[parts[0]].(map[string]any), parts[1], value)
+	} else {
+		// if the key does not contain a dot, assign the value
+		m[key] = value
+	}
+}
+
+// RenderToMap renders the config into a map.
+func (cc *CollectorConfig) RenderToMap() map[string]any {
+	m := make(map[string]any)
+	for section := range cc.Sections {
+		for k, v := range cc.Sections[section] {
+			key := section + "." + k
+			cc.renderInto(m, key, v)
+		}
+	}
+	return m
+}
+
+// RenderYAML renders the config into YAML.
+func (cc *CollectorConfig) RenderYAML() ([]byte, error) {
+	// we render the config to a map, and then marshal it to yaml
+	// but that yaml is not idiomatic for the collector
+	m := cc.RenderToMap()
+	data, err := y.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	// now we unmarshal it into a struct so that we can use struct decorators
+	// to create a format that's idiomatic for the collector
+	var f collectorConfigFormat
+	err = y.Unmarshal(data, &f)
+	if err != nil {
+		return nil, err
+	}
+
+	// now marshal from the struct to yaml
+	data, err = y.Marshal(f)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// Merge merges another TemplateConfig into this one, but only if it's really
+// a CollectorConfig. If it's not, it just returns this config unmodified.
+func (cc *CollectorConfig) Merge(other TemplateConfig) TemplateConfig {
+	otherCC, ok := other.(*CollectorConfig)
+	if !ok {
+		// if the other TemplateConfig is not a CollectorConfig, we can't merge it
+		return cc
+	}
+	for section, items := range otherCC.Sections {
+		for k, v := range items {
+			cc.Set(section, k, v)
+		}
+	}
+	return cc
+}
+
+// NewCollectorConfig creates a new CollectorConfig with an empty map of sections.
+func NewCollectorConfig() *CollectorConfig {
+	cc := CollectorConfig{Sections: make(map[string]DottedConfig)}
+	return &cc
+}

--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -10,11 +10,6 @@ import (
 // YAML configuration files.
 type CollectorConfig struct {
 	Sections map[string]DottedConfig
-	// receivers  DottedConfig
-	// processors DottedConfig
-	// exporters  DottedConfig
-	// extensions DottedConfig
-	// service    DottedConfig
 }
 
 // ensure CollectorConfig implements TemplateConfig

--- a/pkg/config/tmpl/collectorconfig_test.go
+++ b/pkg/config/tmpl/collectorconfig_test.go
@@ -1,0 +1,34 @@
+package tmpl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCollectorConfig_RenderYAML(t *testing.T) {
+	cc := NewCollectorConfig()
+	cc.Set("receivers", "otlp.Port", "4317")
+	cc.Set("receivers", "otlp.Endpoint", "localhost")
+	cc.Set("service", "pipelines.traces.receivers", []string{"otlp"})
+	// NOTE: this "want" string is indented with spaces, not tabs; the YAML renderer uses spaces.
+	want := `
+receivers:
+    otlp:
+        Endpoint: localhost
+        Port: "4317"
+service:
+    pipelines:
+        traces:
+            receivers: [otlp]
+            processors: []
+            exporters: []
+`
+	got, err := cc.RenderYAML()
+	if err != nil {
+		t.Errorf("CollectorConfig.RenderYAML() error = %v, expected nil", err)
+		return
+	}
+	if strings.TrimSpace(string(got)) != strings.TrimSpace(want) {
+		t.Errorf("CollectorConfig.RenderYAML() got = \n%s, want \n%v", got, want)
+	}
+}

--- a/pkg/config/tmpl/collectorconfig_test.go
+++ b/pkg/config/tmpl/collectorconfig_test.go
@@ -15,7 +15,7 @@ func TestCollectorConfig_RenderYAML(t *testing.T) {
 receivers:
     otlp:
         endpoint: localhost
-        Port: "4317"
+        port: 4317
 service:
     pipelines:
         traces:

--- a/pkg/config/tmpl/collectorconfig_test.go
+++ b/pkg/config/tmpl/collectorconfig_test.go
@@ -14,7 +14,7 @@ func TestCollectorConfig_RenderYAML(t *testing.T) {
 	want := `
 receivers:
     otlp:
-        Endpoint: localhost
+        endpoint: localhost
         Port: "4317"
 service:
     pipelines:

--- a/pkg/config/tmpl/dottedconfig.go
+++ b/pkg/config/tmpl/dottedconfig.go
@@ -1,4 +1,4 @@
-package yaml
+package tmpl
 
 import (
 	"crypto/md5"
@@ -52,8 +52,13 @@ func (dc DottedConfig) RenderYAML() ([]byte, string, error) {
 	return data, hash, nil
 }
 
-func (dc DottedConfig) Merge(other DottedConfig) DottedConfig {
-	for k, v := range other {
+func (dc DottedConfig) Merge(other TemplateConfig) TemplateConfig {
+	otherDotted, ok := other.(DottedConfig)
+	if !ok {
+		// if the other TemplateConfig is not a DottedConfig, we can't merge it
+		return dc
+	}
+	for k, v := range otherDotted {
 		dc[k] = v
 	}
 	return dc

--- a/pkg/config/tmpl/dottedconfig.go
+++ b/pkg/config/tmpl/dottedconfig.go
@@ -48,7 +48,8 @@ func (dc DottedConfig) RenderYAML() ([]byte, error) {
 	return data, nil
 }
 
-// Merge merges two DottedConfigs together.
+// Merge combines two `DottedConfig` structs together, the values from the
+// `DottedConfig` passed in will override any values that are not slices.
 func (dc DottedConfig) Merge(other TemplateConfig) TemplateConfig {
 	otherDotted, ok := other.(DottedConfig)
 	if !ok {

--- a/pkg/config/tmpl/dottedconfig_test.go
+++ b/pkg/config/tmpl/dottedconfig_test.go
@@ -1,4 +1,4 @@
-package yaml
+package tmpl
 
 import (
 	"reflect"

--- a/pkg/config/tmpl/dottedconfig_test.go
+++ b/pkg/config/tmpl/dottedconfig_test.go
@@ -20,7 +20,7 @@ func TestDottedConfig_Render(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.dc.Render(); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.dc.RenderToMap(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DottedConfig.Render() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/config/tmpl/templateconfig.go
+++ b/pkg/config/tmpl/templateconfig.go
@@ -1,0 +1,7 @@
+package tmpl
+
+type TemplateConfig interface {
+	Render() map[string]any
+	RenderYAML() ([]byte, string, error)
+	Merge(other TemplateConfig) TemplateConfig
+}

--- a/pkg/config/tmpl/templateconfig.go
+++ b/pkg/config/tmpl/templateconfig.go
@@ -1,7 +1,8 @@
 package tmpl
 
+// TemplateConfig is an interface for a configuration abstraction that can be rendered as a map or as YAML.
 type TemplateConfig interface {
-	Render() map[string]any
-	RenderYAML() ([]byte, string, error)
+	RenderToMap() map[string]any
+	RenderYAML() ([]byte, error)
 	Merge(other TemplateConfig) TemplateConfig
 }

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -80,6 +80,7 @@ func (c *Component) Validate() []error {
 	return results
 }
 
+// returns the port with the given name, or nil if not found
 func (c *Component) GetPort(name string) *Port {
 	for _, p := range c.Ports {
 		if p.Name == name {
@@ -89,6 +90,7 @@ func (c *Component) GetPort(name string) *Port {
 	return nil
 }
 
+// returns the property with the given name, or nil if not found
 func (c *Component) GetProperty(name string) *Property {
 	for _, p := range c.Properties {
 		if p.Name == name {
@@ -96,6 +98,15 @@ func (c *Component) GetProperty(name string) *Property {
 		}
 	}
 	return nil
+}
+
+// returns all specified property names as a slice of strings
+func (c *Component) GetPropertyNames() []string {
+	props := make([]string, len(c.Properties))
+	for i, p := range c.Properties {
+		props[i] = p.Name
+	}
+	return props
 }
 
 type ConnectionPort struct {

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -25,7 +25,7 @@ func TestEnsureHPSF(t *testing.T) {
 			for i, arg := range tt.args {
 				y[arg] = i
 			}
-			text, _, _ := y.RenderYAML()
+			text, _ := y.RenderYAML()
 			if err := EnsureHPSF(string(text)); (err != nil) && !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("EnsureHPSF() error = %v, should contain '%v'", err, tt.wantErr)
 			}

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/honeycombio/hpsf/pkg/yaml"
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 )
 
 func TestEnsureHPSF(t *testing.T) {
@@ -21,7 +21,7 @@ func TestEnsureHPSF(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			y := yaml.DottedConfig{}
+			y := tmpl.DottedConfig{}
 			for i, arg := range tt.args {
 				y[arg] = i
 			}

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -27,6 +27,7 @@ func (t *Translator) MakeConfigComponent(component hpsf.Component) (config.Compo
 	// first look in the template components
 	tc, ok := t.templateComponents[component.Kind]
 	if ok {
+		tc.SetHPSF(component)
 		return &tc, nil
 	}
 

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/honeycombio/hpsf/pkg/config"
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
-	"github.com/honeycombio/hpsf/pkg/yaml"
 )
 
 type Translator struct {
@@ -38,8 +38,8 @@ func (t *Translator) MakeConfigComponent(component hpsf.Component) (config.Compo
 	}
 }
 
-func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[string]any) (yaml.DottedConfig, error) {
-	composite := yaml.DottedConfig{}
+func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
+	composite := tmpl.DottedConfig{}
 
 	// Add base component to the config so we can make a valid config
 	// this may be temporary until we have a database of components

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -8,6 +8,9 @@ import (
 	"github.com/honeycombio/hpsf/pkg/hpsf"
 )
 
+// A Translator is responsible for translating an HPSF document into a
+// collection of components, and then further rendering those into configuration
+// files.
 type Translator struct {
 	templateComponents map[string]config.TemplateComponent
 }
@@ -39,17 +42,14 @@ func (t *Translator) MakeConfigComponent(component hpsf.Component) (config.Compo
 }
 
 func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
-	composite := tmpl.DottedConfig{}
-
 	// Add base component to the config so we can make a valid config
 	// this may be temporary until we have a database of components
 	dummy := hpsf.Component{Name: "dummy", Kind: "dummy"}
-	base := config.RefineryBaseComponent{Component: dummy}
-	cfg, err := base.GenerateConfig(ct, userdata)
+	base := config.GenericBaseComponent{Component: dummy}
+	composite, err := base.GenerateConfig(ct, userdata)
 	if err != nil {
 		return nil, err
 	}
-	composite.Merge(cfg)
 
 	for _, c := range h.Components {
 		comp, err := t.MakeConfigComponent(c)


### PR DESCRIPTION
## Which problem is this PR solving?

- Ability to generate a collector config
- A couple of collector components
- Add a lot of comments
- Reorganize for easier maintenance

## Short description of the changes

- Render is now RenderToMap
- The user's HPSF is now available to the template and used
- Some refinery-specific stuff is now more generic
- Additional config type for collector
- Remove the generated hash because it's not solving the right problem
- We should be using text/template not html/template
- Two collector components (that will be merged in a future PR)
- Lots of comments added

The code in this PR is functional and runs to completion, but it's not correct yet. It was just a plausible place to stop. #13 builds on this one.