### PR TITLE
feat: First 2 templates for configurations

### DIFF
--- a/pkg/config/components/TraceConverter.yaml
+++ b/pkg/config/components/TraceConverter.yaml
@@ -1,0 +1,59 @@
+name: TraceConverter_1
+kind: TraceConverter
+summary: Receives traffic for Refinery via gRPC or HTTP and converts it to Honeycomb's event format.
+description: |
+  Imports OTel telemetry via gRPC or HTTP.
+  This receiver can be configured to listen on both gRPC and HTTP, or just one.
+  It forwards the data to Refinery for processing.
+ports:
+  - name: Traces
+    direction: input
+    type: OTelTraces
+  - name: Logs
+    direction: input
+    type: OTelLogs
+  - name: Events
+    direction: output
+    type: HoneycombEvents
+properties:
+  - name: Host
+    summary: The hostname or IP address on which to listen
+    description: |
+      Hostname or IP address on which to listen for incoming traffic.
+      It is recommended not to change the default unless
+      you know what you're doing.
+    type: string
+    validations: [nonblank]
+    default: ${STRAWS_REFINERY_POD_IP}
+  - name: GRPCPort
+    summary: The port on which Refinery is listening for gRPC traffic.
+    description: |
+      The port on which Refinery listens for incoming gRPC traffic.
+      The OTel default is 4317. Set to 0 to disable gRPC.
+    type: integer
+    validations: [integer]
+    default: 4317
+  - name: HTTPPort
+    summary: The port on which Refinery is listening for HTTP traffic.
+    description: |
+      The port on which Refinery listens for incoming HTTP traffic.
+      The OTel default is 4318. Set to 0 to disable HTTP.
+    type: integer
+    validations: [integer]
+    default: 4318
+templates:
+  - kind: collector_config
+    name: otel_receiver_collector
+    format: collector
+    meta:
+      componentSection: exporters
+      signalTypes: [traces, metrics, logs]
+      collectorComponentName: otlp
+    data:
+      - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.GRPCPort .User.GRPCPort .Props.GRPCPort.Default }}"
+        suppress_if: "{{ eq .HProps.GRPCPort 0 }}"
+      - key: "{{ .ComponentName }}.protocols.http.endpoint"
+        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.HTTPPort .User.HTTPPort .Props.HTTPPort.Default }}"
+        suppress_if: "{{ eq .HProps.HTTPPort 0 }}"
+      # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/components/TraceConverter.yaml
+++ b/pkg/config/components/TraceConverter.yaml
@@ -50,10 +50,10 @@ templates:
       signalTypes: [traces, metrics, logs]
       collectorComponentName: otlp
     data:
-      - key: "{{ .ComponentName }}.protocols.grpc.endpoint"
+      - key: "{{ .ComponentName }}.grpc.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.GRPCPort .User.GRPCPort .Props.GRPCPort.Default }}"
         suppress_if: "{{ eq .HProps.GRPCPort 0 }}"
-      - key: "{{ .ComponentName }}.protocols.http.endpoint"
+      - key: "{{ .ComponentName }}.http.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.HTTPPort .User.HTTPPort .Props.HTTPPort.Default }}"
         suppress_if: "{{ eq .HProps.HTTPPort 0 }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/config/templates/emathroughput.yaml
+++ b/pkg/config/templates/emathroughput.yaml
@@ -1,0 +1,58 @@
+name: EMA Throughput Sampling
+description: |
+  Limit the throughput of traces to Honeycomb using an EMA sampler. This template
+  accepts traces from an OTel receiver, converts them to Honeycomb format, and
+  then samples them using an EMA throughput sampler before exporting them to
+  Honeycomb. Control the volume of traces by modifying the GoalThroughput value in
+  the properties section of the EMAThroughputSampler component.
+components:
+  - name: TraceGRPC_1
+    kind: TraceGRPC
+  - name: TraceConverter_1
+    kind: TraceConverter
+  - name: EMAThroughputSampler_1
+    kind: EMAThroughputSampler
+  - name: HoneycombExporter_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: TraceGRPC_1
+      port: TraceOut
+      type: OTelTraces
+    destination:
+      component: TraceConverter_1
+      port: Input
+      type: OTelTraces
+  - source:
+      component: TraceConverter_1
+      port: Output
+      type: Honeycomb
+    destination:
+      component: EMAThroughputSampler_1
+      port: Input
+      type: Honeycomb
+  - source:
+      component: EMAThroughputSampler_1
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: HoneycombExporter_1
+      port: Traces
+      type: Honeycomb
+layout:
+  frame:
+    width: 1835
+    height: 1491
+  components:
+    - name: EMAThroughputSampler_1
+      x: 606
+      y: 208
+    - name: HoneycombExporter_1
+      x: 1032
+      y: 191
+    - name: TraceConverter_1
+      x: 358
+      y: 195
+    - name: TraceGRPC_1
+      x: 120
+      y: 169

--- a/pkg/config/templates/emathroughput.yaml
+++ b/pkg/config/templates/emathroughput.yaml
@@ -6,17 +6,17 @@ description: |
   Honeycomb. Control the volume of traces by modifying the GoalThroughput value in
   the properties section of the EMAThroughputSampler component.
 components:
-  - name: TraceGRPC_1
-    kind: TraceGRPC
+  - name: OTelReceiver_1
+    kind: OTelReceiver
   - name: TraceConverter_1
     kind: TraceConverter
-  - name: EMAThroughputSampler_1
-    kind: EMAThroughputSampler
+  - name: EMAThroughput_1
+    kind: EMAThroughput
   - name: HoneycombExporter_1
     kind: HoneycombExporter
 connections:
   - source:
-      component: TraceGRPC_1
+      component: OTelReceiver_1
       port: TraceOut
       type: OTelTraces
     destination:
@@ -28,11 +28,11 @@ connections:
       port: Output
       type: Honeycomb
     destination:
-      component: EMAThroughputSampler_1
+      component: EMAThroughput_1
       port: Input
       type: Honeycomb
   - source:
-      component: EMAThroughputSampler_1
+      component: EMAThroughput_1
       port: Kept
       type: Honeycomb
     destination:
@@ -44,15 +44,15 @@ layout:
     width: 1835
     height: 1491
   components:
-    - name: EMAThroughputSampler_1
-      x: 606
-      y: 208
-    - name: HoneycombExporter_1
-      x: 1032
-      y: 191
+    - name: OTelReceiver_1
+      x: 253
+      y: 223
     - name: TraceConverter_1
-      x: 358
-      y: 195
-    - name: TraceGRPC_1
-      x: 120
-      y: 169
+      x: 439
+      y: 227
+    - name: HoneycombExporter_1
+      x: 938
+      y: 210
+    - name: EMAThroughput_1
+      x: 676
+      y: 228

--- a/pkg/config/templates/emathroughput.yaml
+++ b/pkg/config/templates/emathroughput.yaml
@@ -17,7 +17,7 @@ components:
 connections:
   - source:
       component: OTelReceiver_1
-      port: TraceOut
+      port: Traces
       type: OTelTraces
     destination:
       component: TraceConverter_1

