### PR TITLE
fix: Improvements to validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ validate:
 	done
 
 .PHONY: validate_all
-validate_all: examples/*
+validate_all: examples/hpsf* pkg/data/templates/*
 	for file in $^ ; do \
 		$(MAKE) validate CONFIG=$${file} || exit 1; \
 	done

--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -131,6 +131,11 @@ func main() {
 			log.Fatalf("error validating input file: %v", err)
 		}
 
+		err = hpsf.EnsureHPSFYAML(string(inputData))
+		if err != nil {
+			log.Fatalf("input file is not hpsf: %v", err)
+		}
+
 		var hpsf hpsf.HPSF
 		err = y.Unmarshal(inputData, &hpsf)
 		if err != nil {

--- a/examples/hpsf.yaml
+++ b/examples/hpsf.yaml
@@ -17,7 +17,7 @@ components:
         type: string
       - name: SampleRate
         value: 10
-        type: number
+        type: int
   - name: RefineryGRPC_2
     kind: RefineryGRPC
     ports:
@@ -27,7 +27,7 @@ components:
     properties:
       - name: Port
         value: 4317
-        type: number
+        type: int
   - name: HoneycombExporter_1
     kind: HoneycombExporter
     ports:

--- a/examples/hpsfBig.yaml
+++ b/examples/hpsfBig.yaml
@@ -8,7 +8,7 @@ components:
     properties:
       - name: Port
         value: 8080
-        type: number
+        type: int
   - name: DeterministicSampler_1
     kind: DeterministicSampler
     ports:
@@ -27,7 +27,7 @@ components:
         type: string
       - name: SampleRate
         value: 10
-        type: number
+        type: int
   - name: TraceConverter_1
     kind: TraceConverter
     ports:

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -123,7 +123,7 @@ func (t *TemplateComponent) Props() map[string]TemplateProperty {
 
 func (t *TemplateComponent) ComponentName() string {
 	if t.CollName != "" {
-		return t.CollName + "/" + t.hpsf.Name
+		return t.CollName + "/" + t.hpsf.GetSafeName()
 	}
 	return t.Name
 }

--- a/pkg/data/components/EmaThroughput.yaml
+++ b/pkg/data/components/EmaThroughput.yaml
@@ -61,7 +61,7 @@ properties:
       quantities of the specified sampling keys, while ensuring that at least
       one instance of every distinct value of each key is sampled.
       There is no default; this field must be specified.
-    type: "stringarray"
+    type: stringarray
     validations:
       - nonblank
       - nonempty

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -27,8 +27,8 @@ properties:
     description: |
       The port on which to send outgoing gRPC traffic. Default is 443, which is
       the value expected by Honeycomb. The OTel standard for gRPC is 4317.
-    type: integer
-    validations: [integer]
+    type: int
+    validations: []
     default: 443
   - name: Headers
     summary: Headers to emit when sending gRPC traffic.
@@ -37,7 +37,7 @@ properties:
       configured. This property supports sending a map of header keys and
       values.
     type: map
-    validations: [map]
+    validations: []
 templates:
   - kind: collector_config
     name: otel_grpc_exporter_collector

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -27,8 +27,8 @@ properties:
     description: |
       The port on which to send outgoing HTTP traffic. Default is 443, which is
       the value expected by Honeycomb. The OTel standard for HTTP is 4318.
-    type: integer
-    validations: [integer]
+    type: int
+    validations: [int]
     default: 443
   - name: Headers
     summary: Headers to emit when sending HTTP traffic.
@@ -37,7 +37,7 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
-    validations: [map]
+    validations: []
 templates:
   - kind: collector_config
     name: otel_http_exporter_collector

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -30,16 +30,16 @@ properties:
     description: |
       The port on which to listen for incoming gRPC traffic.
       The OTel default is 4317. Set to 0 to disable gRPC.
-    type: integer
-    validations: [integer]
+    type: int
+    validations: [int]
     default: 4317
   - name: HTTPPort
     summary: The port on which to listen for HTTP traffic.
     description: |
       The port on which to listen for incoming HTTP traffic.
       The OTel default is 4318. Set to 0 to disable HTTP.
-    type: integer
-    validations: [integer]
+    type: int
+    validations: [int]
     default: 4318
 templates:
   - kind: collector_config

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -31,16 +31,16 @@ properties:
     description: |
       The port on which Refinery listens for incoming gRPC traffic.
       The OTel default is 4317. Set to 0 to disable gRPC.
-    type: integer
-    validations: [integer]
+    type: int
+    validations: [int]
     default: 4317
   - name: HTTPPort
     summary: The port on which Refinery is listening for HTTP traffic.
     description: |
       The port on which Refinery listens for incoming HTTP traffic.
       The OTel default is 4318. Set to 0 to disable HTTP.
-    type: integer
-    validations: [integer]
+    type: int
+    validations: [int]
     default: 4318
 templates:
   - kind: collector_config

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -179,13 +179,17 @@ func (c *Component) Validate() []error {
 	return results
 }
 
+func safeName(s string) string {
+	re := regexp.MustCompile(`[^a-zA-Z0-9]+`)
+	return re.ReplaceAllString(s, "_")
+}
+
 // Returns the safe name of the component (no spaces or special characters)
 // This has potential to cause a problem if the resulting name is not unique -- so uniqueness
 // should be tested with this name, not the original name.
 // we replace any runs of characters not in [a-zA-Z0-9] with an underscore
 func (c *Component) GetSafeName() string {
-	re := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	return re.ReplaceAllString(c.Name, "_")
+	return safeName(c.Name)
 }
 
 // returns the port with the given name, or nil if not found
@@ -221,6 +225,10 @@ type ConnectionPort struct {
 	Component string         `yaml:"component"`
 	PortName  string         `yaml:"port"`
 	Type      ConnectionType `yaml:"type"`
+}
+
+func (cp *ConnectionPort) GetSafeName() string {
+	return safeName(cp.Component)
 }
 
 func (cp *ConnectionPort) Validate() []error {

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -2,6 +2,9 @@ package hpsf
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -18,7 +21,7 @@ components:
     properties:
       - name: SampleRate
         value: 1
-        type: number
+        type: int
 `
 
 type ConnectionType string
@@ -38,45 +41,57 @@ const (
 type PropType string
 
 const (
-	PTYPE_NUMBER PropType = "number"
+	PTYPE_INT    PropType = "int"
+	PTYPE_FLOAT  PropType = "float"
 	PTYPE_STRING PropType = "string"
 	PTYPE_BOOL   PropType = "bool"
 	PTYPE_ARRSTR PropType = "stringarray"
+	PTYPE_MAPSTR PropType = "map" // map[string]any
 )
 
 func (p PropType) Validate() error {
 	switch p {
-	case PTYPE_NUMBER:
+	case PTYPE_INT:
+	case PTYPE_FLOAT:
 	case PTYPE_STRING:
 	case PTYPE_BOOL:
 	case PTYPE_ARRSTR:
+	case PTYPE_MAPSTR:
 	default:
 		return errors.New("invalid PropType '" + string(p) + "'")
 	}
 	return nil
 }
 
-func (p PropType) Conforms(a any) error {
+func (p PropType) ValueConforms(a any) error {
 	// null proptype means anything goes
 	if p == "" {
 		return nil
 	}
 	switch p {
-	case PTYPE_NUMBER:
+	case PTYPE_INT:
 		if _, ok := a.(int); !ok {
-			return errors.New("expected int, got " + a.(string))
+			return errors.New("expected int, got " + fmt.Sprint(a))
+		}
+	case PTYPE_FLOAT:
+		if _, ok := a.(float64); !ok {
+			return errors.New("expected float, got " + fmt.Sprint(a))
 		}
 	case PTYPE_STRING:
 		if _, ok := a.(string); !ok {
-			return errors.New("expected string, got " + a.(string))
+			return errors.New("expected string, got " + fmt.Sprint(a))
 		}
 	case PTYPE_BOOL:
 		if _, ok := a.(bool); !ok {
-			return errors.New("expected bool, got " + a.(string))
+			return errors.New("expected bool, got " + fmt.Sprint(a))
 		}
 	case PTYPE_ARRSTR:
 		if _, ok := a.([]string); !ok {
-			return errors.New("expected []string, got " + a.(string))
+			return errors.New("expected []string, got " + fmt.Sprint(a))
+		}
+	case PTYPE_MAPSTR:
+		if _, ok := a.(map[string]any); !ok {
+			return errors.New("expected map[string]any, got " + fmt.Sprint(a))
 		}
 	default:
 		return errors.New("invalid PropType '" + string(p) + "'")
@@ -140,6 +155,7 @@ func (c *Component) Validate() []error {
 		switch p.Value.(type) {
 		case string:
 		case int:
+		case float64:
 		case bool:
 		case map[string]any:
 		case []any:
@@ -155,12 +171,21 @@ func (c *Component) Validate() []error {
 			results = append(results, validator.NewErrorf("Component %s Property %s Value must be a string, number, bool, []any, or map[string]any", c.Name, p.Name))
 		}
 
-		err := p.Type.Conforms(p.Value)
+		err := p.Type.ValueConforms(p.Value)
 		if err != nil {
 			results = append(results, validator.NewErrorf("Component %s Property %s Value %s", c.Name, p.Name, err))
 		}
 	}
 	return results
+}
+
+// Returns the safe name of the component (no spaces or special characters)
+// This has potential to cause a problem if the resulting name is not unique -- so uniqueness
+// should be tested with this name, not the original name.
+// we replace any runs of characters not in [a-zA-Z0-9] with an underscore
+func (c *Component) GetSafeName() string {
+	re := regexp.MustCompile(`[^a-zA-Z0-9]+`)
+	return re.ReplaceAllString(c.Name, "_")
 }
 
 // returns the port with the given name, or nil if not found
@@ -304,11 +329,30 @@ type HPSF struct {
 	Layout      Layout        `yaml:"layout,omitempty"`
 }
 
+// use reflect to generate a list of valid yaml tags in a pointer to
+// a struct
+func getValidKeys(p any) []string {
+	keys := []string{}
+	v := reflect.ValueOf(p).Elem()
+	for i := range v.NumField() {
+		f := v.Type().Field(i)
+		yamltag := f.Tag.Get("yaml")
+		if yamltag != "" {
+			// ignore any options like "omitempty"
+			if strings.Contains(yamltag, ",") {
+				yamltag = strings.Split(yamltag, ",")[0]
+			}
+			keys = append(keys, yamltag)
+		}
+	}
+	return keys
+}
+
 func (h *HPSF) Validate() []error {
 	results := []error{}
 
 	if h.Components == nil && h.Connections == nil && h.Containers == nil && h.Layout == nil {
-		results = append(results, errors.New("default HPSF structs are considered invalid"))
+		results = append(results, errors.New("empty and default HPSF structs are considered invalid"))
 	}
 
 	for _, c := range h.Components {
@@ -326,8 +370,8 @@ func (h *HPSF) Validate() []error {
 	return results
 }
 
-// EnsureHPSF returns an error if the input is not HPSF yaml or invalid HPSF
-func EnsureHPSF(input string) error {
+// EnsureHPSFYAML returns an error if the input is not HPSF yaml or invalid HPSF
+func EnsureHPSFYAML(input string) error {
 	m, err := validator.EnsureYAML([]byte(input))
 	if err != nil {
 		return err
@@ -337,12 +381,17 @@ func EnsureHPSF(input string) error {
 		return errors.New("HPSF yaml is empty")
 	}
 
-	// check to see if it has only expected keys
-	keys := []string{"components", "connections", "containers", "layout"}
+	// check to see if it has only expected top-level keys
+	// (it would be interesting to do this recursively someday, but it's a lot)
+	keys := getValidKeys(&HPSF{})
+	badkeys := make([]string, 0)
 	for k := range m {
 		if !slices.Contains(keys, k) {
-			return errors.New("HPSF yaml contains unexpected keys")
+			badkeys = append(badkeys, k)
 		}
+	}
+	if len(badkeys) > 0 {
+		return errors.New("HPSF yaml contains unexpected keys: " + strings.Join(badkeys, ", "))
 	}
 
 	var hpsf HPSF
@@ -351,8 +400,13 @@ func EnsureHPSF(input string) error {
 	if err != nil {
 		return err
 	}
-	if len(hpsf.Validate()) != 0 {
-		return errors.New("HPSF validation failed")
+	validations := hpsf.Validate()
+	if len(validations) != 0 {
+		v := make([]string, len(validations))
+		for i, e := range validations {
+			v[i] = e.Error()
+		}
+		return errors.New("HPSF validation failed: " + strings.Join(v, ", "))
 	}
 	return nil
 }

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -92,6 +92,7 @@ func TestComponent_GetSafeName(t *testing.T) {
 		{"a b c", "a_b_c"},
 		{"a#@#$%^&*()b", "a_b"},
 		{"Deterministic Sampler", "Deterministic_Sampler"},
+		{"Deterministic_Sampler", "Deterministic_Sampler"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -30,7 +30,7 @@ func TestEnsureHPSF(t *testing.T) {
 				y[arg] = i
 			}
 			text, _ := y.RenderYAML()
-			if err := EnsureHPSF(string(text)); (err != nil) && !strings.Contains(err.Error(), tt.wantErr) {
+			if err := EnsureHPSFYAML(string(text)); (err != nil) && !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("EnsureHPSF() error = %v, should contain '%v'", err, tt.wantErr)
 			}
 		})
@@ -78,5 +78,27 @@ connections:
 }
 
 func TestDefaultConfigurationIsValidYAML(t *testing.T) {
-	require.NoError(t, EnsureHPSF(DefaultConfiguration))
+	err := EnsureHPSFYAML(DefaultConfiguration)
+	require.NoError(t, err)
+}
+
+func TestComponent_GetSafeName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"a", "a"},
+		{"a b", "a_b"},
+		{"a b c", "a_b_c"},
+		{"a#@#$%^&*()b", "a_b"},
+		{"Deterministic Sampler", "Deterministic_Sampler"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Component{Name: tt.name}
+			if got := c.GetSafeName(); got != tt.want {
+				t.Errorf("Component.GetSafeName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -83,13 +83,13 @@ func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[s
 
 	// now add the connections
 	for _, conn := range h.Connections {
-		comp, ok := comps[conn.Source.Component]
+		comp, ok := comps[conn.Source.GetSafeName()]
 		if !ok {
 			return nil, fmt.Errorf("unknown source component %s in connection", conn.Source.Component)
 		}
 		comp.AddConnection(conn)
 
-		comp, ok = comps[conn.Destination.Component]
+		comp, ok = comps[conn.Destination.GetSafeName()]
 		if !ok {
 			return nil, fmt.Errorf("unknown target component %s in connection", conn.Destination.Component)
 		}

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -78,7 +78,7 @@ func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[s
 		if err != nil {
 			return nil, err
 		}
-		comps[c.Name] = comp
+		comps[c.GetSafeName()] = comp
 	}
 
 	// now add the connections


### PR DESCRIPTION
## Which problem is this PR solving?

- Cleaning up the validation logic

## Short description of the changes

- Fix up property types (number -> int and float, add map)
- Adjust property definitions in various places
- Add validation for names of top-level keys in HPSF files
- Adjust makefile to check templates as well as examples

## Still to do

- [ ] Add validation of template components
- [ ] Add makefile steps to validate them
- [ ] Add validation of HPSF property values including their validation steps specified in the components

