### PR TITLE
feat: Add logos to receivers and exporters, tweak some text

### DIFF
--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -4,7 +4,7 @@ style: sampler
 type: base
 status: alpha
 version: v0.1.0
-summary: A sampler that deterministically samples a fixed fraction of traces based on trace ID.
+summary: Deterministically samples a fixed fraction of traces based on trace ID.
 description: |
   A sampler that deterministically samples a fixed fraction of traces based on trace ID.
 tags:

--- a/pkg/data/components/FilterProcessor.yaml
+++ b/pkg/data/components/FilterProcessor.yaml
@@ -3,7 +3,7 @@ name: Filter Processor
 style: processor
 type: base
 status: development
-version: v0.1.0
+version: v0.0.0
 summary: A processor that can be used to filter telemetry.
 description: |
   Filters traces, metrics, and logs based on rules defined

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -1,7 +1,7 @@
 kind: HoneycombExporter
 name: Honeycomb Exporter
 style: exporter
-logo: opentelemetry
+logo: honeycomb
 type: base
 status: alpha
 version: v0.1.0

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -1,10 +1,11 @@
 kind: HoneycombExporter
 name: Honeycomb Exporter
 style: exporter
+logo: opentelemetry
 type: base
 status: alpha
 version: v0.1.0
-summary: An exporter that sends traces to Honeycomb in Honeycomb's event format.
+summary: Sends traces to Honeycomb in Honeycomb's event format.
 description: |
   This component exports traces to Honeycomb in Honeycomb's event format.
 tags:

--- a/pkg/data/components/NopExporter.yaml
+++ b/pkg/data/components/NopExporter.yaml
@@ -2,6 +2,7 @@ kind: NopExporter
 name: DefaultNopExporter
 version: v0.1.0
 style: exporter
+logo: opentelemetry
 type: base
 status: development
 summary: An "exporter" that does nothing, but might be useful for testing.
@@ -11,6 +12,7 @@ description: |
 tags:
   - category:exporter
   - category:nop
+  - category:debug
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -2,7 +2,7 @@ kind: NopReceiver
 name: DefaultNopReceiver
 version: v0.1.0
 style: receiver
-logo: datadog
+logo: opentelemetry
 type: base
 status: development
 summary: A no-op "receiver" that does nothing, but might be useful for testing.

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -2,15 +2,17 @@ kind: NopReceiver
 name: DefaultNopReceiver
 version: v0.1.0
 style: receiver
+logo: datadog
 type: base
 status: development
-summary: A "receiver" that does nothing, but might be useful for testing.
+summary: A no-op "receiver" that does nothing, but might be useful for testing.
 description: |
   A simple no-op receiver.
-  This receiver does nothing. It is required for the minimal collector.
+  This receiver does nothing. It is required for the minimal configuration.
 tags:
   - category:receiver
   - category:nop
+  - category:debug
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/OTelDebugExporter.yaml
+++ b/pkg/data/components/OTelDebugExporter.yaml
@@ -1,10 +1,11 @@
 kind: OTelDebugExporter
 name: OTel Debug Exporter
 style: exporter
+logo: opentelemetry
 type: base
 status: alpha
 version: v0.1.0
-summary: An exporter that sends pipeline signal traffic to stdout for debugging.
+summary: Sends pipeline signal traffic to stdout for debugging.
 description: |
   Exports signal data from a pipeline to stdout. This is useful for debugging, but only if you
   have access to the stdout stream in your environment. This component is not intended for production use.

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -2,9 +2,10 @@ kind: OTelGRPCExporter
 name: OTel gRPC Exporter
 type: base
 style: exporter
+logo: opentelemetry
 status: development
 version: v0.1.0
-summary: An exporter that sends telemetry in OTLP (OpenTelemetry) format via gRPC.
+summary: Sends telemetry in OTLP (OpenTelemetry) format via gRPC.
 description: |
   Exports OpenTelemetry signals using OTLP via gRPC.
 tags:

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -1,10 +1,11 @@
 kind: OTelHTTPExporter
 name: OTel HTTP Exporter
 style: exporter
+logo: opentelemetry
 type: base
 status: alpha
 version: v0.1.0
-summary: An exporter that sends telemetry in OTLP (OpenTelemetry) format via HTTP.
+summary: Sends telemetry in OTLP (OpenTelemetry) format via HTTP.
 description: |
   Exports OpenTelemetry signals using OTLP via HTTP.
 tags:

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -1,6 +1,7 @@
 kind: OTelReceiver
 name: OTel Receiver
 style: receiver
+logo: opentelemetry
 type: base
 status: development
 version: v0.1.0

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -1,13 +1,13 @@
 kind: TraceConverter
 name: Trace Converter
-style: receiver
+style: processor
 type: base
 status: alpha
 version: v0.1.0
-summary: Exports telemetry to Refinery via HTTP for further processing.
+summary: Sends telemetry to Refinery via HTTP for further processing.
 description: |
-  Exports OTel telemetry via HTTP.
-  This exporter forwards the data to Refinery over HTTP for processing.
+  Sends OTel telemetry via HTTP.
+  This component forwards the data to Refinery over HTTP for processing.
 tags:
   - category:converter
   - service:refinery


### PR DESCRIPTION
## Which problem is this PR solving?

- Receivers and Exporters need to name a logo to show up in the UI. This adds those logos.
- Also adjusts some descriptions to be clearer and less redundant
- The TraceConverter is not an "exporter" in the straws sense (it is for collector but in straws it's a type of processor)
