### PR TITLE
feat: use http exporter in default

### DIFF
--- a/pkg/data/templates/default.yaml
+++ b/pkg/data/templates/default.yaml
@@ -1,23 +1,23 @@
 name: Default Template
 kind: TemplateDefault
 version: v0.1.0
-summary: The default configuration that receives traces, metrics, and logs and forwards them to the OpenTelemetry GRPC exporter.
+summary: The default configuration that receives traces, metrics, and logs and forwards them to the OpenTelemetry HTTP exporter.
 description: |
   This is the default configuration that forwards traces, metrics, and logs received via OpenTelemetry
-  components to the OpenTelemetry GRPC exporter. This is useful for testing and debugging, or
+  components to the OpenTelemetry HTTP exporter. This is useful for testing and debugging, or
   as a starting point for more complex configurations.
 components:
   - name: OTel Receiver 1
     kind: OTelReceiver
-  - name: OTel gRPC Exporter 1
-    kind: OTelGRPCExporter
+  - name: OTel HTTP Exporter 1
+    kind: OTelHTTPExporter
 connections:
   - source:
       component: OTel Receiver 1
       port: Traces
       type: OTelTraces
     destination:
-      component: OTel gRPC Exporter 1
+      component: OTel HTTP Exporter 1
       port: Traces
       type: OTelTraces
   - source:
@@ -25,7 +25,7 @@ connections:
       port: Metrics
       type: OTelMetrics
     destination:
-      component: OTel gRPC Exporter 1
+      component: OTel HTTP Exporter 1
       port: Metrics
       type: OTelMetrics
   - source:
@@ -33,7 +33,7 @@ connections:
       port: Logs
       type: OTelLogs
     destination:
-      component: OTel gRPC Exporter 1
+      component: OTel HTTP Exporter 1
       port: Logs
       type: OTelLogs
 layout:
@@ -44,6 +44,6 @@ layout:
     - name: OTel Receiver 1
       x: 260
       y: 182
-    - name: OTel gRPC Exporter 1
+    - name: OTel HTTP Exporter 1
       x: 642
       y: 182

--- a/pkg/translator/testdata/collector_config/default.yaml
+++ b/pkg/translator/testdata/collector_config/default.yaml
@@ -9,7 +9,7 @@ processors:
     batch: {}
     usage: {}
 exporters:
-    otlp/OTel_gRPC_Exporter_1:
+    otlphttp/OTel_HTTP_Exporter_1:
         endpoint: https://api.honeycomb.io:443
 extensions:
     honeycomb: {}
@@ -19,12 +19,12 @@ service:
         logs:
             receivers: [otlp/OTel_Receiver_1]
             processors: [usage, batch]
-            exporters: [otlp/OTel_gRPC_Exporter_1]
+            exporters: [otlphttp/OTel_HTTP_Exporter_1]
         metrics:
             receivers: [otlp/OTel_Receiver_1]
             processors: [usage, batch]
-            exporters: [otlp/OTel_gRPC_Exporter_1]
+            exporters: [otlphttp/OTel_HTTP_Exporter_1]
         traces:
             receivers: [otlp/OTel_Receiver_1]
             processors: [usage, batch]
-            exporters: [otlp/OTel_gRPC_Exporter_1]
+            exporters: [otlphttp/OTel_HTTP_Exporter_1]


### PR DESCRIPTION
## Which problem is this PR solving?

- sometimes http is easier to work with

## Short description of the changes

- use OTelHTTPExporter in default instead of gRPC

