### PR TITLE
fix: handle non-string properties in components and update them

### DIFF
--- a/pkg/config/collectorTemplate.go
+++ b/pkg/config/collectorTemplate.go
@@ -23,6 +23,8 @@ func getKV(d any) (*dottedConfigTemplateKV, bool) {
 	if !ok {
 		return kv, false
 	}
+
+	// keys must be strings
 	if mk, ok := m["key"]; !ok {
 		return kv, false
 	} else {
@@ -31,6 +33,8 @@ func getKV(d any) (*dottedConfigTemplateKV, bool) {
 		}
 		kv.key = mk.(string)
 	}
+
+	// values can be strings, ints, bools, []string, map[string]string, []any, or map[string]any
 	if _, ok := m["value"]; !ok {
 		return kv, false
 	} else {
@@ -67,6 +71,9 @@ func getKV(d any) (*dottedConfigTemplateKV, bool) {
 			return kv, false
 		}
 	}
+
+	// suppress_if specifies a condition under which the key-value pair should be suppressed
+	// if it evaluates to 'true' then it's suppressed
 	if _, ok := m["suppress_if"]; ok {
 		if _, ok := m["suppress_if"].(string); !ok {
 			return kv, false

--- a/pkg/config/collectorTemplate.go
+++ b/pkg/config/collectorTemplate.go
@@ -15,6 +15,8 @@ type collectorTemplate struct {
 	kvs                    map[string][]dottedConfigTemplateKV
 }
 
+// getKV is a helper function to extract a key-value pair from a map[string]any.
+// It returns the kv and a boolean indicating if the extraction was successful.
 func getKV(d any) (*dottedConfigTemplateKV, bool) {
 	kv := &dottedConfigTemplateKV{}
 	m, ok := d.(map[string]any)
@@ -32,10 +34,38 @@ func getKV(d any) (*dottedConfigTemplateKV, bool) {
 	if _, ok := m["value"]; !ok {
 		return kv, false
 	} else {
-		if _, ok := m["value"].(string); !ok {
+		switch val := m["value"].(type) {
+		case string:
+			kv.value = val
+		case int:
+			kv.value = val
+		case bool:
+			kv.value = val
+		case []string:
+			kv.value = val
+		case map[string]string:
+			kv.value = val
+		case []any:
+			sl := make([]string, len(val))
+			for _, v := range val {
+				if _, ok := v.(string); !ok {
+					return kv, false
+				}
+				sl = append(sl, v.(string))
+			}
+			kv.value = sl
+		case map[string]any:
+			mp := make(map[string]string)
+			for k, v := range val {
+				if _, ok := v.(string); !ok {
+					return kv, false
+				}
+				mp[k] = v.(string)
+			}
+			kv.value = mp
+		default:
 			return kv, false
 		}
-		kv.value = m["value"].(string)
 	}
 	if _, ok := m["suppress_if"]; ok {
 		if _, ok := m["suppress_if"].(string); !ok {

--- a/pkg/config/components/OTelDebugExporter.yaml
+++ b/pkg/config/components/OTelDebugExporter.yaml
@@ -21,4 +21,4 @@ templates:
       collectorComponentName: debug
     data:
       - key: "{{ .ComponentName }}.verbosity"
-        value: "{{ firstNonblank .HProps.Verbosity .User.Verbosity .Props.Verbosity.Default }}"
+        value: "{{ firstNonZero .HProps.Verbosity .User.Verbosity .Props.Verbosity.Default }}"

--- a/pkg/config/components/OTelGRPCExporter.yaml
+++ b/pkg/config/components/OTelGRPCExporter.yaml
@@ -33,7 +33,7 @@ properties:
     summary: Headers to emit when sending gRPC traffic.
     description: |
       Sending data to a backend may require additional headers to be
-      configured. This properties supports sending a map of header keys and
+      configured. This property supports sending a map of header keys and
       values.
     type: map
     validations: [map]
@@ -49,6 +49,6 @@ templates:
       - key: "{{ .ComponentName }}.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.headers"
-        value: "{{ .HProps.Headers }}"
+        value: "{{ mapify .HProps.Headers }}"
         suppress_if: "{{ not .HProps.Headers }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelGRPCExporter.yaml
+++ b/pkg/config/components/OTelGRPCExporter.yaml
@@ -47,7 +47,7 @@ templates:
       collectorComponentName: otlp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers }}"
         suppress_if: "{{ not .HProps.Headers }}"

--- a/pkg/config/components/OTelGRPCExporter.yaml
+++ b/pkg/config/components/OTelGRPCExporter.yaml
@@ -49,6 +49,6 @@ templates:
       - key: "{{ .ComponentName }}.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.headers"
-        value: "{{ mapify .HProps.Headers }}"
+        value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelGRPCReceiver.yaml
+++ b/pkg/config/components/OTelGRPCReceiver.yaml
@@ -35,5 +35,5 @@ templates:
       collectorComponentName: otlp  # required receiver we'll check against configured collector
     data:
       - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
-        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelHTTPExporter.yaml
+++ b/pkg/config/components/OTelHTTPExporter.yaml
@@ -49,6 +49,6 @@ templates:
       - key: "{{ .ComponentName }}.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.headers"
-        value: "{{ .HProps.Headers }}"
+        value: "{{ mapify .HProps.Headers }}"
         suppress_if: "{{ not .HProps.Headers }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelHTTPExporter.yaml
+++ b/pkg/config/components/OTelHTTPExporter.yaml
@@ -49,6 +49,6 @@ templates:
       - key: "{{ .ComponentName }}.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.headers"
-        value: "{{ mapify .HProps.Headers }}"
+        value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelHTTPExporter.yaml
+++ b/pkg/config/components/OTelHTTPExporter.yaml
@@ -47,7 +47,7 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers }}"
         suppress_if: "{{ not .HProps.Headers }}"

--- a/pkg/config/components/OTelHTTPReceiver.yaml
+++ b/pkg/config/components/OTelHTTPReceiver.yaml
@@ -35,5 +35,5 @@ templates:
       collectorComponentName: otlp  # required receiver we'll check against configured collector
     data:
       - key: "{{ .ComponentName }}.protocols.http.endpoint"
-        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.Port .User.Port .Props.Port.Default }}"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/OTelReceiver.yaml
+++ b/pkg/config/components/OTelReceiver.yaml
@@ -50,9 +50,9 @@ templates:
       collectorComponentName: otlp
     data:
       - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
-        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.GRPCPort .User.GRPCPort .Props.GRPCPort.Default }}"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.GRPCPort .User.GRPCPort .Props.GRPCPort.Default }}"
         suppress_if: "{{ eq .HProps.GRPCPort 0 }}"
       - key: "{{ .ComponentName }}.protocols.http.endpoint"
