### PR TITLE
fix: remove incorrect otlp export config

### DIFF
--- a/pkg/config/components/OTelGRPCExporter.yaml
+++ b/pkg/config/components/OTelGRPCExporter.yaml
@@ -38,6 +38,6 @@ templates:
       signalTypes: [traces, metrics, logs] # we'll generate a name for each pipeline if there's more than 1
       collectorComponentName: otlp
     data:
-      - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
+      - key: "{{ .ComponentName }}.endpoint"
         value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/translator/testdata/simple_collector_config.yaml
+++ b/pkg/translator/testdata/simple_collector_config.yaml
@@ -7,9 +7,7 @@ receivers:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:1234
 exporters:
     otlp/otlp_out:
-        protocols:
-            grpc:
-                endpoint: myhost.com:1234
+        endpoint: myhost.com:1234
 service:
     pipelines:
         traces:


### PR DESCRIPTION
## Which problem is this PR solving?

- The collector config for otlpexporter we were generating was using the wrong schema. It doesn't need `protocols.grpc.`.

## Short description of the changes

- Removed wrong schema
- updated test expectation

