### PR TITLE
fix: Translator generates valid refinery rules when no sampler component is provided

### DIFF
--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -241,6 +241,7 @@ type Component struct {
 	Kind       string     `yaml:"kind"`
 	Ports      []Port     `yaml:"ports,omitempty"`
 	Properties []Property `yaml:"properties,omitempty"`
+	Style      string     `yaml:"style,omitempty"`
 }
 
 type ErrorSeverity string

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -138,7 +138,7 @@ func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[s
 
 func maybeAddDefaultSampler(h *hpsf.HPSF) {
 	foundSampler := slices.ContainsFunc(h.Components, func(c hpsf.Component) bool {
-		return c.Kind == "sampler"
+		return c.Style == "sampler"
 	})
 	if !foundSampler {
 		h.Components = append(h.Components, hpsf.Component{

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -138,11 +138,7 @@ func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[s
 
 func maybeAddDefaultSampler(h *hpsf.HPSF) {
 	foundSampler := slices.ContainsFunc(h.Components, func(c hpsf.Component) bool {
-		switch c.Kind {
-		case "DeterministicSampler", "EMASampler":
-			return true
-		}
-		return false
+		return c.Kind == "sampler"
 	})
 	if !foundSampler {
 		h.Components = append(h.Components, hpsf.Component{

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"fmt"
+	"slices"
 
 	"maps"
 
@@ -86,6 +87,9 @@ func (t *Translator) MakeConfigComponent(component hpsf.Component) (config.Compo
 }
 
 func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
+	// we need to make sure that there is a sampler in the config to produce a valid refinery rules config
+	maybeAddDefaultSampler(h)
+
 	comps := make(map[string]config.Component)
 	// make all the components
 	for _, c := range h.Components {
@@ -130,4 +134,26 @@ func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[s
 		}
 	}
 	return composite, nil
+}
+
+func maybeAddDefaultSampler(h *hpsf.HPSF) {
+	foundSampler := slices.ContainsFunc(h.Components, func(c hpsf.Component) bool {
+		switch c.Kind {
+		case "DeterministicSampler", "EMASampler":
+			return true
+		}
+		return false
+	})
+	if !foundSampler {
+		h.Components = append(h.Components, hpsf.Component{
+			Name: "defaultSampler",
+			Kind: "DeterministicSampler",
+			Properties: []hpsf.Property{
+				{
+					Name:  "SampleRate",
+					Value: 1,
+				},
+			},
+		})
+	}
 }

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -142,3 +142,23 @@ func TestDefaultHPSF(t *testing.T) {
 		})
 	}
 }
+
+func TestHPSFWithoutSamplerComponentGeneratesValidRefineryRules(t *testing.T) {
+	b, err := os.ReadFile("testdata/default_refinery_rules.yaml")
+	require.NoError(t, err)
+	var expectedConfig = string(b)
+
+	hpsf := hpsf.HPSF{}
+	tlater := NewEmptyTranslator()
+	comps, err := data.LoadEmbeddedComponents()
+	require.NoError(t, err)
+	tlater.InstallComponents(comps)
+
+	cfg, err := tlater.GenerateConfig(&hpsf, config.RefineryRulesType, nil)
+	require.NoError(t, err)
+
+	got, err := cfg.RenderYAML()
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedConfig, string(got))
+}


### PR DESCRIPTION
## Which problem is this PR solving?

When generating configs, if no sampler component is provided the translator does not produce a valid refinery rules configuration (no default sampler).

This PR updates the sampler to check if a sampler was provided in the list of components, and if not, adds a default deterministic sampler with a sample rate of 1.

## Short description of the changes

- Add style property to hpsf.Component
- Add `maybeAddDefaultSampler` that checks if there the components contains a sampler and adds one if not
- Add unit test

