### PR TITLE
feat: Update the default template to be a complete embedded template

### DIFF
--- a/pkg/data/loadEmbedded.go
+++ b/pkg/data/loadEmbedded.go
@@ -11,6 +11,8 @@ import (
 	y "gopkg.in/yaml.v3"
 )
 
+const DefaultConfigurationKind = "TemplateProxy"
+
 // Reads a set of components from the local embedded filesystem (in the source, this is the
 // data/components directory) and loads them into a map of TemplateComponent by name.
 func LoadEmbeddedComponents() (map[string]config.TemplateComponent, error) {
@@ -75,6 +77,21 @@ func LoadEmbeddedTemplates() (map[string]hpsf.HPSF, error) {
 	}
 
 	return templates, nil
+}
+
+// LoadEmbeddedDefaultTemplate loads the default template from the embedded filesystem.
+func LoadEmbeddedDefaultTemplate() (hpsf.HPSF, error) {
+	templates, err := LoadEmbeddedTemplates()
+	if err != nil {
+		return hpsf.HPSF{}, err
+	}
+
+	template, ok := templates[DefaultConfigurationKind]
+	if !ok {
+		return hpsf.HPSF{}, fmt.Errorf("no default template found")
+	}
+
+	return template, nil
 }
 
 // CalculateChecksums reads the components and templates in the non-test

--- a/pkg/data/loadEmbedded.go
+++ b/pkg/data/loadEmbedded.go
@@ -11,7 +11,7 @@ import (
 	y "gopkg.in/yaml.v3"
 )
 
-const DefaultConfigurationKind = "TemplateProxy"
+const DefaultConfigurationKind = "TemplateDefault"
 
 // Reads a set of components from the local embedded filesystem (in the source, this is the
 // data/components directory) and loads them into a map of TemplateComponent by name.

--- a/pkg/data/loadEmbedded_test.go
+++ b/pkg/data/loadEmbedded_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
+	"github.com/honeycombio/hpsf/pkg/hpsf"
 	"github.com/stretchr/testify/require"
 	y "gopkg.in/yaml.v3"
 )
@@ -143,4 +144,15 @@ func TestLoadTemplates(t *testing.T) {
 			require.Empty(t, tmpl.Validate())
 		})
 	}
+}
+
+func TestDefaultConfigurationIsValidYAML(t *testing.T) {
+	templates, err := LoadEmbeddedTemplates()
+	require.NoError(t, err)
+	template, ok := templates[DefaultConfigurationKind]
+	require.True(t, ok)
+	data, err := template.AsYAML()
+	require.NoError(t, err)
+	err = hpsf.EnsureHPSFYAML(data)
+	require.NoError(t, err)
 }

--- a/pkg/data/templates/default.yaml
+++ b/pkg/data/templates/default.yaml
@@ -1,0 +1,49 @@
+name: Default Template
+kind: TemplateDefault
+version: v0.1.0
+summary: The default configuration that receives traces, metrics, and logs and forwards them to the OpenTelemetry GRPC exporter.
+description: |
+  This is the default configuration that forwards traces, metrics, and logs received via OpenTelemetry
+  components to the OpenTelemetry GRPC exporter. This is useful for testing and debugging, or
+  as a starting point for more complex configurations.
+components:
+  - name: OTel Receiver 1
+    kind: OTelReceiver
+  - name: OTel gRPC Exporter 1
+    kind: OTelGRPCExporter
+connections:
+  - source:
+      component: OTel Receiver 1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: OTel gRPC Exporter 1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: OTel Receiver 1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: OTel gRPC Exporter 1
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: OTel Receiver 1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: OTel gRPC Exporter 1
+      port: Logs
+      type: OTelLogs
+layout:
+  frame:
+    width: 1835
+    height: 1491
+  components:
+    - name: OTel Receiver 1
+      x: 260
+      y: 182
+    - name: OTel gRPC Exporter 1
+      x: 642
+      y: 182

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -13,32 +13,6 @@ import (
 	y "gopkg.in/yaml.v3"
 )
 