-        value: "{{ firstNonblank .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonblank .HProps.HTTPPort .User.HTTPPort .Props.HTTPPort.Default }}"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.HTTPPort .User.HTTPPort .Props.HTTPPort.Default }}"
         suppress_if: "{{ eq .HProps.HTTPPort 0 }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/deterministicSampler.yaml
+++ b/pkg/config/components/deterministicSampler.yaml
@@ -41,4 +41,4 @@ templates:
     format: dotted
     data:
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.GoalThroughput"
-        value: "{{ firstNonZero .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default }}"
+        value: "{{ firstNonZero .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default | encodeAsInt }}"

--- a/pkg/config/components/deterministicSampler.yaml
+++ b/pkg/config/components/deterministicSampler.yaml
@@ -40,5 +40,5 @@ templates:
     name: DeterministicSampler_RefineryRules
     format: dotted
     data:
-      - key: "Samplers.{{ firstNonblank .HProps.Environment .Props.Environment.Default }}.DeterministicSampler.GoalThroughput"
-        value: "{{ firstNonblank .HProps.SampleRate .User.SampleRate.Value .Props.SampleRate.Default }}"
+      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.GoalThroughput"
+        value: "{{ firstNonblank .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default }}"

--- a/pkg/config/components/deterministicSampler.yaml
+++ b/pkg/config/components/deterministicSampler.yaml
@@ -40,5 +40,5 @@ templates:
     name: DeterministicSampler_RefineryRules
     format: dotted
     data:
