### PR TITLE
fix: remove duplicate collector section declarations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,12 @@ go 1.23.0
 
 require (
 	github.com/jessevdk/go-flags v1.6.1
+	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.21.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -106,7 +106,7 @@ func (t *TemplateComponent) Props() map[string]TemplateProperty {
 
 func (t *TemplateComponent) ComponentName() string {
 	if t.CollName != "" {
-		return t.CollName + "/" + t.Name
+		return t.CollName + "/" + t.hpsf.Name
 	}
 	return t.Name
 }

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -212,7 +212,6 @@ func (t *TemplateComponent) generateCollectorConfig(ct collectorTemplate, userda
 				if err != nil {
 					return nil, err
 				}
-				key = fmt.Sprintf("%s.%s", section, key)
 				value, err := t.applyTemplate(kv.value, userdata)
 				if err != nil {
 					return nil, err

--- a/pkg/translator/testdata/simple_collector_config.yaml
+++ b/pkg/translator/testdata/simple_collector_config.yaml
@@ -1,0 +1,18 @@
+receivers:
+    otlp/otlp_in:
+        protocols:
+            grpc:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:9922
+            http:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:1234
+exporters:
+    otlp/otlp_out:
+        protocols:
+            grpc:
+                endpoint: myhost.com:1234
+service:
+    pipelines:
+        traces:
+            receivers: [otlp/otlp_in]
+            processors: []
+            exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/simple_hpsf.yaml
+++ b/pkg/translator/testdata/simple_hpsf.yaml
@@ -1,0 +1,34 @@
+components:
+  - name: RefineryGRPC_2
+    kind: RefineryGRPC
+    ports:
+      - name: TraceOut
+        direction: output
+        type: Honeycomb
+    properties:
+      - name: Port
+        value: 4317
+        type: number
+  - name: otlp_in
+    kind: OTelReceiver
+    properties:
+      - name: GRPCPort
+        value: 9922
+      - name: HTTPPort
+        value: 1234
+  - name: otlp_out
+    kind: OTelGRPCExporter
+    properties:
+      - name: Host
+        value: myhost.com
+      - name: Port
+        value: 1234
+connections:
+  - source:
+      component: otlp_in
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: otlp_out
+      port: Traces
+      type: OTelTraces

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -1,0 +1,85 @@
+package translator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/honeycombio/hpsf/pkg/config"
+	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+func TestGenerateConfig(t *testing.T) {
+	const inputData = `components:
+  - name: RefineryGRPC_2
+    kind: RefineryGRPC
+    ports:
+      - name: TraceOut
+        direction: output
+        type: Honeycomb
+    properties:
+      - name: Port
+        value: 4317
+        type: number
+  - name: otlp_in
+    kind: OTelReceiver
+    properties:
+      - name: GRPCPort
+        value: 9922
+      - name: HTTPPort
+        value: 1234
+  - name: otlp_out
+    kind: OTelGRPCExporter
+    properties:
+      - name: Host
+        value: myhost.com
+      - name: Port
+        value: 1234
+connections:
+  - source:
+      component: otlp_in
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: otlp_out
+      port: Traces
+      type: OTelTraces`
+
+	const expectedConfig = `receivers:
+    otlp/otlp_in:
+        protocols:
+            grpc:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:9922
+            http:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:1234
+exporters:
+    otlp/otlp_out:
+        protocols:
+            grpc:
+                endpoint: myhost.com:1234
+service:
+    pipelines:
+        traces:
+            receivers: [otlp/otlp_in]
+            processors: []
+            exporters: [otlp/otlp_out]
+`
+
+	var hpsf *hpsf.HPSF
+	dec := yamlv3.NewDecoder(strings.NewReader(inputData))
+	err := dec.Decode(&hpsf)
+	require.NoError(t, err)
+
+	tlater, err := NewTranslator()
+	require.NoError(t, err)
+
+	cfg, err := tlater.GenerateConfig(hpsf, config.CollectorConfigType, nil)
+	require.NoError(t, err)
+
+	got, err := cfg.RenderYAML()
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedConfig, string(got))
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Correcting the emitted collector config.

## Short description of the changes

- add a test for collector config output
  - currently depends on #15 for the addition of testify to go dependencies
- remove duplicate section from config key templating

Changes collector config output from ...

    receivers:
      receivers:
        otlp/x:

... to ...

    receivers:
      otlp/x:

- use the collector component Name property

Reference the instance property Name when rendering a component instance
instead of the name of the component type.

1. This is clearer in the rendered config. Items have the names
   humans gave them.
2. Avoids naming collisions for HPSF that have two or more of the
   same type of component.

Turns ...

    receivers:
      otlp/otlp_receiver:

... into ...

    receivers:
      otlp/otlp_in: