### PR TITLE
maint: add make targets for validating configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 test_results/
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,21 @@ test_results:
 
 tidy:
 	$(GOCMD) mod tidy
+
+TEMPLATE ?= pkg/config/templates/emathroughput
+.PHONY: test_template
+#: generate config from template (usage: make test_template TEMPLATE=pkg/config/templates/proxy)
+test_template:
+	@echo
+	@echo "+++ generating config from template $(TEMPLATE)"
+	@echo
+	./testTemplate.sh $(TEMPLATE)
+
+CONFIG ?= examples/hpsf.yaml
+.PHONY: validate
+#: validate provided config (usage: make validate CONFIG=examples/hpsf2.yaml)
+validate:
+	@echo
+	@echo "+++ validating config $(CONFIG)"
+	@echo
+	go run ./cmd/hpsf -i $(CONFIG) validate

--- a/testTemplate.sh
+++ b/testTemplate.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+# Generates configs for a given template, placing in tmp/ directory
+	# $1 - template
+
+# check if $1.yaml exists
+if [ ! -f $1.yaml ]; then
+    echo "File $1.yaml does not exist"
+    exit 1
+fi
+
+mkdir -p tmp/
+
+# Get just the filename without the path
+BASENAME=$(basename $1)
+
+go run ./cmd/hpsf -i $1.yaml -o tmp/${BASENAME}.cconfig.yaml cConfig
+go run ./cmd/hpsf -i $1.yaml -o tmp/${BASENAME}.rconfig.yaml rConfig
+go run ./cmd/hpsf -i $1.yaml -o tmp/${BASENAME}.rrules.yaml rRules


### PR DESCRIPTION
## Which problem is this PR solving?

- easy way to generate configs from templates
- easy way to validate configs

## Short description of the changes

- Add make targets for `validate` and `test_template` 
- Generated configs from templates get placed in tmp/ directory that is gitignored

Example usage

```sh
make test_template TEMPLATE=pkg/config/templates/proxy
make validate CONFIG=examples/hpsf2.yaml
```