### PR TITLE
feat: Add S3 exporter component

### DIFF
--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -1,0 +1,90 @@
+kind: S3Exporter
+name: S3 Exporter
+type: base
+style: exporter
+logo: opentelemetry
+status: development
+version: v0.1.0
+summary: Stores telemetry in OTLP (OpenTelemetry) format in S3 storage.
+description: |
+  Exports OpenTelemetry signals using OTLP to S3 storage.
+tags:
+  - category:exporter
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
+ports:
+  - name: Traces
+    direction: input
+    type: OTelTraces
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Logs
+    direction: input
+    type: OTelLogs
+properties:
+  - name: Bucket
+    summary: The bucket in which to store the S3.
+    description: |
+      The bucket in which to store the S3. This is a required field.
+    type: string
+    validations: [noblanks]
+  - name: Region
+    summary: The region in which to store the S3.
+    description: |
+      The region in which to store the S3. The default value is `us-east-1`.
+    type: string
+  - name: Prefix
+    summary: The prefix to use for the S3.
+    description: |
+      The prefix to use for the S3.
+    type: string
+  # advanced properties
+  - name: PartitionFormat
+    summary: The partition format to use for the S3.
+    description: |
+      The partition format to use for the S3. The default value is `year=%Y/month=%m/day=%d/hour=%H/minute=%M`.
+    type: string
+    advanced: true
+  - name: Timeout
+    summary: The timeout to use for the S3.
+    description: |
+      The timeout to use for the S3. The default value is `5s`.
+    type: duration
+    validations: [duration]
+    advanced: true
+  - name: Marshaler
+    summary: The marshaler to use for the S3.
+    description: |
+      The marshaler to use for the S3. The default value is `otlp_json`.
+    type: string
+    validations: [oneof(otlp_json, otlp_proto)]
+    advanced: true
+templates:
+  - name: s3_exporter_collector
+    kind: collector_config
+    format: collector
+    meta:
+      componentSection: exporters
+      signalTypes: [traces, metrics, logs]
+      collectorComponentName: awss3
+    data:
+      - key: "{{ .ComponentName }}.s3uploader.s3_bucket"
+        value: "{{ firstNonZero .HProps.Bucket .User.Bucket .Props.Bucket.Default }}"
+      - key: "{{ .ComponentName }}.s3uploader.region"
+        value: "{{ firstNonZero .HProps.Region .User.Region .Props.Region.Default }}"
+        suppress_if: "{{ not .HProps.Region }}"
+      - key: "{{ .ComponentName }}.s3uploader.s3_prefix"
+        value: "{{ firstNonZero .HProps.Prefix .User.Prefix .Props.Prefix.Default }}"
+        suppress_if: "{{ not .HProps.Prefix }}"
+      - key: "{{ .ComponentName }}.s3uploader.s3_partition_format"
+        value: "{{ firstNonZero .HProps.PartitionFormat .User.PartitionFormat .Props.PartitionFormat.Default }}"
+        suppress_if: "{{ not .HProps.PartitionFormat }}"
+      - key: "{{ .ComponentName }}.timeout"
+        value: "{{ firstNonZero .HProps.Timeout .User.Timeout .Props.Timeout.Default }}"
+        suppress_if: "{{ not .HProps.Timeout }}"
+      - key: "{{ .ComponentName }}.marshaler"
+        value: "{{ firstNonZero .HProps.Marshaler .User.Marshaler .Props.Marshaler.Default }}"
+        suppress_if: "{{ not .HProps.Marshaler }}"

--- a/pkg/translator/testdata/collector_config/s3exporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_all.yaml
@@ -1,0 +1,28 @@
+receivers:
+    otlp/otlp_in:
+        protocols:
+            grpc:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+            http:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+processors:
+    batch: {}
+    usage: {}
+exporters:
+    awss3/s3_out:
+        marshaler: otlp_json
+        s3uploader:
+            region: my-region
+            s3_bucket: my-bucket
+            s3_partition_format: my-partition-format
+            s3_prefix: my-prefix
+        timeout: 30s
+extensions:
+    honeycomb: {}
+service:
+    extensions: [honeycomb]
+    pipelines:
+        traces:
+            receivers: [otlp/otlp_in]
+            processors: [usage, batch]
+            exporters: [awss3/s3_out]

--- a/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
@@ -1,0 +1,23 @@
+receivers:
+    otlp/otlp_in:
+        protocols:
+            grpc:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+            http:
+                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+processors:
+    batch: {}
+    usage: {}
+exporters:
+    awss3/s3_out:
+        s3uploader:
+            s3_bucket: my-bucket
+extensions:
+    honeycomb: {}
+service:
+    extensions: [honeycomb]
+    pipelines:
+        traces:
+            receivers: [otlp/otlp_in]
+            processors: [usage, batch]
+            exporters: [awss3/s3_out]

--- a/pkg/translator/testdata/hpsf/s3exporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/s3exporter_all.yaml
@@ -1,0 +1,27 @@
+components:
+  - name: otlp_in
+    kind: OTelReceiver
+  - name: s3_out
+    kind: S3Exporter
+    properties:
+      - name: Region
+        value: 'my-region'
+      - name: Bucket
+        value: 'my-bucket'
+      - name: Prefix
+        value: 'my-prefix'
+      - name: PartitionFormat
+        value: 'my-partition-format'
+      - name: Timeout
+        value: 30s
+      - name: Marshaler
+        value: otlp_json
+connections:
+  - source:
+      component: otlp_in
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: s3_out
+      port: Traces
+      type: OTelTraces

--- a/pkg/translator/testdata/hpsf/s3exporter_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/s3exporter_defaults.yaml
@@ -1,0 +1,17 @@
+components:
+  - name: otlp_in
+    kind: OTelReceiver
+  - name: s3_out
+    kind: S3Exporter
+    properties:
+      - name: Bucket
+        value: my-bucket
+connections:
+  - source:
+      component: otlp_in
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: s3_out
+      port: Traces
+      type: OTelTraces


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the a new HPSF component for the OTel Collector [S3 Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter).

The only required property is `Bucket`, all others have default values assumed from the collector component.

- https://app.asana.com/0/1208469935858869/1208531739378699/f

## Short description of the changes
- Add new component definition
- Add default and all test data files to verify expected output

