### PR TITLE
fix: update env var for refinery key

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -25,7 +25,7 @@ properties:
     type: string
     validations:
       - noblanks
-    default: ${HONEYCOMB_EXPORTER_APIKEY}
+    default: ${REFINERY_HONEYCOMB_API_KEY}
   - name: APIEndpoint
     summary: The Endpoint URL of the Honeycomb API
     description: |


### PR DESCRIPTION
This updates the default variable for the refinery environment variable to the same value as the helm chart.
