### PR TITLE
feat: set SendKeyMode when api key present

### DIFF
--- a/pkg/config/dotTemplate.go
+++ b/pkg/config/dotTemplate.go
@@ -62,6 +62,16 @@ func (t *TemplateComponent) generateDottedConfig(dct dottedConfigTemplate, userd
 		if err != nil {
 			return nil, err
 		}
+		if kv.suppress_if != "" {
+			// if the suppress_if condition is met, we skip this key
+			condition, err := t.applyTemplate(kv.suppress_if, userdata)
+			if err != nil {
+				return nil, err
+			}
+			if condition == "true" {
+				continue
+			}
+		}
 		// and then the value
 		value, err := t.applyTemplate(kv.value, userdata)
 		if err != nil {

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -48,6 +48,7 @@ func helpers() template.FuncMap {
 		"join":          join,
 		"makeSlice":     makeSlice,
 		"meta":          meta,
+		"nonempty":      nonempty,
 		"now":           now,
 		"split":         split,
 		"yamlf":         yamlf,

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -46,4 +46,6 @@ templates:
         value: "{{ firstNonZero .HProps.APIEndpoint .User.APIEndpoint .Props.APIEndpoint.Default }}"
       - key: AccessKeys.SendKey
         value: "{{ firstNonZero .HProps.APIKey .User.APIKey }}"
-
+      - key: AccessKeys.SendKeyMode
+        value: "all"
+        suppress_if: "{{ not (nonempty (firstNonZero .HProps.APIKey .User.APIKey)) }}"

--- a/pkg/data/testdata/HoneycombExporter_output_refinery_config.yaml
+++ b/pkg/data/testdata/HoneycombExporter_output_refinery_config.yaml
@@ -1,4 +1,5 @@
 AccessKeys:
     SendKey: test
+    SendKeyMode: all
 Network:
     HoneycombAPI: https://api.honeycomb.io

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
@@ -1,5 +1,6 @@
 AccessKeys:
     SendKey: key1234
+    SendKeyMode: all
 General:
     ConfigurationVersion: 2
     MinRefineryVersion: v2.0


### PR DESCRIPTION
## Which problem is this PR solving?

- This allows refinery to use the configured API key instead of the one present in the headers.

## Short description of the changes

- added tests for presence of the API key and when it's not present
- ensure `suppress_if` is respected for all types of config
- updated honeycomb exporter with SendKeyMode template

