### PR TITLE
fix: Update Honeycomb exporter test data to use valid API key

### DIFF
--- a/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
@@ -7,7 +7,7 @@ components:
       - name: APIEndpoint
         value: https://alternative.honeycomb.io
       - name: APIKey
-        value: key1234
+        value: abcdef1234567890abcdef1 #must be 232 characters
 connections:
   - source:
       component: honeycomb_in

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
@@ -1,5 +1,5 @@
 AccessKeys:
-    SendKey: key1234
+    SendKey: abcdef1234567890abcdef1
     SendKeyMode: all
 General:
     ConfigurationVersion: 2


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the Honeycomb Exporter test data to use a valid API key, which is required to start Refinery.

## Short description of the changes
- Update the API key to be a dummy but valid key (ie 23 chars)