-      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.GoalThroughput"
-        value: "{{ firstNonblank .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default }}"
+      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.GoalThroughput"
+        value: "{{ firstNonZero .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default }}"

--- a/pkg/config/components/emaThroughput.yaml
+++ b/pkg/config/components/emaThroughput.yaml
@@ -71,8 +71,8 @@ templates:
     format: dotted
     data:
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.GoalThroughput"
-        value: "int:{{ firstNonZero .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default }}"
+        value: "{{ firstNonZero .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default | encodeAsInt }}"
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.AdjustmentInterval"
-        value: "int:{{ firstNonZero .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}"
+        value: "{{ firstNonZero .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default | encodeAsInt }}"
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.FieldList"
-        value: "arr:{{ firstNonZero .HProps.FieldList .User.FieldList .Props.FieldList.Default }}"
+        value: "{{ firstNonZero .HProps.FieldList .User.FieldList .Props.FieldList.Default | encodeAsArray }}"

--- a/pkg/config/components/emaThroughput.yaml
+++ b/pkg/config/components/emaThroughput.yaml
@@ -70,9 +70,9 @@ templates:
     name: EMA_Throughput_Rules
     format: dotted
     data:
-      - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.GoalThroughput\" .Props.Environment.Value }}"
-        value: "{{ firstNonblank .HProps.GoalThroughput .User.GoalThroughput.Value .Props.GoalThroughput.Default }}"
-      - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.AdjustmentInterval\" .Props.Environment.Value }}"
-        value: "{{ firstNonblank .HProps.AdjustmentInterval .User.AdjustmentInterval.Value .Props.AdjustmentInterval.Default }}"
-      - key: "{{ printf \"Samplers.%s.EMAThroughputSampler.FieldList\" .Props.Environment.Value }}"
-        value: "{{ firstNonblank .HProps.FieldList .User.FieldList.Value .Props.FieldList.Default }}"
+      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.GoalThroughput"
+        value: "{{ firstNonblank .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default }}"
+      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.AdjustmentInterval"
+        value: "{{ firstNonblank .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}"
+      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.FieldList"
+        value: "{{ firstNonblank .HProps.FieldList .User.FieldList .Props.FieldList.Default }}"

--- a/pkg/config/components/emaThroughput.yaml
+++ b/pkg/config/components/emaThroughput.yaml
@@ -70,9 +70,9 @@ templates:
     name: EMA_Throughput_Rules
     format: dotted
     data:
-      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.GoalThroughput"
-        value: "{{ firstNonblank .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default }}"
-      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.AdjustmentInterval"
-        value: "{{ firstNonblank .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}"
-      - key: "Samplers.{{ firstNonblank .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.FieldList"
-        value: "{{ firstNonblank .HProps.FieldList .User.FieldList .Props.FieldList.Default }}"
+      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.GoalThroughput"
+        value: "{{ firstNonZero .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default }}"
+      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.AdjustmentInterval"
+        value: "{{ firstNonZero .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}"
+      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.FieldList"
+        value: "{{ firstNonZero .HProps.FieldList .User.FieldList .Props.FieldList.Default }}"

--- a/pkg/config/components/emaThroughput.yaml
+++ b/pkg/config/components/emaThroughput.yaml
@@ -60,7 +60,7 @@ properties:
       quantities of the specified sampling keys, while ensuring that at least
       one instance of every distinct value of each key is sampled.
       There is no default; this field must be specified.
-    type: "[]string"
+    type: "stringarray"
     validations:
       - nonblank
       - nonempty
