### PR TITLE
fix: Update component positions in templates due to bigger nodes in new design

### DIFF
--- a/pkg/data/templates/default.yaml
+++ b/pkg/data/templates/default.yaml
@@ -48,5 +48,5 @@ layout:
         y: 0
     - name: OTel HTTP Exporter 1
       position:
-        x: 100
+        x: 200
         y: 0

--- a/pkg/data/templates/emathroughput.yaml
+++ b/pkg/data/templates/emathroughput.yaml
@@ -55,13 +55,13 @@ layout:
         y: 0
     - name: Trace Converter 1
       position:    
-        x: -100
+        x: 0
         y: 0
     - name: Honeycomb Exporter 1
       position:
-        x: 100
+        x: 240
         y: 0
     - name: EMA Throughput 1
       position:
-        x: 340
+        x: 540
         y: 0

--- a/pkg/data/templates/proxy.yaml
+++ b/pkg/data/templates/proxy.yaml
@@ -44,5 +44,5 @@ layout:
         y: 0
     - name: OTel gRPC Exporter 1
       position:
-        x: 100
+        x: 200
         y: 0


### PR DESCRIPTION
## Which problem is this PR solving?
* Fixes https://github.com/honeycombio/pipeline-team/issues/320
* The nodes are much bigger now due to this PR matching the elements to look more like the Figma design: https://github.com/honeycombio/hound/pull/23956
  * The original positions in the templates were picked based on the smaller nodes, now that the new design is implemented and the nodes are bigger, it's causing the nodes to either overlap or look wonky like below:
  ![image](https://github.com/user-attachments/assets/e57e0eb9-8b8a-4dbc-8eb1-b54694b34ff8)

## Short description of the changes
This PR just moves the nodes in the template further apart from each other 😄 

* Default Template:
  ![image](https://github.com/user-attachments/assets/4230549c-c7d2-4ce3-af8a-62ea2ce1bc8b)

* Proxy Template:
  ![image](https://github.com/user-attachments/assets/831b9cdb-5b8e-4bd8-b24b-1d6a29d345ca)

* EMA Throughput Template:
  ![image](https://github.com/user-attachments/assets/692e76e4-4a1d-42c4-bdd6-1721ba1d4aa2)