### PR TITLE
feat: add InstallTemplates func

### DIFF
--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -46,6 +46,16 @@ func (t *Translator) InstallTemplates(components map[string]hpsf.HPSF) {
 	maps.Copy(t.templates, components)
 }
 
+// GetComponents returns the components installed in the translator.
+func (t *Translator) GetComponents() map[string]config.TemplateComponent {
+	return t.components
+}
+
+// GetTemplates returns the templates installed in the translator.
+func (t *Translator) GetTemplates() map[string]hpsf.HPSF {
+	return t.templates
+}
+
 // Loads the embedded components into the translator.
 // Deprecated: use InstallComponents instead
 func (t *Translator) LoadEmbeddedComponents() error {

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -3,6 +3,8 @@ package translator
 import (
 	"fmt"
 
+	"maps"
+
 	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/data"
@@ -13,7 +15,8 @@ import (
 // collection of components, and then further rendering those into configuration
 // files.
 type Translator struct {
-	templateComponents map[string]config.TemplateComponent
+	components map[string]config.TemplateComponent
+	templates  map[string]hpsf.HPSF
 }
 
 // Deprecated: use NewEmptyTranslator and InstallComponents instead
@@ -26,16 +29,21 @@ func NewTranslator() (*Translator, error) {
 
 // Creates a translator with no components loaded.
 func NewEmptyTranslator() *Translator {
-	tr := &Translator{templateComponents: make(map[string]config.TemplateComponent)}
+	tr := &Translator{
+		components: make(map[string]config.TemplateComponent),
+		templates:  make(map[string]hpsf.HPSF),
+	}
 	return tr
 }
 
 // InstallComponents installs the given components into the translator.
 func (t *Translator) InstallComponents(components map[string]config.TemplateComponent) {
-	// copy components into the templateComponents map, overwriting any duplicates
-	for k, v := range components {
-		t.templateComponents[k] = v
-	}
+	maps.Copy(t.components, components)
+}
+
+// InstallTemplates installs the given templates into the translator.
+func (t *Translator) InstallTemplates(components map[string]hpsf.HPSF) {
+	maps.Copy(t.templates, components)
 }
 
 // Loads the embedded components into the translator.
@@ -46,16 +54,13 @@ func (t *Translator) LoadEmbeddedComponents() error {
 	if err != nil {
 		return err
 	}
-	// overwrite anything in the templateComponents map with the embedded components
-	for k, v := range tcs {
-		t.templateComponents[k] = v
-	}
+	maps.Copy(t.components, tcs)
 	return nil
 }
 
 func (t *Translator) MakeConfigComponent(component hpsf.Component) (config.Component, error) {
 	// first look in the template components
-	tc, ok := t.templateComponents[component.Kind]
+	tc, ok := t.components[component.Kind]
 	if ok {
 		tc.SetHPSF(component)
 		return &tc, nil

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -74,7 +74,10 @@ func TestGenerateConfig(t *testing.T) {
 			comps, err := data.LoadEmbeddedComponents()
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
+
+			templates, err := data.LoadEmbeddedTemplates()
 			require.NoError(t, err)
+			tlater.InstallTemplates(templates)
 
 			cfg, err := tlater.GenerateConfig(hpsf, config.CollectorConfigType, nil)
 			require.NoError(t, err)

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -74,10 +74,12 @@ func TestGenerateConfig(t *testing.T) {
 			comps, err := data.LoadEmbeddedComponents()
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
+			require.Equal(t, comps, tlater.GetComponents())
 
 			templates, err := data.LoadEmbeddedTemplates()
 			require.NoError(t, err)
 			tlater.InstallTemplates(templates)
+			require.Equal(t, templates, tlater.GetTemplates())
 
 			cfg, err := tlater.GenerateConfig(hpsf, config.CollectorConfigType, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?

- This adds support to the translator to return contents of templates as well as components it currently supports.

## Short description of the changes

- added `InstallTemplates` func to translator
- applied the suggestion to use `maps.Copy` instead of looping through the maps
- updated the test to include loading templates and installing them
- add GetComponents & GetTemplates funcs

