### PR TITLE
fix: deterministic sampler should use SampleRate

### DIFF
--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -41,5 +41,5 @@ templates:
     name: DeterministicSampler_RefineryRules
     format: dotted
     data:
-      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.GoalThroughput"
+      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.SampleRate"
         value: "{{ firstNonZero .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default | encodeAsInt }}"

--- a/pkg/data/testdata/DeterministicSampler_output_refinery_rules.yaml
+++ b/pkg/data/testdata/DeterministicSampler_output_refinery_rules.yaml
@@ -1,4 +1,4 @@
 Samplers:
     staging:
         DeterministicSampler:
-            GoalThroughput: 42
+            SampleRate: 42

--- a/pkg/translator/testdata/default_refinery_rules.yaml
+++ b/pkg/translator/testdata/default_refinery_rules.yaml
@@ -2,4 +2,4 @@ RulesVersion: 2
 Samplers:
     __default__:
         DeterministicSampler:
-            GoalThroughput: 1
+            SampleRate: 1


### PR DESCRIPTION
## Which problem is this PR solving?

- Deterministic Sampler should use SampleRate, not GoalThroughput

## Short description of the changes

- Update DeterministicSampler component to look at SampleRate
- Update expected default refinery rules

