### PR TITLE
bugfix: trace converter must support one of http or grpc

### DIFF
--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -4,11 +4,10 @@ style: receiver
 type: base
 status: development
 version: v0.1.0
-summary: Receives traffic for Refinery via gRPC or HTTP and converts it to Honeycomb's event format.
+summary: Exports telemetry to Refinery via HTTP for further processing.
 description: |
-  Imports OTel telemetry via gRPC or HTTP.
-  This receiver can be configured to listen on both gRPC and HTTP, or just one.
-  It forwards the data to Refinery for processing.
+  Exports OTel telemetry via HTTP.
+  This exporter forwards the data to Refinery over HTTP for processing.
 tags:
   - category:converter
   - service:refinery
@@ -37,15 +36,6 @@ properties:
     validations: [nonblank]
     default: ${STRAWS_REFINERY_POD_IP}
     advanced: true
-  - name: GRPCPort
-    summary: The port on which Refinery is listening for gRPC traffic.
-    description: |
-      The port on which Refinery listens for incoming gRPC traffic.
-      The OTel default is 4317. Set to 0 to disable gRPC.
-    type: int
-    validations: [int]
-    default: 4317
-    advanced: true
   - name: HTTPPort
     summary: The port on which Refinery is listening for HTTP traffic.
     description: |
@@ -62,12 +52,9 @@ templates:
     meta:
       componentSection: exporters
       signalTypes: [traces, metrics, logs]
-      collectorComponentName: otlp
+      collectorComponentName: otlphttp
     data:
-      - key: "{{ .ComponentName }}.grpc.endpoint"
-        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.GRPCPort .User.GRPCPort .Props.GRPCPort.Default }}"
-        suppress_if: "{{ eq .HProps.GRPCPort 0 }}"
-      - key: "{{ .ComponentName }}.http.endpoint"
+      - key: "{{ .ComponentName }}.endpoint"
         value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.HTTPPort .User.HTTPPort .Props.HTTPPort.Default }}"
         suppress_if: "{{ eq .HProps.HTTPPort 0 }}"
       # service is not part of the template, it's generated automatically by the collectorConfig


### PR DESCRIPTION

## Which problem is this PR solving?

- The TraceConverter was producing invalid configuration.

## Short description of the changes

- Updated the template to only use HTTP for export

