### PR TITLE
feat: add metrics/logs to nop components, all signals to debug exporter

### DIFF
--- a/pkg/data/components/NopExporter.yaml
+++ b/pkg/data/components/NopExporter.yaml
@@ -8,17 +8,30 @@ summary: An "exporter" that does nothing, but might be useful for testing.
 description: |
   A simple no-op exporter.
   This exporter does nothing. It is required for the minimal collector.
+tags:
+  - category:exporter
+  - category:nop
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
     direction: input
     type: OTelTraces
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Logs
+    direction: input
+    type: OTelLogs
 templates:
   - kind: collector_config
     name: nop_exporter_collector
     format: collector
     meta:
       componentSection: exporters
-      signalTypes: [traces]
+      signalTypes: [traces, metrics, logs]
       collectorComponentName: nop
     data:
       - key: "{{ .ComponentName }}"

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -8,17 +8,30 @@ summary: A "receiver" that does nothing, but might be useful for testing.
 description: |
   A simple no-op receiver.
   This receiver does nothing. It is required for the minimal collector.
+tags:
+  - category:receiver
+  - category:nop
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
-    direction: output
+    direction: input
     type: OTelTraces
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Logs
+    direction: input
+    type: OTelLogs
 templates:
   - kind: collector_config
     name: nop_receiver_collector
     format: collector
     meta:
       componentSection: receivers
-      signalTypes: [traces]
+      signalTypes: [traces, metrics, logs]
       collectorComponentName: nop
     data:
       - key: "{{ .ComponentName }}"

--- a/pkg/data/components/OTelDebugExporter.yaml
+++ b/pkg/data/components/OTelDebugExporter.yaml
@@ -15,6 +15,16 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+ports:
+  - name: Traces
+    direction: input
+    type: OTelTraces
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Logs
+    direction: input
+    type: OTelLogs
 properties:
   - name: Verbosity
     summary: The verbosity level of the debug output.


### PR DESCRIPTION
## Which problem is this PR solving?

- Ensures nop receiver/exporter and for the debug exporter can be connected for all signals.

## Short description of the changes

- This adds all the signals for the nop receiver/exporter and for the debug exporter.

