### PR TITLE
fix: Replace duplicate HoneycombExporter in test data

### DIFF
--- a/pkg/translator/testdata/hpsf/deterministicsampler_all.yaml
+++ b/pkg/translator/testdata/hpsf/deterministicsampler_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: HoneycombExporter
+    kind: TraceConverter
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: DeterministicSampler_1

--- a/pkg/translator/testdata/hpsf/deterministicsampler_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/deterministicsampler_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: HoneycombExporter
+    kind: TraceConverter
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: DeterministicSampler_1

--- a/pkg/translator/testdata/hpsf/emathroughput_all.yaml
+++ b/pkg/translator/testdata/hpsf/emathroughput_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: HoneycombExporter
+    kind: TraceConverter
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: EMAThroughput_1

--- a/pkg/translator/testdata/hpsf/emathroughput_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/emathroughput_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: HoneycombExporter
+    kind: TraceConverter
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: EMAThroughput_1

--- a/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: HoneycombExporter
+    kind: TraceConverter
   - name: honeycomb_out
     kind: HoneycombExporter
     properties:

--- a/pkg/translator/testdata/hpsf/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: HoneycombExporter
+    kind: TraceConverter
   - name: honeycomb_out
     kind: HoneycombExporter
 connections:

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -28,16 +28,16 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 	tlater.InstallTemplates(templates)
 	require.Equal(t, templates, tlater.GetTemplates())
 
-	for componentName := range comps {
+	for _, component := range comps {
 		for _, properties := range []string{"all", "defaults"} {
-			testData := fmt.Sprintf("%s_%s.yaml", strings.ToLower(componentName), properties)
+			testData := fmt.Sprintf("%s_%s.yaml", strings.ToLower(component.Kind), properties)
 			t.Run(testData, func(t *testing.T) {
 				// test source config lives in testdata/hpsf
 				b, err := os.ReadFile(path.Join("testdata", "hpsf", testData))
 				require.NoError(t, err)
 				var inputData = string(b)
 
-				for _, template := range comps[componentName].Templates {
+				for _, template := range component.Templates {
 					configType := config.Type(template.Kind)
 					b, err = os.ReadFile(path.Join("testdata", string(configType), testData))
 					require.NoError(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?

Having duplicate HoneycombExporter components in the same workflow can inconsistent output Refinery config's as they compete to write the same values.

- closes #70 

## Short description of the changes

- Replace duplicate HoneycombExporter components in test data workflows with TraceConverter for input streams
- Simplify the translator test loop to use the component struct in the for loop

