### PR TITLE
feat: Add basic transform processor

### DIFF
--- a/pkg/data/components/TransformProcessor.yaml
+++ b/pkg/data/components/TransformProcessor.yaml
@@ -16,14 +16,23 @@ tags:
   - signal:OTelMetrics
   - signal:OTelLogs
 ports:
-  - name: Traces
+  - name: TracesIn
     direction: input
     type: OTelTraces
-  - name: Metrics
+  - name: TracesOut
+    direction: output
+    type: OTelTraces
+  - name: MetricsIn
     direction: input
     type: OTelMetrics
-  - name: Logs
+  - name: MetricsOut
+    direction: output
+    type: OTelMetrics
+  - name: LogsIn
     direction: input
+    type: OTelLogs
+  - name: LogsOut
+    direction: output
     type: OTelLogs
 properties:
   - name: ErrorMode

--- a/pkg/data/components/TransformProcessor.yaml
+++ b/pkg/data/components/TransformProcessor.yaml
@@ -1,0 +1,67 @@
+kind: TransformProcessor
+name: Transform Processor
+style: processor
+type: base
+status: development
+version: v0.1.0
+summary: A processor that can be used to transform telemetry.
+description: |
+  Transforms traces based on rules defined
+  in the configuration.
+tags:
+  - category:processor
+  - service:collector
+  - category:transform
+  - signal:OTelTraces
+ports:
+  - name: Traces
+    direction: input
+    type: OTelTraces
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Logs
+    direction: input
+    type: OTelLogs
+properties:
+  - name: ErrorMode
+    type: string
+    default: ignore
+  - name: TracesStatements
+    type: stringarray
+    validations:
+      - nonblank
+      - nonempty
+    default: []
+  - name: MetricsStatements
+    type: stringarray
+    validations:
+      - nonblank
+      - nonempty
+    default: []
+  - name: LogsStatements
+    type: stringarray
+    validations:
+      - nonblank
+      - nonempty
+    default: []
+templates:
+  - kind: collector_config
+    name: otel_filter
+    format: collector
+    meta:
+      componentSection: processors
+      signalTypes: [traces]
+      collectorComponentName: transform
+    data:
+      - key: "{{ .ComponentName }}.error_mode"
+        value: "{{ firstNonZero .HProps.ErrorMode .User.ErrorMode .Props.ErrorMode.Default }}"
+      - key: "{{ .ComponentName }}.traces_statements"
+        value: "{{ firstNonZero .HProps.TracesStatements .User.TracesStatements .Props.TracesStatements.Default | encodeAsArray }}"
+        suppress_if: "{{ not .HProps.TracesStatements }}"
+      - key: "{{ .ComponentName }}.metrics_statements"
+        value: "{{ firstNonZero .HProps.MetricsStatements .User.MetricsStatements .Props.MetricsStatements.Default | encodeAsArray }}"
+        suppress_if: "{{ not .HProps.MetricsStatements }}"
+      - key: "{{ .ComponentName }}.logs_statements"
+        value: "{{ firstNonZero .HProps.LogsStatements .User.LogsStatements .Props.LogsStatements.Default | encodeAsArray }}"
+        suppress_if: "{{ not .HProps.LogsStatements }}"

--- a/pkg/data/components/TransformProcessor.yaml
+++ b/pkg/data/components/TransformProcessor.yaml
@@ -6,13 +6,15 @@ status: development
 version: v0.1.0
 summary: A processor that can be used to transform telemetry.
 description: |
-  Transforms traces based on rules defined
+  Transforms traces, metrics and logs based on rules defined
   in the configuration.
 tags:
   - category:processor
   - service:collector
   - category:transform
   - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
 ports:
   - name: Traces
     direction: input
@@ -51,7 +53,7 @@ templates:
     format: collector
     meta:
       componentSection: processors
-      signalTypes: [traces]
+      signalTypes: [traces, metrics, logs]
       collectorComponentName: transform
     data:
       - key: "{{ .ComponentName }}.error_mode"

