### PR TITLE
maint: only check for test files for valid component config types

### DIFF
--- a/pkg/translator/testdata/collector_config/deterministicsampler_all.yaml
+++ b/pkg/translator/testdata/collector_config/deterministicsampler_all.yaml
@@ -1,8 +1,0 @@
-processors:
-    batch: {}
-    usage: {}
-extensions:
-    honeycomb: {}
-service:
-    extensions: [honeycomb]
-    pipelines: {}

--- a/pkg/translator/testdata/collector_config/deterministicsampler_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/deterministicsampler_defaults.yaml
@@ -1,8 +1,0 @@
-processors:
-    batch: {}
-    usage: {}
-extensions:
-    honeycomb: {}
-service:
-    extensions: [honeycomb]
-    pipelines: {}

--- a/pkg/translator/testdata/collector_config/emathroughput_all.yaml
+++ b/pkg/translator/testdata/collector_config/emathroughput_all.yaml
@@ -1,8 +1,0 @@
-processors:
-    batch: {}
-    usage: {}
-extensions:
-    honeycomb: {}
-service:
-    extensions: [honeycomb]
-    pipelines: {}

--- a/pkg/translator/testdata/collector_config/emathroughput_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/emathroughput_defaults.yaml
@@ -1,8 +1,0 @@
-processors:
-    batch: {}
-    usage: {}
-extensions:
-    honeycomb: {}
-service:
-    extensions: [honeycomb]
-    pipelines: {}

--- a/pkg/translator/testdata/refinery_config/filterprocessor_all.yaml
+++ b/pkg/translator/testdata/refinery_config/filterprocessor_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/filterprocessor_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/filterprocessor_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/logdeduplicationprocessor_all.yaml
+++ b/pkg/translator/testdata/refinery_config/logdeduplicationprocessor_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/logdeduplicationprocessor_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/logdeduplicationprocessor_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/nopexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/nopexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/nopexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/nopexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/nopreceiver_all.yaml
+++ b/pkg/translator/testdata/refinery_config/nopreceiver_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/nopreceiver_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/nopreceiver_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/oteldebugexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/oteldebugexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/oteldebugexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/oteldebugexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/otelgrpcexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/otelgrpcexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/otelgrpcexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/otelgrpcexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/otelhttpexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/otelhttpexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/otelhttpexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/otelhttpexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/otelreceiver_all.yaml
+++ b/pkg/translator/testdata/refinery_config/otelreceiver_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/otelreceiver_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/otelreceiver_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/traceconverter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/traceconverter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_config/traceconverter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/traceconverter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/filterprocessor_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/filterprocessor_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/filterprocessor_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/filterprocessor_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/honeycombexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/honeycombexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/logdeduplicationprocessor_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/logdeduplicationprocessor_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/logdeduplicationprocessor_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/logdeduplicationprocessor_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/nopexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/nopexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/nopexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/nopexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/nopreceiver_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/nopreceiver_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/nopreceiver_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/nopreceiver_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/oteldebugexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/oteldebugexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/oteldebugexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/oteldebugexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/otelgrpcexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/otelgrpcexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/otelgrpcexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/otelgrpcexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/otelhttpexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/otelhttpexporter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/otelhttpexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/otelhttpexporter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/otelreceiver_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/otelreceiver_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/otelreceiver_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/otelreceiver_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/traceconverter_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/traceconverter_all.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/testdata/refinery_rules/traceconverter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/traceconverter_defaults.yaml
@@ -1,1 +1,0 @@
-default.yaml

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -37,7 +37,8 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 				require.NoError(t, err)
 				var inputData = string(b)
 
-				for _, configType := range []config.Type{config.CollectorConfigType, config.RefineryConfigType, config.RefineryRulesType} {
+				for _, template := range comps[componentName].Templates {
+					configType := config.Type(template.Kind)
 					b, err = os.ReadFile(path.Join("testdata", string(configType), testData))
 					require.NoError(t, err)
 					var expectedConfig = string(b)
@@ -57,8 +58,6 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 				}
 			})
 		}
-		// get a file for the component
-
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

As part of the work in #63, additional default config files were required for components for config types that component didn't need. This PR updates the tests to only require test files for defined config types for each component and remove unnecessary test data files.

## Short description of the changes
- Use component template kind to get valid config types used to load test output files
- Remove unnecessary test files
