### PR TITLE
maint: Apply component property validations

### DIFF
--- a/pkg/config/templateProperty.go
+++ b/pkg/config/templateProperty.go
@@ -24,7 +24,7 @@ type TemplateProperty struct {
 	Description string        `yaml:"description,omitempty"`
 	Type        hpsf.PropType `yaml:"type"`
 	Advanced    bool          `yaml:"advanced,omitempty"`
-	Validations []string      `yaml:"validation,omitempty"`
+	Validations []string      `yaml:"validations,omitempty"`
 	Default     any           `yaml:"default,omitempty"`
 }
 
@@ -97,7 +97,7 @@ func (tp *TemplateProperty) Validate(prop hpsf.Property) error {
 	var value any
 	// this tries to coerce the value of the property to the type specified in the TemplateProperty
 	// and stores it in the `value` variable
-	if err := prop.Type.ValueCoerce(tp.Type, &value); err != nil {
+	if err := prop.Type.ValueCoerce(prop.Value, &value); err != nil {
 		// if the type of the property does not match the type of the template property, return an error
 		return hpsf.NewError("value cannot be converted to expected type " + tp.Type.String()).
 			WithComponent(prop.Name). // include the component name for context

--- a/pkg/data/components/FilterProcessor.yaml
+++ b/pkg/data/components/FilterProcessor.yaml
@@ -28,10 +28,10 @@ ports:
 properties:
   - name: Rules
     type: rule
-    validations: [filterrule]
   - name: Signal
     type: string
-    validations: ["oneof(traces, metrics, logs)"] # TODO: validate a valid signal
+    validations:
+      - oneof(traces, metrics, logs)
 templates:
   - kind: collector_config
     name: otel_filter

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -23,7 +23,8 @@ properties:
     description: |
       The API key to use to authenticate with Honeycomb.
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
     default: ${HONEYCOMB_EXPORTER_APIKEY}
   - name: APIEndpoint
     summary: The Endpoint URL of the Honeycomb API
@@ -31,7 +32,9 @@ properties:
       The Endpoint URL of the Honeycomb API.
       This is normally https://api.honeycomb.io, but can be overridden.
     type: string
-    validations: [noblanks, url]
+    validations:
+      - noblanks
+      - url
     default: https://api.honeycomb.io
     advanced: true
 templates:

--- a/pkg/data/components/LogDeduplicationProcessor.yaml
+++ b/pkg/data/components/LogDeduplicationProcessor.yaml
@@ -22,7 +22,8 @@ ports:
 properties:
   - name: Interval
     type: duration
-    validations: [duration]
+    validations:
+      - duration
     default: 60s
     advanced: true
   - name: CountAttribute

--- a/pkg/data/components/OTelDebugExporter.yaml
+++ b/pkg/data/components/OTelDebugExporter.yaml
@@ -32,7 +32,8 @@ properties:
     description: |
       The verbosity level of the debug output. Valid values are basic, normal, or detailed. The default is "basic".
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
     default: basic
 templates:
   - kind: collector_config

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -37,7 +37,8 @@ properties:
     description: |
       Hostname or IP address on which to send outgoing GRPC traffic.
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
     default: https://api.honeycomb.io
     advanced: true
   - name: Port
@@ -46,7 +47,8 @@ properties:
       The port on which to send outgoing gRPC traffic. Default is 443, which is
       the value expected by Honeycomb. The OTel standard for gRPC is 4317.
     type: int
-    validations: [inrange(1, 65535)]
+    validations:
+      - inrange(1, 65535)
     default: 443
     advanced: true
   - name: Insecure

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -32,13 +32,13 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
-    validations: []
   - name: Host
     summary: The hostname or IP address to send data to.
     description: |
       Hostname or IP address on which to send outgoing HTTP traffic.
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
     default: https://api.honeycomb.io
     advanced: true
   - name: Port
@@ -47,7 +47,8 @@ properties:
       The port on which to send outgoing HTTP traffic. Default is 443, which is
       the value expected by Honeycomb. The OTel standard for HTTP is 4318.
     type: int
-    validations: [inrange(1, 65535)]
+    validations:
+      - inrange(1, 65535)
     default: 443
     advanced: true
   - name: Insecure
@@ -55,7 +56,6 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
-    validations: []
     default: false
     advanced: true
 templates:

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -33,7 +33,8 @@ properties:
       It is recommended not to change the default unless
       you know what you're doing.
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
     default: ${STRAWS_COLLECTOR_POD_IP}
     advanced: true
   - name: GRPCPort
@@ -42,7 +43,8 @@ properties:
       The port on which to listen for incoming gRPC traffic.
       The OTel default is 4317. Set to 0 to disable gRPC.
     type: int
-    validations: [inrange(1, 65535)]
+    validations:
+      - inrange(1, 65535)
     default: 4317
     advanced: true
   - name: HTTPPort
@@ -51,7 +53,8 @@ properties:
       The port on which to listen for incoming HTTP traffic.
       The OTel default is 4318. Set to 0 to disable HTTP.
     type: int
-    validations: [inrange(1, 65535)]
+    validations:
+      - inrange(1, 65535)
     default: 4318
     advanced: true
 templates:

--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -30,7 +30,8 @@ properties:
     description: |
       The bucket in which to store the S3. This is a required field.
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
   - name: Region
     summary: The region in which to store the S3.
     description: |
@@ -53,14 +54,18 @@ properties:
     description: |
       The timeout to use for the S3. The default value is `5s`.
     type: duration
-    validations: [duration]
+    default: 5s
+    validations:
+      - duration
     advanced: true
   - name: Marshaler
     summary: The marshaler to use for the S3.
     description: |
       The marshaler to use for the S3. The default value is `otlp_json`.
     type: string
-    validations: [oneof(otlp_json, otlp_proto)]
+    default: otlp_json
+    validations:
+      - oneof(otlp_json, otlp_proto)
     advanced: true
 templates:
   - name: s3_exporter_collector

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -33,7 +33,8 @@ properties:
       It is recommended not to change the default unless
       you know what you're doing.
     type: string
-    validations: [noblanks]
+    validations:
+      - noblanks
     default: ${STRAWS_REFINERY_POD_IP}
     advanced: true
   - name: Port
@@ -42,7 +43,8 @@ properties:
       The port on which Refinery listens for incoming HTTP traffic.
       The OTel default is 4318. Set to 0 to disable HTTP.
     type: int
-    validations: [inrange(1, 65535)]
+    validations:
+      - inrange(1, 65535)
     default: 4318
     advanced: true
   - name: Headers
@@ -52,13 +54,11 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
-    validations: []
   - name: Insecure
     summary: Provide a way to disable TLS export.
     description: |
       Can be used to send data without TLS.
     type: bool
-    validations: []
     default: false
     advanced: true
 templates:

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -114,14 +114,12 @@ connections:
 	err = yaml.Unmarshal(inputData, &hpsf)
 	assert.NoError(t, err)
 
-	errors := hpsf.Validate()
-	errs, ok := errors.(validator.Result)
+	err = hpsf.Validate()
+	result, ok := err.(validator.Result)
 	assert.True(t, ok)
-	assert.Equal(t, 2, errs.Len())
-	unwrapped := errs.Unwrap()
-	assert.Equal(t, 2, len(unwrapped))
-	assert.Contains(t, unwrapped[0].Error(), "GRPCPort")
-	assert.Contains(t, unwrapped[1].Error(), "otlp_in2")
+	assert.Equal(t, 2, result.Len())
+	assert.Contains(t, result.Details[0].Error(), "GRPCPort")
+	assert.Contains(t, result.Details[1].Error(), "otlp_in2")
 }
 
 func TestComponent_GetSafeName(t *testing.T) {

--- a/pkg/translator/testdata/collector_config/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/honeycombexporter_all.yaml
@@ -1,8 +1,0 @@
-processors:
-    batch: {}
-    usage: {}
-extensions:
-    honeycomb: {}
-service:
-    extensions: [honeycomb]
-    pipelines: {}

--- a/pkg/translator/testdata/collector_config/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/honeycombexporter_defaults.yaml
@@ -1,8 +1,0 @@
-processors:
-    batch: {}
-    usage: {}
-extensions:
-    honeycomb: {}
-service:
-    extensions: [honeycomb]
-    pipelines: {}

--- a/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
@@ -5,7 +5,7 @@ components:
     kind: HoneycombExporter
     properties:
       - name: APIEndpoint
-        value: endpoint:1234
+        value: https://alternative.honeycomb.io
       - name: APIKey
         value: key1234
 connections:

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
@@ -4,4 +4,4 @@ General:
     ConfigurationVersion: 2
     MinRefineryVersion: v2.0
 Network:
-    HoneycombAPI: endpoint:1234
+    HoneycombAPI: https://alternative.honeycomb.io

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -10,7 +11,6 @@ import (
 	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/data"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
-	"github.com/honeycombio/hpsf/pkg/validator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -163,19 +163,7 @@ func TestTranslatorValidation(t *testing.T) {
 			require.NoError(t, err)
 
 			err = tlater.ValidateConfig(hpsf)
-			if err != nil {
-				// If validation fails, check if it's a validator.Result
-				// and ensure it contains errors
-				if result, ok := err.(validator.Result); ok {
-					// If it's a Result, we can check the details
-					// This means the validation failed and we expect it to fail
-					// We can log the error for debugging
-					for _, err := range result.Unwrap() {
-						t.Logf("Validation failed for %s: %v", filePath, err)
-					}
-				}
-			}
-			require.NoError(t, err)
+			require.NoError(t, errors.Unwrap(err))
 		})
 	}
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,6 +1,8 @@
 package validator
 
 import (
+	"errors"
+
 	y "gopkg.in/yaml.v3"
 )
 
@@ -15,19 +17,19 @@ func (e Result) Error() string {
 	return e.Msg
 }
 
-func (e Result) Unwrap() []error {
+func (e Result) Unwrap() error {
 	output := []error{}
 	for _, d := range e.Details {
 		// if any of the details are themselves a Result, unpack them recursively and add to the output.
 		if other, ok := d.(Result); ok {
 			// recursively unpack the details of the other Result
-			output = append(output, other.Unwrap()...)
+			output = append(output, other.Unwrap())
 		} else {
 			// otherwise just append the error to the output
 			output = append(output, d)
 		}
 	}
-	return output
+	return errors.Join(output...)
 }
 
 func NewResult(msg string) Result {


### PR DESCRIPTION
## Which problem is this PR solving?

Component validations are not currently being applied. This update applies property validation and updates the components where necessary to conform to their validations.

## Short description of the changes
- Update TemplateComponent's yaml name to so they are loaded into the component
- Use the property value, not type, when trying to coerce the value before applying a validation
- Update each components validations definition to use a yaml list instead of inline array which can cause issues when parsing strings
- Update HoneycombExporter testdata to set a valid URL
- Update Validation.Result's Unwrap to return a single error instead of an []error
  - The docs say []error should be okay, but it fails the [interface check](https://github.com/golang/go/blob/master/src/errors/wrap.go#L17) and always returned nil
- Remove filter processor's Rules `filterrule` as it doesn't exist yet
  - Opened #67 to track adding a custom validation
- Remove unused traceconverter collector config testdata files