### PR TITLE
fix: replace validations for user-declared property types

### DIFF
--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -72,9 +72,18 @@ func (c *Component) Validate() []error {
 		}
 	}
 	for _, p := range c.Properties {
-		if p.Type != PTYPE_NUMBER && p.Type != PTYPE_STRING && p.Type != PTYPE_BOOL {
-			results = append(results, validator.NewErrorf(
-				"Component %s Property %s Type must be 'Number', 'String', or 'Bool'", c.Name, p.Name))
+		if p.Name == "" {
+			results = append(results, validator.NewErrorf("Component %s Property Name must be set", c.Name))
+		}
+		if p.Value == nil {
+			results = append(results, validator.NewErrorf("Component %s Property %s Value must be set", c.Name, p.Name))
+		}
+		switch p.Value.(type) {
+		case string:
+		case int:
+		case bool:
+		default:
+			results = append(results, validator.NewErrorf("Component %s Property %s Value must be a string, number, or bool", c.Name, p.Name))
 		}
 	}
 	return results


### PR DESCRIPTION
Component properties no longer expect the property type to be set by the user authoring HPSF.

* Remove the check for declared property type.
* Add check for presence of a property name.
* Add check for presence of a property value.
* Add check that a given property value must be a string, int, or bool.
* Add a very simple initial test for validation.

