### PR TITLE
feat: change the way rules files are generated

### DIFF
--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -58,8 +58,8 @@ func (c GenericBaseComponent) GenerateConfig(ct Type, userdata map[string]any) (
 			"General.MinRefineryVersion":   "v2.0",
 		}, nil
 	case RefineryRulesType:
-		return tmpl.DottedConfig{
-			"RulesVersion": 2,
+		return &tmpl.RulesConfig{
+			Version: 2,
 		}, nil
 	case CollectorConfigType:
 		return tmpl.NewCollectorConfig(), nil

--- a/pkg/config/rulestemplate.go
+++ b/pkg/config/rulestemplate.go
@@ -63,9 +63,9 @@ func (r *rulesCondition) Render(prefix string) (map[string]any, error) {
 // separated by semicolons, e.g. "k=v;k2=v2;k3=v3"
 // the key-value pairs can be either a single value or a list of values
 // separated by commas, e.g. "k=v" or "ks=v1,v2,v3"
-func splitCondition(v any) *rulesCondition {
+func splitCondition(condition any) *rulesCondition {
 	// if the value is a string, split it by semicolons
-	if s, ok := v.(string); ok {
+	if s, ok := condition.(string); ok {
 		parts := strings.Split(s, ";")
 		m := make(map[string]any)
 		for _, part := range parts {
@@ -75,13 +75,14 @@ func splitCondition(v any) *rulesCondition {
 			}
 			k := strings.TrimSpace(kv[0])
 			v := strings.TrimSpace(kv[1])
-			if strings.Contains(v, ",") {
+			if k == "fs" {
 				m[k] = strings.Split(v, ",")
 			} else {
 				m[k] = v
 			}
 		}
 
+		// only the fs case can be a []strings, every other v is a string
 		cond := &rulesCondition{index: -1}
 		for k, v := range m {
 			switch k {
@@ -111,8 +112,8 @@ func splitCondition(v any) *rulesCondition {
 	return nil
 }
 
-func buildRulesTemplate(t TemplateData) (rulesTemplate, error) {
-	r := rulesTemplate{kvs: make([]dottedConfigTemplateKV, 0)}
+func buildRulesTemplate(t TemplateData) (*rulesTemplate, error) {
+	r := &rulesTemplate{kvs: make([]dottedConfigTemplateKV, 0)}
 
 	for mk, mv := range t.Meta {
 		var ok bool
@@ -134,6 +135,9 @@ func buildRulesTemplate(t TemplateData) (rulesTemplate, error) {
 
 	if r.env == "" {
 		return r, fmt.Errorf("missing env in meta")
+	}
+	if r.sampler == "" {
+		return r, fmt.Errorf("missing sampler in meta")
 	}
 
 	for _, d := range t.Data {
@@ -170,24 +174,20 @@ func buildRulesTemplate(t TemplateData) (rulesTemplate, error) {
 	return r, nil
 }
 
-func (t *TemplateComponent) generateRulesConfig(rt rulesTemplate, userdata map[string]any) (*tmpl.RulesConfig, error) {
+func (t *TemplateComponent) generateRulesConfig(rt *rulesTemplate, userdata map[string]any) (*tmpl.RulesConfig, error) {
 	dc := tmpl.NewDottedConfig(nil)
-	if strings.Contains(rt.env, "{{") {
-		// if the env contains a template variable, we need to expand it
-		env, err := t.expandTemplateVariable(rt.env, userdata)
-		if err != nil {
-			return nil, err
-		}
-		rt.env = env
+
+	env, err := t.expandTemplateVariable(rt.env, userdata)
+	if err != nil {
+		return nil, err
 	}
-	if strings.Contains(rt.sampler, "{{") {
-		// if the sampler contains a template variable, we need to expand it
-		sampler, err := t.expandTemplateVariable(rt.sampler, userdata)
-		if err != nil {
-			return nil, err
-		}
-		rt.sampler = sampler
+	rt.env = env
+
+	sampler, err := t.expandTemplateVariable(rt.sampler, userdata)
+	if err != nil {
+		return nil, err
 	}
+	rt.sampler = sampler
 
 	keyPrefix := "Samplers." + rt.env + "." + rt.sampler + "."
 	for _, kv := range rt.kvs {

--- a/pkg/config/rulestemplate.go
+++ b/pkg/config/rulestemplate.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/honeycombio/hpsf/pkg/config/tmpl"
+)
+
+type rulesTemplate struct {
+	env     string
+	sampler string
+	kvs     []dottedConfigTemplateKV
+}
+
+type rulesCondition struct {
+	fields   []string
+	op       string
+	value    string
+	datatype string
+}
+
+func (r *rulesCondition) Render() (map[string]any, error) {
+	// render the condition into a dottedConfigTemplateKV
+	dc := make(map[string]any)
+	if len(r.fields) == 1 {
+		dc["Conditions.Field"] = r.fields[0]
+	} else {
+		dc["Conditions.Fields"] = r.fields
+	}
+	dc["Conditions.Operator"] = r.op
+	if r.op == "exists" || r.op == "not_exists" {
+		// if the operator is exists or not_exists, we don't need a value or datatype
+		return dc, nil
+	}
+	dc["Conditions.Value"] = r.value
+
+	switch r.datatype {
+	case "string", "s":
+		dc["Conditions.Datatype"] = "string"
+	case "int", "i":
+		dc["Conditions.Datatype"] = "int"
+	case "float", "f":
+		dc["Conditions.Datatype"] = "float"
+	case "bool", "b":
+		dc["Conditions.Datatype"] = "bool"
+	case "":
+		// if the datatype is empty, don't set it
+	default:
+		return nil, fmt.Errorf("unknown datatype %q", r.datatype)
+	}
+	return dc, nil
+}
+
+// the format of a condition is multiple key-value pairs
+// separated by semicolons, e.g. "k=v;k2=v2;k3=v3"
+// the key-value pairs can be either a single value or a list of values
+// separated by commas, e.g. "k=v" or "ks=v1,v2,v3"
+func splitCondition(v any) *rulesCondition {
+	// if the value is a string, split it by semicolons
+	if s, ok := v.(string); ok {
+		parts := strings.Split(s, ";")
+		m := make(map[string]any)
+		for _, part := range parts {
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) != 2 {
+				continue
+			}
+			k := strings.TrimSpace(kv[0])
+			v := strings.TrimSpace(kv[1])
+			if strings.Contains(v, ",") {
+				m[k] = strings.Split(v, ",")
+			} else {
+				m[k] = v
+			}
+		}
+
+		cond := &rulesCondition{}
+		for k, v := range m {
+			switch k {
+			case "f":
+				cond.fields = append(cond.fields, v.(string))
+			case "fs":
+				cond.fields = v.([]string)
+			case "o":
+				cond.op = v.(string)
+			case "v":
+				cond.value = v.(string)
+			case "d":
+				cond.datatype = v.(string)
+			default:
+				// ignore unknown keys
+			}
+		}
+		return cond
+	}
+	return nil
+}
+
+func buildRulesTemplate(t TemplateData) (rulesTemplate, error) {
+	r := rulesTemplate{kvs: make([]dottedConfigTemplateKV, 0)}
+
+	for mk, mv := range t.Meta {
+		var ok bool
+		switch mk {
+		case "env":
+			r.env, ok = mv.(string)
+			if !ok {
+				return r, fmt.Errorf("expected string for env, got %T", mv)
+			}
+		case "sampler":
+			r.sampler, ok = mv.(string)
+			if !ok {
+				return r, fmt.Errorf("expected string for sampler, got %T", mv)
+			}
+		default:
+			return r, fmt.Errorf("unknown meta key %q", mk)
+		}
+	}
+
+	if r.env == "" {
+		return r, fmt.Errorf("missing env in meta")
+	}
+
+	for _, d := range t.Data {
+		kv, ok := getKV(d)
+		if !ok {
+			return r, fmt.Errorf("expected map for data, got %T", d)
+		}
+
+		switch kv.key {
+		// this is a special case for the conditions
+		// we need to render them into a dottedConfigTemplateKV
+		case "!condition!":
+			cond := splitCondition(kv.value)
+			if cond == nil {
+				return r, fmt.Errorf("expected string for condition, got %T", kv.value)
+			}
+			m, err := cond.Render()
+			if err != nil {
+				return r, err
+			}
+			for k, v := range m {
+				kv := dottedConfigTemplateKV{
+					key:   k,
+					value: v,
+				}
+				r.kvs = append(r.kvs, kv)
+			}
+		default:
+			r.kvs = append(r.kvs, *kv)
+		}
+	}
+	return r, nil
+}
+
+func (t *TemplateComponent) generateRulesConfig(rt rulesTemplate, userdata map[string]any) (*tmpl.RulesConfig, error) {
+	dc := tmpl.DottedConfig{}
+	if strings.Contains(rt.env, "{{") {
+		// if the env contains a template variable, we need to expand it
+		env, err := t.expandTemplateVariable(rt.env, userdata)
+		if err != nil {
+			return nil, err
+		}
+		rt.env = env
+	}
+	if strings.Contains(rt.sampler, "{{") {
+		// if the sampler contains a template variable, we need to expand it
+		sampler, err := t.expandTemplateVariable(rt.sampler, userdata)
+		if err != nil {
+			return nil, err
+		}
+		rt.sampler = sampler
+	}
+
+	keyPrefix := "Samplers." + rt.env + "." + rt.sampler + "."
+	for _, kv := range rt.kvs {
+		// do the key
+		key, err := t.expandTemplateVariable(kv.key, userdata)
+		if err != nil {
+			return nil, err
+		}
+		if kv.suppress_if != "" {
+			// if the suppress_if condition is met, we skip this key
+			condition, err := t.applyTemplate(kv.suppress_if, userdata)
+			if err != nil {
+				return nil, err
+			}
+			if condition == "true" {
+				continue
+			}
+		}
+		// and then the value
+		value, err := t.applyTemplate(kv.value, userdata)
+		if err != nil {
+			return nil, err
+		}
+		if kv.value != "" {
+			dc[keyPrefix+key] = value
+		}
+	}
+	ec := tmpl.EnvConfig{
+		Name:       rt.env,
+		ConfigData: dc,
+	}
+	rc := tmpl.NewRulesConfig()
+	rc.Envs = append(rc.Envs, ec)
+	return rc, nil
+}

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -231,6 +231,15 @@ func (t *TemplateComponent) GenerateConfig(cfgType Type, userdata map[string]any
 						err, t.Kind)
 				}
 				return t.generateCollectorConfig(ct, userdata)
+			case "rules":
+				// a rules template expects the metadata to include environment
+				// information.
+				rt, err := buildRulesTemplate(template)
+				if err != nil {
+					return nil, fmt.Errorf("error %w building rules template for %s",
+						err, t.Kind)
+				}
+				return t.generateRulesConfig(rt, userdata)
 			default:
 				return nil, fmt.Errorf("unknown template format %s", template.Format)
 			}
@@ -316,7 +325,7 @@ func undecorate(s string) any {
 func (t *TemplateComponent) applyTemplate(tmplVal any, userdata map[string]any) (any, error) {
 	switch k := tmplVal.(type) {
 	case string:
-		if tmplVal == "" || !strings.Contains(k, "{{") {
+		if !strings.Contains(k, "{{") {
 			return k, nil
 		}
 
@@ -331,6 +340,8 @@ func (t *TemplateComponent) applyTemplate(tmplVal any, userdata map[string]any) 
 		return result, nil
 	// right now this is dealing with nop receiver/exporter case
 	case map[string]string:
+		return k, nil
+	case []string:
 		return k, nil
 	default:
 		return "", fmt.Errorf("invalid templated variable type %T", k)

--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -142,8 +142,10 @@ func (cc *CollectorConfig) renderInto(m map[string]any, key string, value any) {
 }
 
 // RenderToMap renders the config into a map.
-func (cc *CollectorConfig) RenderToMap() map[string]any {
-	m := make(map[string]any)
+func (cc *CollectorConfig) RenderToMap(m map[string]any) map[string]any {
+	if m == nil {
+		m = make(map[string]any)
+	}
 	for section := range cc.Sections {
 		for k, v := range cc.Sections[section] {
 			key := section + "." + k
@@ -157,7 +159,7 @@ func (cc *CollectorConfig) RenderToMap() map[string]any {
 func (cc *CollectorConfig) RenderYAML() ([]byte, error) {
 	// we render the config to a map, and then marshal it to yaml
 	// but that yaml is not idiomatic for the collector
-	m := cc.RenderToMap()
+	m := cc.RenderToMap(nil)
 	data, err := y.Marshal(m)
 	if err != nil {
 		return nil, err

--- a/pkg/config/tmpl/dottedconfig_test.go
+++ b/pkg/config/tmpl/dottedconfig_test.go
@@ -72,13 +72,31 @@ func TestDottedConfig_Compose(t *testing.T) {
 		want map[string]any
 	}{
 		{"1", DottedConfig{"b": 1}, map[string]any{"a": map[string]any{"b": map[string]any{"c": 1}}, "b": 1}},
-		{"2", DottedConfig{"a.b.c": 2}, map[string]any{"a": map[string]any{"b": []map[string]any{map[string]any{"c": 1}, map[string]any{"c": 2}}}}},
+		{"2", DottedConfig{"a.b.c": 2}, map[string]any{"a": map[string]any{"b": []map[string]any{{"c": 1}, {"c": 2}}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := clone(baseMap)
 			if got := tt.dc.RenderToMap(m); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DottedConfig.Render() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_processIndices(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]any
+		want map[string]any
+	}{
+		{"0", map[string]any{}, map[string]any{}},
+		{"1", map[string]any{"a[0]": map[string]any{"a": "b"}}, map[string]any{"a": []map[string]any{{"a": "b"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := processIndices(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("processIndices() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -23,8 +23,19 @@ func (rc *RulesConfig) RenderToMap(m map[string]any) map[string]any {
 		m = make(map[string]any)
 	}
 	m["RulesVersion"] = rc.Version
+	foundDefault := false
 	for _, env := range rc.Envs {
+		if env.Name == "__default__" {
+			foundDefault = true
+		}
 		m = env.ConfigData.RenderToMap(m)
+	}
+	if !foundDefault {
+		// if we don't have a default env, we need to add one
+		defaultConfig := DottedConfig{
+			"Samplers.__default__.DeterministicSampler.SampleRate": 1,
+		}
+		m = defaultConfig.RenderToMap(m)
 	}
 	return m
 }

--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -14,7 +14,8 @@ type EnvConfig struct {
 
 func NewRulesConfig() *RulesConfig {
 	return &RulesConfig{
-		Envs: []EnvConfig{},
+		Version: 2,
+		Envs:    []EnvConfig{},
 	}
 }
 

--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -24,7 +24,7 @@ func (rc *RulesConfig) RenderToMap(m map[string]any) map[string]any {
 	}
 	m["RulesVersion"] = rc.Version
 	for _, env := range rc.Envs {
-		env.ConfigData.RenderToMap(m)
+		m = env.ConfigData.RenderToMap(m)
 	}
 	return m
 }

--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -1,0 +1,61 @@
+package tmpl
+
+import y "gopkg.in/yaml.v3"
+
+type RulesConfig struct {
+	Version int
+	Envs    []EnvConfig
+}
+
+type EnvConfig struct {
+	Name       string
+	ConfigData DottedConfig
+}
+
+func NewRulesConfig() *RulesConfig {
+	return &RulesConfig{
+		Envs: []EnvConfig{},
+	}
+}
+
+func (rc *RulesConfig) RenderToMap(m map[string]any) map[string]any {
+	if m == nil {
+		m = make(map[string]any)
+	}
+	m["RulesVersion"] = rc.Version
+	for _, env := range rc.Envs {
+		env.ConfigData.RenderToMap(m)
+	}
+	return m
+}
+
+func (rc *RulesConfig) RenderYAML() ([]byte, error) {
+	m := rc.RenderToMap(nil)
+	data, err := y.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (rc *RulesConfig) Merge(other TemplateConfig) TemplateConfig {
+	otherRC, ok := other.(*RulesConfig)
+	if !ok {
+		// if the other TemplateConfig is not a RulesConfig, we can't merge it
+		return rc
+	}
+	for _, otherEnv := range otherRC.Envs {
+		found := false
+		for i, env := range rc.Envs {
+			if env.Name == otherEnv.Name {
+				rc.Envs[i].ConfigData = rc.Envs[i].ConfigData.Merge(otherEnv.ConfigData).(DottedConfig)
+				found = true
+				break
+			}
+		}
+		if !found {
+			rc.Envs = append(rc.Envs, otherEnv)
+		}
+	}
+	return rc
+}

--- a/pkg/config/tmpl/templateconfig.go
+++ b/pkg/config/tmpl/templateconfig.go
@@ -2,7 +2,7 @@ package tmpl
 
 // TemplateConfig is an interface for a configuration abstraction that can be rendered as a map or as YAML.
 type TemplateConfig interface {
-	RenderToMap() map[string]any
+	RenderToMap(m map[string]any) map[string]any
 	RenderYAML() ([]byte, error)
 	Merge(other TemplateConfig) TemplateConfig
 }

--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -44,7 +44,10 @@ properties:
 templates:
   - kind: refinery_rules
     name: DeterministicSampler_RefineryRules
-    format: dotted
+    format: rules
+    meta:
+      env: "{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}"
+      sampler: DeterministicSampler
     data:
-      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.DeterministicSampler.SampleRate"
+      - key: SampleRate
         value: "{{ firstNonZero .HProps.SampleRate .User.SampleRate .Props.SampleRate.Default | encodeAsInt }}"

--- a/pkg/data/components/EmaThroughput.yaml
+++ b/pkg/data/components/EmaThroughput.yaml
@@ -75,11 +75,14 @@ properties:
 templates:
   - kind: refinery_rules
     name: EMA_Throughput_Rules
-    format: dotted
+    format: rules
+    meta:
+      env: "{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}"
+      sampler: EMAThroughputSampler
     data:
-      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.GoalThroughputPerSec"
+      - key: GoalThroughputPerSec
         value: "{{ firstNonZero .HProps.GoalThroughputPerSec .User.GoalThroughputPerSec .Props.GoalThroughputPerSec.Default | encodeAsInt }}"
-      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.AdjustmentInterval"
+      - key: AdjustmentInterval
         value: "{{ firstNonZero .HProps.AdjustmentInterval .User.AdjustmentInterval .Props.AdjustmentInterval.Default }}s"
-      - key: "Samplers.{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}.EMAThroughputSampler.FieldList"
+      - key: FieldList
         value: "{{ firstNonZero .HProps.FieldList .User.FieldList .Props.FieldList.Default | encodeAsArray }}"

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -71,12 +71,12 @@ templates:
       - key: "Rules[0].!condition!"
         value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=500"
       - key: Rules[1].Name
-        value: "Sample 400 statuses at {{ .HProps.UserErrorRate }}"
+        value: "Sample 400 statuses at {{ firstNonZero .HProps.UserErrorRate .User.UserErrorRate .Props.UserErrorRate.Default }}"
       - key: Rules[1].SampleRate
         value: "{{ firstNonZero .HProps.UserErrorRate .User.UserErrorRate .Props.UserErrorRate.Default }}"
       - key: "Rules[1].!condition!"
         value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
       - key: Rules[2].Name
-        value: "Sample remainder at {{ .HProps.DefaultRate }}"
+        value: "Sample remainder at {{ firstNonZero .HProps.DefaultRate .User.DefaultRate .Props.DefaultRate.Default }}"
       - key: Rules[2].SampleRate
         value: "{{ firstNonZero .HProps.DefaultRate .User.DefaultRate .Props.DefaultRate.Default }}"

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -64,19 +64,19 @@ templates:
       env: "{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}"
       sampler: "RulesBasedSampler"
     data:
-      - key: Name
-        value: "Sample 500 statuses at {{ .HProps.ErrorRate }} ({{ .HProps.Name }})"
-      - key: SampleRate
+      - key: Rules[0].Name
+        value: "Sample 500 statuses at {{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }} ({{ .HProps.Name }})"
+      - key: Rules[0].SampleRate
         value: "{{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }}"
-      - key: "!condition!"
+      - key: "Rules[0].!condition!"
         value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=500"
-      - key: Name
-        value: "Sample 400 statuses at {{ .HProps.UserErrorRate }} ({{ .HProps.Name }})"
-      - key: SampleRate
+      - key: Rules[1].Name
+        value: "Sample 400 statuses at {{ .HProps.UserErrorRate }}"
+      - key: Rules[1].SampleRate
         value: "{{ firstNonZero .HProps.UserErrorRate .User.UserErrorRate .Props.UserErrorRate.Default }}"
-      - key: "!condition!"
-        value: "ix=1;fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
-      - key: Name
-        value: "Sample remainder at {{ .HProps.DefaultRate }} ({{ .HProps.Name }})"
-      - key: SampleRate
+      - key: "Rules[1].!condition!"
+        value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
+      - key: Rules[2].Name
+        value: "Sample remainder at {{ .HProps.DefaultRate }}"
+      - key: Rules[2].SampleRate
         value: "{{ firstNonZero .HProps.DefaultRate .User.DefaultRate .Props.DefaultRate.Default }}"

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -1,0 +1,82 @@
+kind: SampleErrors
+name: Sample Based on Errors
+style: processor
+type: base
+status: development
+version: v0.1.0
+summary: Samples HTTP errors based on error codes
+description: |
+  Samples HTTP errors based on the http status of processes within the trace.
+  If any span a trace has a status code in the 500s, it will be sampled
+  at the error rate. If any span has a status code in the 400s,
+  it will be sampled at the user error rate.
+  All other traces will be sampled at the default rate.
+tags:
+  - category:refinery_rule
+  - service:refinery
+  - vendor:Honeycomb
+  - type:error
+ports:
+  - name: In
+    direction: input
+    type: HoneycombEvents
+  - name: Out
+    direction: output
+    type: HoneycombEvents
+properties:
+  - name: Environment
+    summary: The environment in which to enable the sampler.
+    description: |
+      The environment in which to enable the sampler. If this field is
+      not specified, the sampler will be enabled in the __default__ environment,
+      which is what is used if the environment specified in the trace is not found.
+    type: string
+    default: "__default__"
+  - name: ErrorRate
+    summary: The sample rate to use if the trace contains error spans (http 500s).
+    description: |
+      The sample rate to use if the rule matches. Example: 10 to keep 1 out of 10 traces.
+    type: int
+    default: 1
+    validations:
+      - positive
+  - name: UserErrorRate
+    summary: The sample rate to use if the trace contains spans with status in the 400s.
+    description: |
+      The sample rate to use if the rule matches. Example: 10 to keep 1 out of 10 traces.
+    type: int
+    default: 10
+    validations:
+      - positive
+  - name: DefaultRate
+    summary: The sample rate to use if the trace does not contain any error spans.
+    description: |
+      The sample rate to use if the rule matches. Example: 10 to keep 1 out of 10 traces.
+    type: int
+    default: 100
+    validations:
+      - positive
+templates:
+  - kind: refinery_rules
+    name: Drop_RefineryRules
+    format: rules
+    meta:
+      env: "{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}"
+      sampler: "RulesBasedSampler"
+    data:
+      - key: Name
+        value: "Sample 500 statuses at {{ .HProps.ErrorRate }} ({{ .HProps.Name }})"
+      - key: SampleRate
+        value: "{{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }}"
+      - key: "!condition!"
+        value: "fs=http.status_code,http.response.status_code;o=>=;d=i;v=500"
+      - key: Name
+        value: "Sample 400 statuses at {{ .HProps.UserErrorRate }} ({{ .HProps.Name }})"
+      - key: SampleRate
+        value: "{{ firstNonZero .HProps.UserErrorRate .User.UserErrorRate .Props.UserErrorRate.Default }}"
+      - key: "!condition!"
+        value: "fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
+      - key: Name
+        value: "Sample remainder at {{ .HProps.DefaultRate }} ({{ .HProps.Name }})"
+      - key: SampleRate
+        value: "{{ firstNonZero .HProps.DefaultRate .User.DefaultRate .Props.DefaultRate.Default }}"

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -65,7 +65,7 @@ templates:
       sampler: "RulesBasedSampler"
     data:
       - key: Rules[0].Name
-        value: "Sample 500 statuses at {{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }} ({{ .HProps.Name }})"
+        value: "Sample 500 statuses at {{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }}"
       - key: Rules[0].SampleRate
         value: "{{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }}"
       - key: "Rules[0].!condition!"

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -1,6 +1,6 @@
 kind: SampleErrors
 name: Sample Based on Errors
-style: processor
+style: sampler
 type: base
 status: development
 version: v0.1.0
@@ -62,7 +62,7 @@ templates:
     format: rules
     meta:
       env: "{{ firstNonZero .HProps.Environment .User.Environment .Props.Environment.Default }}"
-      sampler: "RulesBasedSampler"
+      sampler: RulesBasedSampler
     data:
       - key: Rules[0].Name
         value: "Sample 500 statuses at {{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }}"

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -69,13 +69,13 @@ templates:
       - key: SampleRate
         value: "{{ firstNonZero .HProps.ErrorRate .User.ErrorRate .Props.ErrorRate.Default }}"
       - key: "!condition!"
-        value: "fs=http.status_code,http.response.status_code;o=>=;d=i;v=500"
+        value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=500"
       - key: Name
         value: "Sample 400 statuses at {{ .HProps.UserErrorRate }} ({{ .HProps.Name }})"
       - key: SampleRate
         value: "{{ firstNonZero .HProps.UserErrorRate .User.UserErrorRate .Props.UserErrorRate.Default }}"
       - key: "!condition!"
-        value: "fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
+        value: "ix=1;fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
       - key: Name
         value: "Sample remainder at {{ .HProps.DefaultRate }} ({{ .HProps.Name }})"
       - key: SampleRate

--- a/pkg/data/loadEmbedded_test.go
+++ b/pkg/data/loadEmbedded_test.go
@@ -95,6 +95,8 @@ func TestTemplateComponents(t *testing.T) {
 		},
 	}
 
+	// set overwrite to true to rewrite the testdata files with the generated config
+	overwrite := false
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			want, err := os.ReadFile(path.Join("testdata", tt.wantOutput))
@@ -106,7 +108,14 @@ func TestTemplateComponents(t *testing.T) {
 			require.NotNil(t, conf)
 			got, err := conf.RenderYAML()
 			require.NoError(t, err)
-			require.Equal(t, string(want), string(got))
+			if overwrite && string(got) != string(want) {
+				// overwrite the testdata file with the generated config
+				err = os.WriteFile(path.Join("testdata", tt.wantOutput), got, 0644)
+				require.NoError(t, err)
+				t.Logf("Overwrote %s with generated config", path.Join("testdata", tt.wantOutput))
+			} else {
+				require.Equal(t, string(want), string(got))
+			}
 		})
 	}
 }

--- a/pkg/data/testdata/EmaThroughput_output_refinery_rules.yaml
+++ b/pkg/data/testdata/EmaThroughput_output_refinery_rules.yaml
@@ -1,4 +1,8 @@
+RulesVersion: 2
 Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 1
     staging:
         EMAThroughputSampler:
             AdjustmentInterval: 120s

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -34,8 +34,9 @@ const (
 	PTYPE_FLOAT  PropType = "float"
 	PTYPE_STRING PropType = "string"
 	PTYPE_BOOL   PropType = "bool"
-	PTYPE_ARRSTR PropType = "stringarray"
-	PTYPE_MAPSTR PropType = "map" // map[string]any
+	PTYPE_ARRSTR PropType = "stringarray" // []string
+	PTYPE_MAPSTR PropType = "map"         // map[string]any
+	PTYPE_COND   PropType = "conditions"  // for refinery conditions
 )
 
 func (p PropType) Validate() error {
@@ -46,6 +47,7 @@ func (p PropType) Validate() error {
 	case PTYPE_BOOL:
 	case PTYPE_ARRSTR:
 	case PTYPE_MAPSTR:
+	case PTYPE_COND:
 	default:
 		return errors.New("invalid PropType '" + string(p) + "'")
 	}
@@ -148,6 +150,13 @@ func (p PropType) ValueCoerce(a any, target *any) error {
 			return errors.New("expected string array, got " + fmt.Sprint(a))
 		}
 	case PTYPE_MAPSTR:
+		switch v := a.(type) {
+		case map[string]any:
+			*target = v
+		default:
+			return errors.New("expected dictionary, got " + fmt.Sprint(a))
+		}
+	case PTYPE_COND:
 		switch v := a.(type) {
 		case map[string]any:
 			*target = v

--- a/pkg/translator/testdata/hpsf/sampleerrors_all.yaml
+++ b/pkg/translator/testdata/hpsf/sampleerrors_all.yaml
@@ -3,6 +3,3 @@ Samplers:
     __default__:
         DeterministicSampler:
             SampleRate: 1
-    staging:
-        DeterministicSampler:
-            SampleRate: 42

--- a/pkg/translator/testdata/hpsf/sampleerrors_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/sampleerrors_defaults.yaml
@@ -1,0 +1,3 @@
+components:
+  - name: se_out
+    kind: SampleErrors

--- a/pkg/translator/testdata/refinery_rules/sampleerrors_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/sampleerrors_all.yaml
@@ -1,0 +1,5 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 1

--- a/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
@@ -1,0 +1,25 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Conditions:
+                    - Datatype: int
+                      Fields:
+                        - http.status_code
+                        - http.response.status_code
+                      Operator: '>='
+                      Value: "500"
+                  Name: Sample 500 statuses at 1
+                  SampleRate: "1"
+                - Conditions:
+                    - Datatype: int
+                      Fields:
+                        - http.status_code
+                        - http.response.status_code
+                      Operator: '>='
+                      Value: "400"
+                  Name: Sample 400 statuses at <no value>
+                  SampleRate: "10"
+                - Name: Sample remainder at <no value>
+                  SampleRate: "100"

--- a/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
@@ -19,7 +19,7 @@ Samplers:
                         - http.response.status_code
                       Operator: '>='
                       Value: "400"
-                  Name: Sample 400 statuses at <no value>
+                  Name: Sample 400 statuses at 10
                   SampleRate: "10"
-                - Name: Sample remainder at <no value>
+                - Name: Sample remainder at 100
                   SampleRate: "100"

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -17,6 +18,10 @@ import (
 )
 
 func TestGenerateConfigForAllComponents(t *testing.T) {
+	// set this to true to overwrite the testdata files with the generated
+	// config files if they are different
+	overwrite := false
+
 	tlater := NewEmptyTranslator()
 	comps, err := data.LoadEmbeddedComponents()
 	require.NoError(t, err)
@@ -54,7 +59,14 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 					got, err := cfg.RenderYAML()
 					require.NoError(t, err)
 
-					assert.Equal(t, expectedConfig, string(got))
+					if overwrite && !reflect.DeepEqual(expectedConfig, string(got)) {
+						// overwrite the testdata file with the generated config
+						err = os.WriteFile(path.Join("testdata", string(configType), testData), got, 0644)
+						require.NoError(t, err)
+						t.Logf("Overwrote %s with generated config", path.Join("testdata", string(configType), testData))
+					} else {
+						assert.Equal(t, expectedConfig, string(got))
+					}
 				}
 			})
 		}


### PR DESCRIPTION
## Which problem is this PR solving?

- Rules files needed to be changed so that they're composable. The old way didn't work. This changes how they're generated and adds some new semantics so that we can build useful rules components. The problem is in the weirdly nested nature of refinery rules -- I wanted to avoid a structure that was tightly tied to refinery's current configuration structure but is still flexible enough to handle it. It's definitely got some rather refinery-specific code in here but it's not quite as brittle as an explicit structure.

## Short description of the changes

- Add a rules_config config type (it uses dotted config but has some rules-specific fields and has extra semantics)
- Add a compact way of expressing rules conditions and a special way to handle them in the rules generator
- Add the ability to specify an index so we can create multiple rows
- Add a single rules-specific component
- Tweak the existing samplers to use the new rules_config
- Write some tests 
- Fix up some existing tests (for a couple of tests driven by control files, I added code to allow rewriting the control files within the test).
- Add some docs