@@ -71,8 +71,8 @@ templates:
     format: dotted
     data:
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.GoalThroughput"
-        value: "{{ firstNonZero .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default }}"
+        value: "int:{{ firstNonZero .HProps.GoalThroughput .User.GoalThroughput .Props.GoalThroughput.Default }}"
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.AdjustmentInterval"
-        value: "{{ firstNonZero .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}"
+        value: "int:{{ firstNonZero .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}"
       - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.FieldList"
-        value: "{{ firstNonZero .HProps.FieldList .User.FieldList .Props.FieldList.Default }}"
+        value: "arr:{{ firstNonZero .HProps.FieldList .User.FieldList .Props.FieldList.Default }}"

--- a/pkg/config/components/honeycombExporter.yaml
+++ b/pkg/config/components/honeycombExporter.yaml
@@ -29,7 +29,7 @@ templates:
     format: dotted
     data:
       - key: Network.HoneycombAPI
-        value: "{{ firstNonblank .HProps.APIEndpoint .User.APIEndpoint .Props.APIEndpoint.Default }}"
+        value: "{{ firstNonZero .HProps.APIEndpoint .User.APIEndpoint .Props.APIEndpoint.Default }}"
       - key: AccessKeys.SendKey
-        value: "{{ firstNonblank .HProps.APIKey .User.APIKey }}"
+        value: "{{ firstNonZero .HProps.APIKey .User.APIKey }}"
 

