### PR TITLE
feat: add subtype to components

### DIFF
--- a/pkg/config/templateProperty.go
+++ b/pkg/config/templateProperty.go
@@ -23,6 +23,7 @@ type TemplateProperty struct {
 	Summary     string        `yaml:"summary,omitempty"`
 	Description string        `yaml:"description,omitempty"`
 	Type        hpsf.PropType `yaml:"type"`
+	Subtype     string        `yaml:"subtype,omitempty"`
 	Advanced    bool          `yaml:"advanced,omitempty"`
 	Validations []string      `yaml:"validations,omitempty"`
 	Default     any           `yaml:"default,omitempty"`

--- a/pkg/data/components/FilterProcessor.yaml
+++ b/pkg/data/components/FilterProcessor.yaml
@@ -30,6 +30,7 @@ properties:
     type: rule
   - name: Signal
     type: string
+    subtype: oneof(traces, metrics, logs)
     validations:
       - oneof(traces, metrics, logs)
 templates:

--- a/pkg/data/components/OTelDebugExporter.yaml
+++ b/pkg/data/components/OTelDebugExporter.yaml
@@ -32,8 +32,10 @@ properties:
     description: |
       The verbosity level of the debug output. Valid values are basic, normal, or detailed. The default is "basic".
     type: string
+    subtype: oneof(basic, normal, detailed)
     validations:
       - noblanks
+      - oneof(basic, normal, detailed)
     default: basic
 templates:
   - kind: collector_config

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -32,6 +32,7 @@ properties:
       configured. This property supports sending a map of header keys and
       values.
     type: map
+    subtype: header
   - name: Host
     summary: The hostname or IP address to send data to.
     description: |

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -32,6 +32,7 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
+    subtype: header
   - name: Host
     summary: The hostname or IP address to send data to.
     description: |

--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -4,7 +4,7 @@ type: base
 style: exporter
 logo: awss3
 status: development
-version: v0.1.0
+version: v0.2.0
 summary: Stores telemetry in OTLP (OpenTelemetry) format in S3 storage.
 description: |
   Exports OpenTelemetry signals using OTLP to S3 storage.
@@ -26,43 +26,46 @@ ports:
     type: OTelLogs
 properties:
   - name: Bucket
-    summary: The bucket in which to store the S3.
+    summary: The S3 bucket in which to store the data.
     description: |
-      The bucket in which to store the S3. This is a required field.
+      The name of the S3 bucket in which to store the data. This is a required field.
     type: string
     validations:
       - noblanks
   - name: Region
-    summary: The region in which to store the S3.
+    summary: The AWS region in which to store the data.
     description: |
-      The region in which to store the S3. The default value is `us-east-1`.
+      The region in which to store the data.
     type: string
+    default: us-east-1
   - name: Prefix
-    summary: The prefix to use for the S3.
+    summary: The prefix to use when writing files to S3.
     description: |
-      The prefix to use for the S3.
+      The prefix to use when writing files to S3.
     type: string
   # advanced properties
   - name: PartitionFormat
-    summary: The partition format to use for the S3.
+    summary: The partition format to use when writing files to S3.
     description: |
-      The partition format to use for the S3. The default value is `year=%Y/month=%m/day=%d/hour=%H/minute=%M`.
+      The partition format to use when writing files to S3. The default value is `year=%Y/month=%m/day=%d/hour=%H/minute=%M`.
     type: string
+    default: year=%Y/month=%m/day=%d/hour=%H/minute=%M
     advanced: true
   - name: Timeout
-    summary: The timeout to use for the S3.
+    summary: The timeout to use when writing files to S3.
     description: |
-      The timeout to use for the S3. The default value is `5s`.
+      The timeout to use when writing files to S3. The default value is `5s`.
     type: duration
     default: 5s
     validations:
       - duration
     advanced: true
   - name: Marshaler
-    summary: The marshaler to use for the S3.
+    summary: The marshaler to use when writing files to S3.
     description: |
-      The marshaler to use for the S3. The default value is `otlp_json`.
+      The marshaler to use when writing files to S3. The default value is `otlp_json`.
     type: string
+    subtype: oneof(otlp_json, otlp_proto)
     default: otlp_json
     validations:
       - oneof(otlp_json, otlp_proto)


### PR DESCRIPTION

## Which problem is this PR solving?

We needed more granularity in our UI for different component types. This adds a subtype field that can be used to feed extra information to select better editors.
- for maps, subtype 'header' changes the default text in the map editor
- for strings, subtype 'oneof(a, b, c)' creates a dropdown with values a, b, and c

## Short description of the changes

- Add `subtype` to templateProperty
- Add subtype entries to components as appropriate
- Fix S3 component to specify its documented defaults (also correct some text)

To see this in the product will require a release of HPSF and a poodle PR.

