### PR TITLE
feat: Add smoke tests for refinery components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 CONFIG ?= examples/hpsf.yaml
 .PHONY: smoke_refinery
 smoke_refinery:
-	@echo generating refinery configs for component component $(CONFIG)
+	@echo generating refinery configs for component $(CONFIG)
 	mkdir -p tmp
 
 	# generate the configs from the provided file
@@ -76,10 +76,10 @@ smoke_refinery:
 
 	# check if the container is running
 	if [ "$$(docker inspect -f '{{.State.Running}}' 'smoke-refinery')" != "true" ]; then \
-		echo "+++ smoke test - container not running"; \
+		echo "+++ container not running"; \
 		exit 1; \
 	else \
-		echo "+++ smoke test - container running"; \
+		echo "+++ container is running"; \
 		docker kill 'smoke-refinery' > /dev/null; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -57,19 +57,39 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		$(MAKE) validate CONFIG=$${file} || exit 1; \
 	done
 
-.PHONY: smoke
-smoke:
-	@echo
-	@echo "+++ basic smoke test - does it start?"
-	@echo "+++ if so, make unsmoke after this"
-	@echo
+CONFIG ?= examples/hpsf.yaml
+.PHONY: smoke_refinery
+smoke_refinery:
+	@echo generating refinery configs for component component $(CONFIG)
 	mkdir -p tmp
-	go run ./cmd/hpsf -i ./examples/hpsfProxy.yaml -o tmp/hpsfProxy.cconfig.yaml cConfig
-	docker run --rm -it \
-		--name smoke-proxy \
-    -p 4227-4228:4227-4228 \
-		-v ./tmp/hpsfProxy.cconfig.yaml:/etc/otelcol/config.yaml \
-		otel/opentelemetry-collector:latest
+
+	# generate the configs from the provided file
+	go run ./cmd/hpsf -i ${CONFIG} -o tmp/refinery-rules.yaml rRules
+	go run ./cmd/hpsf -i ${CONFIG} -o tmp/refinery-config.yaml rConfig
+	
+	# run refinery with the generated configs
+	docker run -d --rm --name smoke-refinery \
+		-v ./tmp/refinery-config.yaml:/etc/refinery/refinery.yaml \
+		-v ./tmp/refinery-rules.yaml:/etc/refinery/rules.yaml \
+		honeycombio/refinery:latest
+	sleep 1
+
+	# check if the container is running
+	if [ "$$(docker inspect -f '{{.State.Running}}' 'smoke-refinery')" != "true" ]; then \
+		echo "+++ smoke test - container not running"; \
+		exit 1; \
+	else \
+		echo "+++ smoke test - container running"; \
+		docker kill 'smoke-refinery' > /dev/null; \
+	fi
+
+.PHONY: smoke
+smoke: pkg/data/components/*.yaml
+	for file in $^ ; do \
+		if [ "$$(yq '.templates[] | select(.kind | contains("refinery_config","refinery_rules"))' $${file})" != "" ]; then \
+			$(MAKE) smoke_refinery CONFIG=$${file}; \
+		fi; \
+	done
 
 .PHONY: unsmoke
 unsmoke:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ validate_all: examples/hpsf* pkg/data/templates/*
 
 .PHONY: .smoke_refinery
 #: run smoke test for refinery
-#: (usage: make smoke_refinery FILE=examples/hpsf.yaml)
 #: Do not use directly, use the smoke target instead
 .smoke_refinery:
 	if [ -z "$(FILE)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	done
 
 .PHONY: .smoke_refinery
-#: run smoke test for refinery
+#: run smoke test for refinery component
 #: Do not use directly, use the smoke target instead
 .smoke_refinery:
 	if [ -z "$(FILE)" ]; then \
@@ -90,6 +90,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	fi
 
 .PHONY: smoke
+#: run smoke tests for HPSF components
 smoke: pkg/data/components/*.yaml
 	for file in $^ ; do \
 		if [ "$$(yq '.templates[] | select(.kind | contains("refinery_config","refinery_rules"))' $${file})" != "" ]; then \


### PR DESCRIPTION
## Which problem is this PR solving?

Adds integration tests to verify each refinery component can generate config and rules files that a refinery docker image can start with.

- https://app.asana.com/1/72322038700732/project/1208469935858869/task/1209503669851437?focus=true
