### PR TITLE
feat: add comment property, use advanced property

### DIFF
--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -178,33 +178,6 @@ func firstNonzero(s ...any) any {
 	return ""
 }
 
-func firstNonzerOld(s ...any) string {
-	// returns the first non-zero-valued item from the arguments
-	// []any is special-cased to return a comma-separated set of strings.
-	// If we eventually feel like the comma syntax is failing to handle some special
-	// cases, we can change it to use some other syntax that's less likely to occur
-	// in real data.
-	for _, v := range s {
-		if !_isZeroValue(v) {
-			switch vt := v.(type) {
-			case string:
-				return fmt.Sprintf("%v", vt)
-			case []any:
-				ss := make([]string, len(vt))
-				for i, vv := range vt {
-					ss[i] = fmt.Sprintf("%v", vv)
-				}
-				return strings.Join(ss, FieldSeparator)
-			case []string:
-				return strings.Join(vt, FieldSeparator)
-			default:
-				return fmt.Sprintf("%v", vt)
-			}
-		}
-	}
-	return ""
-}
-
 // indents a string by the specified number of spaces
 func indent(count int, s string) string {
 	return strings.Repeat(" ", count) + _indentRest(count, s)

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -159,6 +159,7 @@ type TemplateComponent struct {
 	Name        string             `yaml:"name"`
 	Summary     string             `yaml:"summary,omitempty"`
 	Description string             `yaml:"description,omitempty"`
+	Comment     string             `yaml:"comment,omitempty"`
 	Tags        []string           `yaml:"tags,omitempty"`
 	Type        ComponentType      `yaml:"type,omitempty"`
 	Style       string             `yaml:"style,omitempty"`

--- a/pkg/data/components/EmaThroughput.yaml
+++ b/pkg/data/components/EmaThroughput.yaml
@@ -57,6 +57,7 @@ properties:
     validations:
       - positive
     default: 60
+    advanced: true
   - name: FieldList
     summary: The field names of the keys to use for controlling sampling
     description: |

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -32,6 +32,7 @@ properties:
     type: string
     validations: [nonblank, url]
     default: https://api.honeycomb.io
+    advanced: true
 templates:
   - kind: refinery_config
     name: HoneycombExporter_RefineryConfig

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -24,21 +24,6 @@ ports:
     direction: input
     type: OTelLogs
 properties:
-  - name: Host
-    summary: The hostname or IP address to send data to
-    description: |
-      Hostname or IP address on which to send outgoing GRPC traffic.
-    type: string
-    validations: [nonblank]
-    default: https://api.honeycomb.io
-  - name: Port
-    summary: The port on which to send gRPC traffic.
-    description: |
-      The port on which to send outgoing gRPC traffic. Default is 443, which is
-      the value expected by Honeycomb. The OTel standard for gRPC is 4317.
-    type: int
-    validations: []
-    default: 443
   - name: Headers
     summary: Headers to emit when sending gRPC traffic.
     description: |
@@ -47,6 +32,23 @@ properties:
       values.
     type: map
     validations: []
+  - name: Host
+    summary: The hostname or IP address to send data to
+    description: |
+      Hostname or IP address on which to send outgoing GRPC traffic.
+    type: string
+    validations: [nonblank]
+    default: https://api.honeycomb.io
+    advanced: true
+  - name: Port
+    summary: The port on which to send gRPC traffic.
+    description: |
+      The port on which to send outgoing gRPC traffic. Default is 443, which is
+      the value expected by Honeycomb. The OTel standard for gRPC is 4317.
+    type: int
+    validations: []
+    default: 443
+    advanced: true
   - name: Insecure
     summary: Provide a way to disable TLS export.
     description: |
@@ -54,6 +56,7 @@ properties:
     type: bool
     validations: [bool]
     default: false
+    advanced: true
 templates:
   - kind: collector_config
     name: otel_grpc_exporter_collector

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -24,28 +24,6 @@ ports:
     direction: input
     type: OTelLogs
 properties:
-  - name: Host
-    summary: The hostname or IP address to send data to
-    description: |
-      Hostname or IP address on which to send outgoing HTTP traffic.
-    type: string
-    validations: [nonblank]
-    default: https://api.honeycomb.io
-  - name: Port
-    summary: The port on which to send HTTP traffic.
-    description: |
-      The port on which to send outgoing HTTP traffic. Default is 443, which is
-      the value expected by Honeycomb. The OTel standard for HTTP is 4318.
-    type: int
-    validations: [int]
-    default: 443
-  - name: Insecure
-    summary: Provide a way to disable TLS export.
-    description: |
-      Can be used to send data without TLS.
-    type: bool
-    validations: [bool]
-    default: false
   - name: Headers
     summary: Headers to emit when sending HTTP traffic.
     description: |
@@ -54,6 +32,31 @@ properties:
       values.
     type: map
     validations: []
+  - name: Host
+    summary: The hostname or IP address to send data to
+    description: |
+      Hostname or IP address on which to send outgoing HTTP traffic.
+    type: string
+    validations: [nonblank]
+    default: https://api.honeycomb.io
+    advanced: true
+  - name: Port
+    summary: The port on which to send HTTP traffic.
+    description: |
+      The port on which to send outgoing HTTP traffic. Default is 443, which is
+      the value expected by Honeycomb. The OTel standard for HTTP is 4318.
+    type: int
+    validations: [int]
+    default: 443
+    advanced: true
+  - name: Insecure
+    summary: Provide a way to disable TLS export.
+    description: |
+      Can be used to send data without TLS.
+    type: bool
+    validations: [bool]
+    default: false
+    advanced: true
 templates:
   - kind: collector_config
     name: otel_http_exporter_collector

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -34,6 +34,7 @@ properties:
     type: string
     validations: [nonblank]
     default: ${STRAWS_COLLECTOR_POD_IP}
+    advanced: true
   - name: GRPCPort
     summary: The port on which to listen for gRPC traffic.
     description: |
@@ -42,6 +43,7 @@ properties:
     type: int
     validations: [int]
     default: 4317
+    advanced: true
   - name: HTTPPort
     summary: The port on which to listen for HTTP traffic.
     description: |
@@ -50,6 +52,7 @@ properties:
     type: int
     validations: [int]
     default: 4318
+    advanced: true
 templates:
   - kind: collector_config
     name: otel_receiver_collector

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -36,6 +36,7 @@ properties:
     type: string
     validations: [nonblank]
     default: ${STRAWS_REFINERY_POD_IP}
+    advanced: true
   - name: GRPCPort
     summary: The port on which Refinery is listening for gRPC traffic.
     description: |
@@ -44,6 +45,7 @@ properties:
     type: int
     validations: [int]
     default: 4317
+    advanced: true
   - name: HTTPPort
     summary: The port on which Refinery is listening for HTTP traffic.
     description: |
@@ -52,6 +54,7 @@ properties:
     type: int
     validations: [int]
     default: 4318
+    advanced: true
 templates:
   - kind: collector_config
     name: otel_receiver_collector


### PR DESCRIPTION
## Which problem is this PR solving?

- TemplateComponents now have a Comment property
- Several of the common components now have some of their properties marked with the Advanced flag

The advanced flag is an indication that most configurations will not need to modify that property, so it is hidden by default in the UI under a control that looks like "> Advanced". Clicking that control will reveal all those properties. It's intended to allow components to have a lot of configurability but to hide it from the average user.

## Short description of the changes

- Add comment field to TemplateComponent
- delete unused function that was mistakenly committed
- Mark some properties as Advanced