--- a/pkg/config/templates/proxy.yaml
+++ b/pkg/config/templates/proxy.yaml
@@ -1,0 +1,63 @@
+name: Basic proxy
+description: |
+  This is a basic proxy that forwards traces, metrics, and logs from the OpenTelemetry gRPC
+  components to the OpenTelemetry exporters. This is useful for testing and debugging, or
+  as a starting point for more complex configurations.
+components:
+  - name: TraceGRPC_1
+    kind: TraceGRPC
+  - name: OTelTraceExporter_1
+    kind: OTelTraceExporter
+  - name: MetricsGRPC_1
+    kind: MetricsGRPC
+  - name: OTelMetricsExporter_1
+    kind: OTelMetricsExporter
+  - name: LogsGRPC_1
+    kind: LogsGRPC
+  - name: OTelLogsExporter_1
+    kind: OTelLogsExporter
+connections:
+  - source:
+      component: TraceGRPC_1
+      port: TraceOut
+      type: OTelTraces
+    destination:
+      component: OTelTraceExporter_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: MetricsGRPC_1
+      port: MetricsOut
+      type: OTelMetrics
+    destination:
+      component: OTelMetricsExporter_1
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: LogsGRPC_1
+      port: LogsOut
+      type: OTelLogs
+    destination:
+      component: OTelLogsExporter_1
+      port: Logs
+      type: OTelLogs
+layout:
+  components:
+    - name: TraceGRPC_1
+      x: 260
+      y: 182
+    - name: OTelTraceExporter_1
+      x: 642
+      y: 182
+    - name: MetricsGRPC_1
+      x: 260
+      y: 320
+    - name: OTelMetricsExporter_1
+      x: 642
+      y: 320
+    - name: LogsGRPC_1
+      x: 260
+      y: 460
+    - name: OTelLogsExporter_1
+      x: 642
+      y: 460

--- a/pkg/config/templates/proxy.yaml
+++ b/pkg/config/templates/proxy.yaml
@@ -1,63 +1,46 @@
 name: Basic proxy
 description: |
-  This is a basic proxy that forwards traces, metrics, and logs from the OpenTelemetry gRPC
-  components to the OpenTelemetry exporters. This is useful for testing and debugging, or
+  This is a basic proxy that forwards traces, metrics, and logs received via OpenTelemetry
+  components to the OpenTelemetry GRPC exporter. This is useful for testing and debugging, or
   as a starting point for more complex configurations.
 components:
-  - name: TraceGRPC_1
-    kind: TraceGRPC
-  - name: OTelTraceExporter_1
-    kind: OTelTraceExporter
-  - name: MetricsGRPC_1
-    kind: MetricsGRPC
-  - name: OTelMetricsExporter_1
-    kind: OTelMetricsExporter
-  - name: LogsGRPC_1
-    kind: LogsGRPC
-  - name: OTelLogsExporter_1
-    kind: OTelLogsExporter
+  - name: OTelReceiver_1
+    kind: OTelReceiver
+  - name: OTelGRPCExporter_1
+    kind: OTelGRPCExporter
 connections:
   - source:
-      component: TraceGRPC_1
-      port: TraceOut
+      component: OTelReceiver_1
+      port: Traces
       type: OTelTraces
     destination:
-      component: OTelTraceExporter_1
+      component: OTelGRPCExporter_1
       port: Traces
       type: OTelTraces
   - source:
-      component: MetricsGRPC_1
-      port: MetricsOut
+      component: OTelReceiver_1
+      port: Metrics
       type: OTelMetrics
     destination:
-      component: OTelMetricsExporter_1
+      component: OTelGRPCExporter_1
       port: Metrics
       type: OTelMetrics
   - source:
-      component: LogsGRPC_1
-      port: LogsOut
+      component: OTelReceiver_1
+      port: Logs
       type: OTelLogs
     destination:
-      component: OTelLogsExporter_1
+      component: OTelGRPCExporter_1
       port: Logs
       type: OTelLogs
 layout:
+  frame:
+    width: 1835
+    height: 1491
   components:
-    - name: TraceGRPC_1
+    - name: OTelReceiver_1
       x: 260
       y: 182
-    - name: OTelTraceExporter_1
+    - name: OTelGRPCExporter_1
       x: 642
       y: 182
-    - name: MetricsGRPC_1
-      x: 260
-      y: 320
-    - name: OTelMetricsExporter_1
-      x: 642
-      y: 320
-    - name: LogsGRPC_1
-      x: 260
-      y: 460
-    - name: OTelLogsExporter_1
-      x: 642
-      y: 460


### PR DESCRIPTION
## Which problem is this PR solving?

- This provides the content of 2 initial template configurations for use in the UI. These will end up being moved to a database eventually.
- We're planning to also have a template for sending things to cold storage (and eventually many more) but we don't have the components to support that yet.

## Short description of the changes

- Proxy template
- EMA Throughput template
- TraceConverter component improved

