### PR TITLE
maint: Update template layouts to be valid

### DIFF
--- a/pkg/data/templates/default.yaml
+++ b/pkg/data/templates/default.yaml
@@ -37,13 +37,12 @@ connections:
       port: Logs
       type: OTelLogs
 layout:
-  frame:
-    width: 1835
-    height: 1491
   components:
     - name: OTel Receiver 1
-      x: 260
-      y: 182
+      position:
+        x: -100
+        y: 0
     - name: OTel HTTP Exporter 1
-      x: 642
-      y: 182
+      position:
+        x: 100
+        y: 0

--- a/pkg/data/templates/emathroughput.yaml
+++ b/pkg/data/templates/emathroughput.yaml
@@ -43,19 +43,20 @@ connections:
       port: Traces
       type: Honeycomb
 layout:
-  frame:
-    width: 1835
-    height: 1491
   components:
     - name: OTel Receiver 1
-      x: 253
-      y: 223
+      position:
+        x: -340
+        y: 0
     - name: Trace Converter 1
-      x: 439
-      y: 227
+      position:    
+        x: -100
+        y: 0
     - name: Honeycomb Exporter 1
-      x: 938
-      y: 210
+      position:
+        x: 100
+        y: 0
     - name: EMA Throughput 1
-      x: 676
-      y: 228
+      position:
+        x: 340
+        y: 0

--- a/pkg/data/templates/proxy.yaml
+++ b/pkg/data/templates/proxy.yaml
@@ -37,13 +37,12 @@ connections:
       port: Logs
       type: OTelLogs
 layout:
-  frame:
-    width: 1835
-    height: 1491
   components:
     - name: OTel Receiver 1
-      x: 260
-      y: 182
+      position:
+        x: -100
+        y: 0
     - name: OTel gRPC Exporter 1
-      x: 642
-      y: 182
+      position:
+        x: 100
+        y: 0


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the layouts for each of the pipeline configuration templates to be valid.

For example, the default template now renders with a valid layout

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/d74e58db-ce4b-4cb6-92c0-9f294b57577e" />

- https://app.asana.com/0/1208469935858869/1209917737059230/f

## Short description of the changes
- Update each template's layout section to move the x and y coordinates into the position sub-section
- Remove frame section

