### PR TITLE
feat: add headers to default otlp exporter

### DIFF
--- a/pkg/data/templates/default.yaml
+++ b/pkg/data/templates/default.yaml
@@ -11,6 +11,10 @@ components:
     kind: OTelReceiver
   - name: OTel HTTP Exporter 1
     kind: OTelHTTPExporter
+    properties:
+      - name: Headers
+        value:
+          x-honeycomb-team: ${HONEYCOMB_API_KEY}
 connections:
   - source:
       component: OTel Receiver 1

--- a/pkg/translator/testdata/collector_config/default.yaml
+++ b/pkg/translator/testdata/collector_config/default.yaml
@@ -11,6 +11,8 @@ processors:
 exporters:
     otlphttp/OTel_HTTP_Exporter_1:
         endpoint: https://api.honeycomb.io:443
+        headers:
+            x-honeycomb-team: ${HONEYCOMB_API_KEY}
 extensions:
     honeycomb: {}
 service:


### PR DESCRIPTION
## Which problem is this PR solving?

- closes https://github.com/honeycombio/pipeline-team/issues/250

## Short description of the changes

- add default headers with env var value to the otlp exporter in the default template

