### PR TITLE
maint: add proxy example and test for collector config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ smoke:
 	@echo
 	mkdir -p tmp
 	go run ./cmd/hpsf -i ./examples/hpsfProxy.yaml -o tmp/hpsfProxy.cconfig.yaml cConfig
-	docker run --rm -d \
+	docker run --rm -it \
 		--name smoke-proxy \
     -p 4227-4228:4227-4228 \
 		-v ./tmp/hpsfProxy.cconfig.yaml:/etc/otelcol/config.yaml \

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,24 @@ validate_all: examples/*
 	for file in $^ ; do \
 		$(MAKE) validate CONFIG=$${file} || exit 1; \
 	done
+
+.PHONY: smoke
+smoke:
+	@echo
+	@echo "+++ basic smoke test - does it start?"
+	@echo "+++ if so, make unsmoke after this"
+	@echo
+	mkdir -p tmp
+	go run ./cmd/hpsf -i ./examples/hpsfProxy.yaml -o tmp/hpsfProxy.cconfig.yaml cConfig
+	docker run --rm -d \
+		--name smoke-proxy \
+    -p 4227-4228:4227-4228 \
+		-v ./tmp/hpsfProxy.cconfig.yaml:/etc/otelcol/config.yaml \
+		otel/opentelemetry-collector:latest
+
+.PHONY: unsmoke
+unsmoke:
+	@echo
+	@echo "+++ stopping smoke test"
+	@echo
+	docker stop smoke-proxy

--- a/examples/hpsfProxy.yaml
+++ b/examples/hpsfProxy.yaml
@@ -1,5 +1,5 @@
 components:
-  - name: MyCompany OTel Receiver
+  - name: MyCompany_OTel_Receiver
     kind: OTelReceiver
     properties:
       - name: Host
@@ -8,7 +8,7 @@ components:
         value: 4227
       - name: HTTPPort
         value: 4228
-  - name: MyCompany gRPC Exporter
+  - name: MyCompany_gRPC_Exporter
     kind: OTelGRPCExporter
     properties:
       - name: Host
@@ -18,7 +18,7 @@ components:
       - name: Headers
         value:
           x-honeycomb-team: my-grpc-key
-  - name: MyCompany HTTP Exporter
+  - name: MyCompany_HTTP_Exporter
     kind: OTelHTTPExporter
     properties:
       - name: Host
@@ -30,26 +30,26 @@ components:
           x-honeycomb-team: my-http-key
 connections:
   - source:
-      component: MyCompany OTel Receiver
+      component: MyCompany_OTel_Receiver
       port: Traces
       type: OTelTraces
     destination:
-      component: MyCompany gRPC Exporter
+      component: MyCompany_gRPC_Exporter
       port: Traces
       type: OTelTraces
   - source:
-      component: MyCompany OTel Receiver
+      component: MyCompany_OTel_Receiver
       port: Metrics
       type: OTelMetrics
     destination:
-      component: MyCompany HTTP Exporter
+      component: MyCompany_HTTP_Exporter
       port: Metrics
       type: OTelMetrics
   - source:
-      component: MyCompany OTel Receiver
+      component: MyCompany_OTel_Receiver
       port: Logs
       type: OTelLogs
     destination:
-      component: MyCompany gRPC Exporter
+      component: MyCompany_gRPC_Exporter
       port: Logs
       type: OTelLogs

--- a/examples/hpsfProxy.yaml
+++ b/examples/hpsfProxy.yaml
@@ -3,7 +3,7 @@ components:
     kind: OTelReceiver
     properties:
       - name: Host
-        value: http://localhost
+        value: localhost
       - name: GRPCPort
         value: 4227
       - name: HTTPPort
@@ -12,7 +12,7 @@ components:
     kind: OTelGRPCExporter
     properties:
       - name: Host
-        value: http://localhost
+        value: localhost
       - name: Port
         value: 1234
       - name: Headers
@@ -22,7 +22,7 @@ components:
     kind: OTelHTTPExporter
     properties:
       - name: Host
-        value: http://localhost
+        value: localhost
       - name: Port
         value: 1234
       - name: Headers

--- a/examples/hpsfProxy.yaml
+++ b/examples/hpsfProxy.yaml
@@ -1,0 +1,55 @@
+components:
+  - name: MyCompany OTel Receiver
+    kind: OTelReceiver
+    properties:
+      - name: Host
+        value: http://localhost
+      - name: GRPCPort
+        value: 4227
+      - name: HTTPPort
+        value: 4228
+  - name: MyCompany gRPC Exporter
+    kind: OTelGRPCExporter
+    properties:
+      - name: Host
+        value: http://localhost
+      - name: Port
+        value: 1234
+      - name: Headers
+        value:
+          x-honeycomb-team: my-grpc-key
+  - name: MyCompany HTTP Exporter
+    kind: OTelHTTPExporter
+    properties:
+      - name: Host
+        value: http://localhost
+      - name: Port
+        value: 1234
+      - name: Headers
+        value:
+          x-honeycomb-team: my-http-key
+connections:
+  - source:
+      component: MyCompany OTel Receiver
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: MyCompany gRPC Exporter
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: MyCompany OTel Receiver
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: MyCompany HTTP Exporter
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: MyCompany OTel Receiver
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: MyCompany gRPC Exporter
+      port: Logs
+      type: OTelLogs


### PR DESCRIPTION
## Which problem is this PR solving?

- internal asana task https://app.asana.com/0/1208469935858869/1209503664352030

## Short description of the changes

- add example that demonstrates basic property overrides for proxy template (otlp collector) 
- add Makefile target for smoke and unsmoke that simply generates the collector config from the proxy template and tries to run it in Docker. This isn't in CI yet but can be run locally.

**Note**: When this is generated it uses the "Name" field in the collector config. If the name has spaces it will be invalid in Collector config. We'll want to normalize that but maybe as a follow-up. We can use this example for testing.

For example, `otlp/MyCompany OTel Receiver` should become something like `otlp/MyCompany_OTel_Receiver`

This can be confirmed with a quick run in docker (basic "smoke" test added, name tbd):

```sh
make smoke
make unsmoke
```

results in collector logs if spaces are in name (truncated for brevity)

```sh
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

error decoding 'receivers': in "MyCompany OTel Receiver" id: invalid character(s) in name "MyCompany OTel Receiver"
error decoding 'exporters': in "MyCompany HTTP Exporter" id: invalid character(s) in name "MyCompany HTTP Exporter"
```