-// DefaultConfiguration is the default HPSF configuration that includes a
-// simple Refinery configuration with a deterministic sampler
-// and a Collector Nop receiver and exporter.
-const DefaultConfiguration = `
-components:
-  - name: DefaultDeterministicSampler
-    kind: DeterministicSampler
-    properties:
-      - name: SampleRate
-        value: 1
-        type: int
-  - name: DefaultNopReceiver
-    kind: NopReceiver
-  - name: DefaultNopExporter
-    kind: NopExporter
-connections:
-  - source:
-      component: DefaultNopReceiver
-      port: Traces
-      type: OTelTraces
-    destination:
-      component: DefaultNopExporter
-      port: Traces
-      type: OTelTraces
-`
-
 type ConnectionType string
 
 const (
@@ -611,4 +585,13 @@ func EnsureHPSFYAML(input string) error {
 		return err
 	}
 	return hpsf.Validate()
+}
+
+func (h *HPSF) AsYAML() (string, error) {
+	// this is a mechanism to marshal the template to YAML
+	data, err := y.Marshal(h)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling hpsf to YAML: %w", err)
+	}
+	return string(data), nil
 }

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/validator"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -123,11 +122,6 @@ connections:
 	assert.Equal(t, 2, len(unwrapped))
 	assert.Contains(t, unwrapped[0].Error(), "GRPCPort")
 	assert.Contains(t, unwrapped[1].Error(), "otlp_in2")
-}
-
-func TestDefaultConfigurationIsValidYAML(t *testing.T) {
-	err := EnsureHPSFYAML(DefaultConfiguration)
-	require.NoError(t, err)
 }
 
 func TestComponent_GetSafeName(t *testing.T) {

--- a/pkg/translator/testdata/default_collector_config.yaml
+++ b/pkg/translator/testdata/default_collector_config.yaml
@@ -1,16 +1,30 @@
 receivers:
-    nop/DefaultNopReceiver: {}
+    otlp/OTel_Receiver_1:
+        protocols:
+            grpc:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+            http:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
     batch: {}
     usage: {}
 exporters:
-    nop/DefaultNopExporter: {}
+    otlp/OTel_gRPC_Exporter_1:
+        endpoint: https://api.honeycomb.io:443
 extensions:
     honeycomb: {}
 service:
     extensions: [honeycomb]
     pipelines:
-        traces:
-            receivers: [nop/DefaultNopReceiver]
+        logs:
+            receivers: [otlp/OTel_Receiver_1]
             processors: [usage, batch]
-            exporters: [nop/DefaultNopExporter]
+            exporters: [otlp/OTel_gRPC_Exporter_1]
+        metrics:
+            receivers: [otlp/OTel_Receiver_1]
+            processors: [usage, batch]
+            exporters: [otlp/OTel_gRPC_Exporter_1]
+        traces:
+            receivers: [otlp/OTel_Receiver_1]
+            processors: [usage, batch]
+            exporters: [otlp/OTel_gRPC_Exporter_1]

--- a/pkg/translator/testdata/default_refinery_rules.yaml
+++ b/pkg/translator/testdata/default_refinery_rules.yaml
@@ -1,5 +1,1 @@
 RulesVersion: 2
-Samplers:
-    __default__:
-        DeterministicSampler:
-            SampleRate: 1

--- a/pkg/translator/testdata/default_refinery_rules.yaml
+++ b/pkg/translator/testdata/default_refinery_rules.yaml
@@ -1,1 +1,5 @@
 RulesVersion: 2
+Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 1

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -122,9 +122,7 @@ func TestDefaultHPSF(t *testing.T) {
 			require.NoError(t, err)
 			var expectedConfig = string(b)
 
-			var h *hpsf.HPSF
-			dec := yamlv3.NewDecoder(strings.NewReader(hpsf.DefaultConfiguration))
-			err = dec.Decode(&h)
+			h, err := data.LoadEmbeddedDefaultTemplate()
 			require.NoError(t, err)
 
 			tlater := NewEmptyTranslator()
@@ -132,7 +130,7 @@ func TestDefaultHPSF(t *testing.T) {
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(h, tC.ct, nil)
+			cfg, err := tlater.GenerateConfig(&h, tC.ct, nil)
 			require.NoError(t, err)
 
 			got, err := cfg.RenderYAML()


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the default HPSF config to use the embedded proxy template.

## Short description of the changes
- Add new default template (copy of proxy)
- Add LoadEmbeddedDefaultTemplate and DefaultConfigurationKind that can be used to retrieve the default template
- Move default config test from hspf to data package
- Add AsYAML func to hspf type (same as we use for TemplateComponent)
- Update translator tests for expected default config to match proxy template output
