### PR TITLE
feat: Add style, tags, and status to TemplateComponents

### DIFF
--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -1,21 +1,25 @@
 kind: DeterministicSampler
 name: Deterministic Sampler
 version: v0.1.0
+style: base
+status: development
 summary: A basic sampler that deterministically samples a fixed fraction of traces based on trace ID
 description: |
   A basic sampler that deterministically samples a fixed fraction of traces based on trace ID.
+tags:
+  - category:sampling
+  - service:refinery
+  - signal:HoneycombEvents
+  - sampler:deterministic
+  - sampler:rate
 ports:
   - name: Traces
     direction: input
-    type: HoneycombTraces
+    type: HoneycombEvents
   - name: SampledOutput
     direction: output
-    type: HoneycombTraces
+    type: HoneycombEvents
     note: "The traces that are sampled"
-  - name: UnsampledOutput
-    direction: output
-    type: HoneycombTraces
-    note: "The traces that are not sampled"
 properties:
   - name: Environment
     summary: The environment in which to enable the sampler

--- a/pkg/data/components/EmaThroughput.yaml
+++ b/pkg/data/components/EmaThroughput.yaml
@@ -1,5 +1,7 @@
 kind: EMAThroughput
 name: EMA Throughput Sampler
+style: base
+status: development
 version: v0.1.0
 summary: An EMA sampler designed to achieve a target throughput (in events per second)
 description: |
@@ -7,18 +9,20 @@ description: |
   target throughput (in events per second) based on trying to achieve representative
   quantities of the specified sampling keys. The keys should be chosen from fields
   with relatively low cardinality, such as HTTP method, status code, etc.
+tags:
+  - category:sampling
+  - service:refinery
+  - signal:HoneycombEvents
+  - sampler:ema
+  - sampler:throughput
 ports:
   - name: Traces
     direction: input
-    type: HoneycombTraces
+    type: HoneycombEvents
   - name: SampledOutput
     direction: output
-    type: HoneycombTraces
-    note: "The traces that are sampled"
-  - name: UnsampledOutput
-    direction: output
-    type: HoneycombTraces
-    note: "The traces that are not sampled"
+    type: HoneycombEvents
+    note: "The traces that are sampled (retained for further processing)"
 properties:
   - name: Environment
     summary: The environment in which to enable the sampler

--- a/pkg/data/components/FilterProcessor.yaml
+++ b/pkg/data/components/FilterProcessor.yaml
@@ -1,10 +1,19 @@
 kind: FilterProcessor
 name: Filter Processor
+style: base
+status: development
 version: v0.1.0
 summary: Processor that can be used to filter telemetry.
 description: |
   Filters traces, metrics, and logs based on rules defined
   in the configuration.
+tags:
+  - category:processor
+  - service:collector
+  - category:filter
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
     direction: input

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -1,13 +1,20 @@
 kind: HoneycombExporter
 name: Honeycomb Exporter
+style: base
+status: development
 version: v0.1.0
-summary: Export telemetry to Honeycomb in Honeycomb's event format.
+summary: Export traces to Honeycomb in Honeycomb's event format.
 description: |
-  This component exports telemetry to Honeycomb in Honeycomb's event format.
+  This component exports traces to Honeycomb in Honeycomb's event format.
+tags:
+  - category:exporter
+  - service:refinery
+  - signal:HoneycombEvents
+  - vendor:Honeycomb
 ports:
   - name: Traces
     direction: input
-    type: HoneycombTraces
+    type: HoneycombEvents
 properties:
   - name: APIKey
     summary: The API key to use to authenticate with Honeycomb

--- a/pkg/data/components/OTelDebugExporter.yaml
+++ b/pkg/data/components/OTelDebugExporter.yaml
@@ -1,9 +1,19 @@
 kind: OTelDebugExporter
 name: OTel Debug Exporter
+style: base
+status: development
 version: v0.1.0
 summary: Exports pipeline signal traffic to stdout
 description: |
-  Exports signal data in a pipeline to stdout.
+  Exports signal data from a pipeline to stdout. This is useful for debugging, but only if you
+  have access to the stdout stream in your environment. This component is not intended for production use.
+tags:
+  - category:exporter
+  - category:debug
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 properties:
   - name: Verbosity
     summary: The verbosity level of the debug output

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -1,9 +1,17 @@
 kind: OTelGRPCExporter
 name: OTel gRPC Exporter
+style: base
+status: development
 version: v0.1.0
 summary: Exports OTLP (OpenTelemetry) traffic via gRPC
 description: |
   Exports OpenTelemetry signals using OTLP via gRPC.
+tags:
+  - category:exporter
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
     direction: input

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -1,9 +1,17 @@
 kind: OTelHTTPExporter
 name: OTel Http Exporter
+style: base
+status: development
 version: v0.1.0
 summary: Exports OTLP (OpenTelemetry) traffic via HTTP
 description: |
   Exports OpenTelemetry signals using OTLP via HTTP.
+tags:
+  - category:exporter
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
     direction: input

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -1,10 +1,18 @@
 kind: OTelReceiver
 name: OTel Receiver
+style: base
+status: development
 version: v0.1.0
 summary: Receives OTLP (OpenTelemetry) traffic via gRPC or HTTP or both
 description: |
   Imports OTLP signals from OpenTelemetry via gRPC or HTTP.
   This receiver can be configured to listen on both gRPC and HTTP, or just one.
+tags:
+  - category:receiver
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
     direction: output

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -1,11 +1,20 @@
 kind: TraceConverter
 name: Trace Converter
+style: base
+status: development
 version: v0.1.0
 summary: Receives traffic for Refinery via gRPC or HTTP and converts it to Honeycomb's event format.
 description: |
   Imports OTel telemetry via gRPC or HTTP.
   This receiver can be configured to listen on both gRPC and HTTP, or just one.
   It forwards the data to Refinery for processing.
+tags:
+  - category:converter
+  - service:refinery
+  - signal:OTelTraces
+  - signal:OTelLogs
+  - signal:HoneycombEvents
+  - vendor:Honeycomb
 ports:
   - name: Traces
     direction: input

--- a/pkg/data/loadEmbedded_test.go
+++ b/pkg/data/loadEmbedded_test.go
@@ -17,6 +17,23 @@ func TestLoadEmbeddedComponents(t *testing.T) {
 	if len(got) == 0 {
 		t.Errorf("LoadEmbeddedComponents() = %v, want non-empty", got)
 	}
+	// we'll eventually move this to a validation library and use that; for now this is just a quick check
+	for k, v := range got {
+		switch v.Style {
+		case config.ComponentStyleBase, config.ComponentStyleMeta, config.ComponentStyleTemplate:
+			// ok
+		default:
+			t.Errorf("LoadEmbeddedComponents() %s style = %v, what's that?", k, v.Style)
+		}
+		switch v.Status {
+		case config.ComponentStatusArchived, config.ComponentStatusDeprecated:
+			t.Errorf("LoadEmbeddedComponents() %s status = %v, want something active", k, v.Status)
+		case config.ComponentStatusDevelopment, config.ComponentStatusStable:
+			// ok
+		default:
+			t.Errorf("LoadEmbeddedComponents() %s status = %v, what's that?", k, v.Status)
+		}
+	}
 }
 
 func TestTemplateComponents(t *testing.T) {


### PR DESCRIPTION

## Which problem is this PR solving?

- Since this is now the source of truth for components, we need all the fields the database would have. 

## Short description of the changes

- Adds Tags, Style and Status to the component data structure
- Ensures that Style and Status are lowercase in YAML but uppercase in the data by defining types for those fields
- Updates all the components to have appropriate values of the new fields

