### PR TITLE
rel: Prepare release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # hpsf library changelog
 
+## 0.3.0 2025-04-03
+
+### Features
+
+- feat: Add S3 exporter component (#65)
+- feat: Validate properties with the property rules (#60)
+- feat: Add logos to receivers and exporters, tweak some text (#56)
+
+### Fixes
+
+- fix: add output config to processor (#59)
+
+### Maintenance
+
+- maint: Apply component property validations (#66)
+- maint: only check for test files for valid component config types (#64)
+- chore: add tests to validate all components (#63)
+- chore: update test path (#62)
+
 ## 0.2.0 2025-03-28
 
 ### Features

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,8 @@
 # Release Process
 
 1. Add release entry to [changelog](./CHANGELOG.md) explaining the general focus points of the changes in this release. A detailed list of PRs is probably not needed, as it will be included in the generated release notes anyway.
-2. Open a PR with above changes.
-3. Once the above PR is merged, pull the updated `main` branch down and tag the merged release commit on `main` with the new version, e.g. `git tag -a v2.3.1 -m "v2.3.1 release"`.
-4. Push the tag, e.g. `git push origin v2.3.1`. This will kick off a CI workflow, which will publish a draft GitHub release.
-5. Update Release Notes on the new draft GitHub release by generating notes with the button and review for any PR titles that could use some wordsmithing or recategorization.
+2. Updated `version.go` with the new version number.
+3. Open a PR with above changes.
+4. Once the above PR is merged, pull the updated `main` branch down and tag the merged release commit on `main` with the new version, e.g. `git tag -a v2.3.1 -m "v2.3.1 release"`.
+5. Push the tag, e.g. `git push origin v2.3.1`. This will kick off a CI workflow, which will publish a draft GitHub release.
+6. Update Release Notes on the new draft GitHub release by generating notes with the button and review for any PR titles that could use some wordsmithing or recategorization.

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package hpsf
 
 var (
-	Version = "0.2.0"
+	Version = "0.3.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

Prepares the next release of the HPSF package.

## Short description of the changes
- Add changelog entry
- Update version to 0.3.0 in `version.go`
- Update RELEASING docs to include update version.go