--- a/pkg/config/dotTemplate.go
+++ b/pkg/config/dotTemplate.go
@@ -8,7 +8,7 @@ import (
 
 type dottedConfigTemplateKV struct {
 	key         string
-	value       string
+	value       any
 	suppress_if string
 }
 

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strings"
@@ -21,6 +22,7 @@ func helpers() template.FuncMap {
 		"indent":       indent,
 		"join":         join,
 		"makeSlice":    makeSlice,
+		"mapify":       mapify,
 		"meta":         meta,
 		"now":          now,
 		"split":        split,
@@ -50,6 +52,8 @@ func firstNonzero(s ...any) string {
 					ss[i] = fmt.Sprintf("%v", vv)
 				}
 				return strings.Join(ss, ", ")
+			case []string:
+				return strings.Join(vt, ", ")
 			default:
 				return fmt.Sprintf("%v", vt)
 			}
@@ -71,6 +75,21 @@ func join(a []string, sep string) string {
 // creates a slice of strings from the arguments
 func makeSlice(a ...string) []string {
 	return a
+}
+
+// mapify takes a map and returns a string intended to be expanded
+// later into a map when it's rendered to YAML.
+// The result looks like "map:a:1_|_b:2_|_"
+func mapify(a map[string]any) string {
+	buf := bytes.Buffer{}
+	buf.WriteString("map:")
+	for k, v := range a {
+		buf.WriteString(k)
+		buf.WriteRune(':')
+		buf.WriteString(fmt.Sprintf("%v", v))
+		buf.WriteString("_|_")
+	}
+	return buf.String()
 }
 
 // wraps a string in "{{" and "}}" to indicate that it's a template variable

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -34,10 +34,8 @@ func comment(s string) string {
 }
 
 // returns the first non-zero-valued item from the arguments
-// []any is special-cased to return a YAML array -- but it's not actually
-// rendered that way. It's used to signal to the YAML serializer that the
-// value is an array.
-// If we eventually feel like the [,] syntax is failing to handle some special
+// []any is special-cased to return a comma-separated set of strings.
+// If we eventually feel like the comma syntax is failing to handle some special
 // cases, we can change it to use some other syntax that's less likely to occur
 // in real data.
 func firstNonzero(s ...any) string {
@@ -51,7 +49,7 @@ func firstNonzero(s ...any) string {
 				for i, vv := range vt {
 					ss[i] = fmt.Sprintf("%v", vv)
 				}
-				return "[" + strings.Join(ss, ", ") + "]"
+				return strings.Join(ss, ", ")
 			default:
 				return fmt.Sprintf("%v", vt)
 			}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+const (
+	RecordSeparator = "\x1e" // ASCII code 30, the record separator
+)
+
 // This file contains template helper functions, which must be listed in this
 // map if they're going to be available to the template.
 // The map key is the name of the function as it will be used in the template,
@@ -79,7 +83,7 @@ func makeSlice(a ...string) []string {
 
 // mapify takes a map and returns a string intended to be expanded
 // later into a map when it's rendered to YAML.
-// The result looks like "map:a:1_|_b:2_|_"
+// The result looks like "map:a:1\x1eb:2\x1e"
 func mapify(a map[string]any) string {
 	buf := bytes.Buffer{}
 	buf.WriteString("map:")
@@ -87,7 +91,7 @@ func mapify(a map[string]any) string {
 		buf.WriteString(k)
 		buf.WriteRune(':')
 		buf.WriteString(fmt.Sprintf("%v", v))
-		buf.WriteString("_|_")
+		buf.WriteString(RecordSeparator)
 	}
 	return buf.String()
 }

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	RecordSeparator = "\x1e" // ASCII code 30, the record separator
+	FieldSeparator  = "\x1f" // ASCII code 31, the unit (field) separator
 )
 
 // This file contains template helper functions, which must be listed in this
@@ -55,9 +56,9 @@ func firstNonzero(s ...any) string {
 				for i, vv := range vt {
 					ss[i] = fmt.Sprintf("%v", vv)
 				}
-				return strings.Join(ss, ", ")
+				return strings.Join(ss, FieldSeparator)
 			case []string:
-				return strings.Join(vt, ", ")
+				return strings.Join(vt, FieldSeparator)
 			default:
 				return fmt.Sprintf("%v", vt)
 			}
@@ -89,7 +90,7 @@ func mapify(a map[string]any) string {
 	buf.WriteString("map:")
 	for k, v := range a {
 		buf.WriteString(k)
-		buf.WriteRune(':')
+		buf.WriteString(FieldSeparator)
 		buf.WriteString(fmt.Sprintf("%v", v))
 		buf.WriteString(RecordSeparator)
 	}

--- a/pkg/config/loadComponents_test.go
+++ b/pkg/config/loadComponents_test.go
@@ -44,10 +44,15 @@ func TestTemplateComponents(t *testing.T) {
 			wantOutput: "DeterministicSampler_output_refinery_rules.yaml",
 		},
 		{
-			name:       "EMAThroughputSampler to refinery rules",
-			kind:       "EMAThroughput",
-			cType:      RefineryRulesType,
-			config:     map[string]any{"Environment": "staging", "GoalThroughput": 42, "AdjustmentInterval": 120, "FieldList": []string{"test"}},
+			name:  "EMAThroughputSampler to refinery rules",
+			kind:  "EMAThroughput",
+			cType: RefineryRulesType,
+			config: map[string]any{
+				"Environment":        "staging",
+				"GoalThroughput":     42,
+				"AdjustmentInterval": 120,
+				"FieldList":          []string{"http.method", "http.status_code"},
+			},
 			wantOutput: "EmaThroughput_output_refinery_rules.yaml",
 		},
 	}

--- a/pkg/config/loadComponents_test.go
+++ b/pkg/config/loadComponents_test.go
@@ -26,25 +26,41 @@ func TestTemplateComponents(t *testing.T) {
 		name       string
 		kind       string
 		cType      Type
+		config     map[string]any
 		wantOutput string
 	}{
 		{
 			name:       "HoneycombExporter to refinery config",
 			kind:       "HoneycombExporter",
 			cType:      RefineryConfigType,
+			config:     map[string]any{"APIKey": "test"},
 			wantOutput: "HoneycombExporter_output_refinery_config.yaml",
 		},
+		{
+			name:       "DeterministicSampler to refinery rules",
+			kind:       "DeterministicSampler",
+			cType:      RefineryRulesType,
+			config:     map[string]any{"Environment": "staging", "SampleRate": 42},
+			wantOutput: "DeterministicSampler_output_refinery_rules.yaml",
+		},
+		{
+			name:       "EMAThroughputSampler to refinery rules",
+			kind:       "EMAThroughput",
+			cType:      RefineryRulesType,
+			config:     map[string]any{"Environment": "staging", "GoalThroughput": 42, "AdjustmentInterval": 120, "FieldList": []string{"test"}},
+			wantOutput: "EmaThroughput_output_refinery_rules.yaml",
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			want, err := os.ReadFile(path.Join("testdata", tt.wantOutput))
 			require.NoError(t, err)
 			c, ok := components[tt.kind]
 			require.True(t, ok)
-			conf, err := c.GenerateConfig(tt.cType, map[string]any{
-				"APIKey": "test",
-			})
+			conf, err := c.GenerateConfig(tt.cType, tt.config)
 			require.NoError(t, err)
+			require.NotNil(t, conf)
 			got, err := conf.RenderYAML()
 			require.NoError(t, err)
 			require.Equal(t, string(want), string(got))

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -227,6 +227,20 @@ func undecorate(s string) any {
 			}
 		}
 		return arr
+	case strings.HasPrefix(s, "map:"):
+		s := strings.TrimPrefix(s, "map:")
+		result := make(map[string]string)
+		items := strings.Split(s, "_|_")
+		// the last item is always blank, so < 2 is what we want
+		if len(items) < 2 {
+			return result
+		}
+		items = items[:len(items)-1]
+		for _, i := range items {
+			sp := strings.Split(i, ":")
+			result[sp[0]] = sp[1]
+		}
+		return result
 	}
 	return s
 }

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -216,7 +216,7 @@ func undecorate(s string) any {
 		}
 	case strings.HasPrefix(s, "arr:"):
 		s := strings.TrimPrefix(s, "arr:")
-		items := strings.Split(s, ",")
+		items := strings.Split(s, FieldSeparator)
 		// we need to trim the spaces from the items and we don't want blanks
 		// in the array
 		var arr []string
@@ -237,7 +237,7 @@ func undecorate(s string) any {
 		}
 		items = items[:len(items)-1]
 		for _, i := range items {
-			sp := strings.Split(i, ":")
+			sp := strings.Split(i, FieldSeparator)
 			result[sp[0]] = sp[1]
 		}
 		return result

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -188,34 +188,28 @@ func (t *TemplateComponent) expandTemplateVariable(tmplText string, userdata map
 // desired type. Now we need to do some extra work to make sure that we return
 // the indicated type. If it can't be converted to the desired type, we return
 // the string as is.
-//
-// Prefixes we support:
-// - "int:" for integers
-// - "bool:" for booleans
-// - "float:" for floats
-// - "arr:" for arrays of strings, comma-separated
 func undecorate(s string) any {
 	switch {
-	case strings.HasPrefix(s, "int:"):
-		s := strings.TrimPrefix(s, "int:")
+	case strings.HasPrefix(s, IntPrefix):
+		s := strings.TrimPrefix(s, IntPrefix)
 		i, err := strconv.Atoi(s)
 		if err == nil {
 			return i
 		}
-	case strings.HasPrefix(s, "bool:"):
-		s := strings.TrimPrefix(s, "bool:")
+	case strings.HasPrefix(s, BoolPrefix):
+		s := strings.TrimPrefix(s, BoolPrefix)
 		b, err := strconv.ParseBool(s)
 		if err == nil {
 			return b
 		}
-	case strings.HasPrefix(s, "float:"):
-		s := strings.TrimPrefix(s, "float:")
+	case strings.HasPrefix(s, FloatPrefix):
+		s := strings.TrimPrefix(s, FloatPrefix)
 		f, err := strconv.ParseFloat(s, 64)
 		if err == nil {
 			return f
 		}
-	case strings.HasPrefix(s, "arr:"):
-		s := strings.TrimPrefix(s, "arr:")
+	case strings.HasPrefix(s, ArrPrefix):
+		s := strings.TrimPrefix(s, ArrPrefix)
 		items := strings.Split(s, FieldSeparator)
 		// we need to trim the spaces from the items and we don't want blanks
 		// in the array
@@ -227,8 +221,8 @@ func undecorate(s string) any {
 			}
 		}
 		return arr
-	case strings.HasPrefix(s, "map:"):
-		s := strings.TrimPrefix(s, "map:")
+	case strings.HasPrefix(s, MapPrefix):
+		s := strings.TrimPrefix(s, MapPrefix)
 		result := make(map[string]string)
 		items := strings.Split(s, RecordSeparator)
 		// the last item is always blank, so < 2 is what we want

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -230,7 +230,7 @@ func undecorate(s string) any {
 	case strings.HasPrefix(s, "map:"):
 		s := strings.TrimPrefix(s, "map:")
 		result := make(map[string]string)
-		items := strings.Split(s, "_|_")
+		items := strings.Split(s, RecordSeparator)
 		// the last item is always blank, so < 2 is what we want
 		if len(items) < 2 {
 			return result

--- a/pkg/config/testdata/DeterministicSampler_output_refinery_rules.yaml
+++ b/pkg/config/testdata/DeterministicSampler_output_refinery_rules.yaml
@@ -1,4 +1,4 @@
 Samplers:
     staging:
         DeterministicSampler:
-            GoalThroughput: "42"
+            GoalThroughput: 42

--- a/pkg/config/testdata/DeterministicSampler_output_refinery_rules.yaml
+++ b/pkg/config/testdata/DeterministicSampler_output_refinery_rules.yaml
@@ -1,0 +1,4 @@
+Samplers:
+    staging:
+        DeterministicSampler:
+            GoalThroughput: "42"

--- a/pkg/config/testdata/EmaThroughput_output_refinery_rules.yaml
+++ b/pkg/config/testdata/EmaThroughput_output_refinery_rules.yaml
@@ -1,6 +1,6 @@
 Samplers:
     staging:
         EMAThroughputSampler:
-            GoalThroughput: "42"
             AdjustmentInterval: 120
             FieldList: ["http.method", "http.status_code"]
+            GoalThroughput: "42"

--- a/pkg/config/testdata/EmaThroughput_output_refinery_rules.yaml
+++ b/pkg/config/testdata/EmaThroughput_output_refinery_rules.yaml
@@ -1,0 +1,6 @@
+Samplers:
+    staging:
+        EMAThroughputSampler:
+            GoalThroughput: "42"
+            AdjustmentInterval: 120
+            FieldList: ["http.method", "http.status_code"]

--- a/pkg/config/testdata/EmaThroughput_output_refinery_rules.yaml
+++ b/pkg/config/testdata/EmaThroughput_output_refinery_rules.yaml
@@ -2,5 +2,7 @@ Samplers:
     staging:
         EMAThroughputSampler:
             AdjustmentInterval: 120
-            FieldList: ["http.method", "http.status_code"]
-            GoalThroughput: "42"
+            FieldList:
+                - http.method
+                - http.status_code
+            GoalThroughput: 42

--- a/pkg/translator/testdata/default_refinery_rules.yaml
+++ b/pkg/translator/testdata/default_refinery_rules.yaml
@@ -2,4 +2,4 @@ RulesVersion: 2
 Samplers:
     __default__:
         DeterministicSampler:
-            GoalThroughput: "1"
+            GoalThroughput: 1


### PR DESCRIPTION
https://app.asana.com/0/1208469935858869/1209310061786981

## Which problem is this PR solving?

- Syntax has changed some for component templates since some were written. 
- HPSF was coercing everything to strings, which caused problems. We really wanted to handle normal datatypes.

## Short description of the changes

- Update template syntax
- Add tests
- Allow all (most?) of the places to have actual data types and allow the templates to express them. We might be able to do still better, but what we have here now works pretty well.
- Fix the templates and tests to do the right things
