### PR TITLE
fix: Fix encoding of map to handle nesting

### DIFF
--- a/pkg/config/components/FilterProcessor.yaml
+++ b/pkg/config/components/FilterProcessor.yaml
@@ -31,5 +31,5 @@ templates:
       collectorComponentName: filter
     data:
       - key: "{{ .ComponentName }}"
-        value: "{{ .HProps.Rules }}"
+        value: "{{ .HProps.Rules | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Rules }}"

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -136,19 +137,14 @@ func encodeAsInt(a any) string {
 	return IntPrefix + value
 }
 
-// encodeAsMap takes a map and returns a string intended to be expanded
-// later into a map when it's rendered to YAML.
-// The result looks like "map\x1dA\x1f1\x1eb\x1f2\x1e"
+// encodeAsMap takes a map (which may contain nested maps) and returns a string
+// intended to be expanded later into the same map when it's rendered to YAML.
+// We encode to JSON because it's fast and easy.
 func encodeAsMap(a map[string]any) string {
 	buf := bytes.Buffer{}
-	buf.WriteString(MapPrefix)
-	for k, v := range a {
-		buf.WriteString(k)
-		buf.WriteString(FieldSeparator)
-		buf.WriteString(fmt.Sprintf("%v", v))
-		buf.WriteString(RecordSeparator)
-	}
-	return buf.String()
+	j := json.NewEncoder(&buf)
+	_ = j.Encode(a)
+	return MapPrefix + buf.String()
 }
 
 func firstNonzero(s ...any) any {

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -143,6 +143,10 @@ func encodeAsInt(a any) string {
 func encodeAsMap(a map[string]any) string {
 	buf := bytes.Buffer{}
 	j := json.NewEncoder(&buf)
+	// There's no model for returning an error, but also...
+	// we know the data we're encoding was valid YAML and we're writing
+	// to a buffer, so there doesn't seem to be an error we
+	// could encounter that would be meaningful.
 	_ = j.Encode(a)
 	return MapPrefix + buf.String()
 }

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -226,6 +226,9 @@ func undecorate(s string) any {
 		s := strings.TrimPrefix(s, MapPrefix)
 		// s is encoded as a JSON map, so we need to decode it
 		var m map[string]any
+		// we ignore the error here because the input string
+		// was marshalled by us and we know it's valid JSON,
+		// and there's nothing we can do with it anyway.
 		json.Unmarshal([]byte(s), &m)
 		return m
 	}

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strconv"
@@ -223,18 +224,10 @@ func undecorate(s string) any {
 		return arr
 	case strings.HasPrefix(s, MapPrefix):
 		s := strings.TrimPrefix(s, MapPrefix)
-		result := make(map[string]string)
-		items := strings.Split(s, RecordSeparator)
-		// the last item is always blank, so < 2 is what we want
-		if len(items) < 2 {
-			return result
-		}
-		items = items[:len(items)-1]
-		for _, i := range items {
-			sp := strings.Split(i, FieldSeparator)
-			result[sp[0]] = sp[1]
-		}
-		return result
+		// s is encoded as a JSON map, so we need to decode it
+		var m map[string]any
+		json.Unmarshal([]byte(s), &m)
+		return m
 	}
 	return s
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Nested maps were getting mangled by the map encoder. 
- This was caught in tests -- except that that test wasn't running on my VS Code test runner OR in branch testing for some reason, so the failure leaked into main. It's working in both places now. I don't know why it failed.

## Short description of the changes

- Change map->string encoding from simple and hand-coded to a JSON encoding.