--- a/pkg/translator/testdata/otlp_with_transform_collector_config.yaml
+++ b/pkg/translator/testdata/otlp_with_transform_collector_config.yaml
@@ -27,6 +27,14 @@ extensions:
 service:
     extensions: [honeycomb]
     pipelines:
+        logs:
+            receivers: [otlp/otlp_in]
+            processors: [usage, transform/my_transformer, batch]
+            exporters: [debug/debug_out]
+        metrics:
+            receivers: [otlp/otlp_in]
+            processors: [usage, transform/my_transformer, batch]
+            exporters: [debug/debug_out]
         traces:
             receivers: [otlp/otlp_in]
             processors: [usage, transform/my_transformer, batch]

--- a/pkg/translator/testdata/otlp_with_transform_collector_config.yaml
+++ b/pkg/translator/testdata/otlp_with_transform_collector_config.yaml
@@ -1,0 +1,33 @@
+receivers:
+    otlp/otlp_in:
+        protocols:
+            grpc:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:9922
+            http:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:1234
+processors:
+    batch: {}
+    transform/my_transformer:
+        error_mode: ignore
+        logs_statements:
+            - some_logs_transform_statement
+            - another_logs_transform_statement
+        metrics_statements:
+            - some_metrics_transform_statement
+            - another_metrics_transform_statement
+        traces_statements:
+            - some_traces_transform_statement
+            - another_traces_transform_statement
+    usage: {}
+exporters:
+    debug/debug_out:
+        verbosity: basic
+extensions:
+    honeycomb: {}
+service:
+    extensions: [honeycomb]
+    pipelines:
+        traces:
+            receivers: [otlp/otlp_in]
+            processors: [usage, transform/my_transformer, batch]
+            exporters: [debug/debug_out]

--- a/pkg/translator/testdata/otlp_with_transform_hpsf.yaml
+++ b/pkg/translator/testdata/otlp_with_transform_hpsf.yaml
@@ -42,3 +42,35 @@ connections:
       component: debug_out
       port: Traces
       type: OTelTraces
+  - source:
+      component: otlp_in
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: my_transformer
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: my_transformer
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: debug_out
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: otlp_in
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: my_transformer
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: my_transformer
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: debug_out
+      port: Logs
+      type: OTelLogs

--- a/pkg/translator/testdata/otlp_with_transform_hpsf.yaml
+++ b/pkg/translator/testdata/otlp_with_transform_hpsf.yaml
@@ -1,0 +1,44 @@
+components:
+  - name: otlp_in
+    kind: OTelReceiver
+    properties:
+      - name: GRPCPort
+        value: 9922
+      - name: HTTPPort
+        value: 1234
+  - name: my_transformer
+    kind: TransformProcessor
+    properties:
+      - name: ErrorMode
+        value: ignore
+      - name: LogsStatements
+        value:
+          - some_logs_transform_statement
+          - another_logs_transform_statement
+      - name: MetricsStatements
+        value:
+          - some_metrics_transform_statement
+          - another_metrics_transform_statement
+      - name: TracesStatements
+        value:
+          - some_traces_transform_statement
+          - another_traces_transform_statement
+  - name: debug_out
+    kind: OTelDebugExporter
+connections:
+  - source:
+      component: otlp_in
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: my_transformer
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: my_transformer
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: debug_out
+      port: Traces
+      type: OTelTraces

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -59,6 +59,11 @@ func TestGenerateConfig(t *testing.T) {
 			inputHPSFTestData:      "testdata/otlp_with_logdeduplication_hpsf.yaml",
 			expectedConfigTestData: "testdata/otlp_with_logdeduplication_collector_config.yaml",
 		},
+		{
+			desc:                   "Collector with transform processor",
+			inputHPSFTestData:      "testdata/otlp_with_transform_hpsf.yaml",
+			expectedConfigTestData: "testdata/otlp_with_transform_collector_config.yaml",
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) that can handle basic configurations for traces, metrics and logs.

## Short description of the changes
- Add transform processor hpsf definition
- Add unit tests to verify behaviour

