### PR TITLE
fix: ensure validate supports map[string]

### DIFF
--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -82,8 +82,9 @@ func (c *Component) Validate() []error {
 		case string:
 		case int:
 		case bool:
+		case map[string]any:
 		default:
-			results = append(results, validator.NewErrorf("Component %s Property %s Value must be a string, number, or bool", c.Name, p.Name))
+			results = append(results, validator.NewErrorf("Component %s Property %s Value must be a string, number, bool, or map[string]any", c.Name, p.Name))
 		}
 	}
 	return results

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -52,6 +52,9 @@ func TestHPSF_Validate(t *testing.T) {
         value: myhost.com
       - name: Port
         value: 1234
+      - name: Headers
+        value:
+          "header1": "1234"
 connections:
   - source:
       component: otlp_in


### PR DESCRIPTION
## Which problem is this PR solving?

- This ensures validates doesn't fail on maps, in support of the Headers field.

## Short description of the changes

- add `map[string]any` as a valid type to the validation function.

