### PR TITLE
fix: TraceConverter default values

### DIFF
--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -35,17 +35,18 @@ properties:
     type: string
     validations:
       - noblanks
-    default: ${STRAWS_REFINERY_POD_IP}
+    default: ${STRAWS_REFINERY_SERVICE}
     advanced: true
   - name: Port
     summary: The port on which Refinery is listening for HTTP traffic.
     description: |
       The port on which Refinery listens for incoming HTTP traffic.
-      The OTel default is 4318. Set to 0 to disable HTTP.
+      The default is 80. It is recommended not to change the default unless
+      you know what you're doing.
     type: int
     validations:
       - inrange(1, 65535)
-    default: 4318
+    default: 80
     advanced: true
   - name: Headers
     summary: Headers to emit when sending HTTP traffic.
@@ -54,10 +55,11 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
-  - name: Insecure
-    summary: Provide a way to disable TLS export.
+  - name: Secure
+    summary: Provide a way to enable TLS export.
     description: |
-      Can be used to send data without TLS.
+      Can be used to send data with TLS.
+      Since Refinery does not use TLS, this is off by default.
     type: bool
     default: false
     advanced: true
@@ -71,10 +73,10 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
+        value: "http{{ if (firstNonZero .HProps.Secure .User.Secure .Props.Secure.Default) }}s{{ end }}://{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.tls.insecure"
-        value: "{{ .HProps.Insecure | encodeAsBool }}"
-        suppress_if: "{{ not .HProps.Insecure }}"
+        value: "{{ not (firstNonZero .HProps.Secure .User.Secure .Props.Secure.Default) | encodeAsBool }}"
+        suppress_if: "{{ firstNonZero .HProps.Secure .User.Secure .Props.Secure.Default }}"
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -55,7 +55,7 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
-  - name: Secure
+  - name: UseTLS
     summary: Provide a way to enable TLS export.
     description: |
       Can be used to send data with TLS.
@@ -73,10 +73,10 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "http{{ if (firstNonZero .HProps.Secure .User.Secure .Props.Secure.Default) }}s{{ end }}://{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
+        value: "http{{ if (firstNonZero .HProps.UseTLS .User.UseTLS .Props.UseTLS.Default) }}s{{ end }}://{{ firstNonZero .HProps.Host .User.Host .Props.Host.Default }}:{{ firstNonZero .HProps.Port .User.Port .Props.Port.Default }}"
       - key: "{{ .ComponentName }}.tls.insecure"
-        value: "{{ not (firstNonZero .HProps.Secure .User.Secure .Props.Secure.Default) | encodeAsBool }}"
-        suppress_if: "{{ firstNonZero .HProps.Secure .User.Secure .Props.Secure.Default }}"
+        value: "{{ not (firstNonZero .HProps.UseTLS .User.UseTLS .Props.UseTLS.Default) | encodeAsBool }}"
+        suppress_if: "{{ firstNonZero .HProps.UseTLS .User.UseTLS .Props.UseTLS.Default }}"
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"

--- a/pkg/translator/testdata/collector_config/traceconverter_all.yaml
+++ b/pkg/translator/testdata/collector_config/traceconverter_all.yaml
@@ -10,12 +10,10 @@ processors:
     usage: {}
 exporters:
     otlphttp/Trace_Converter_1:
-        endpoint: myhost.com:1234
+        endpoint: https://myhost.com:1234
         headers:
             x-honeycomb-dataset: custom
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
-        tls:
-            insecure: true
 extensions:
     honeycomb: {}
 service:

--- a/pkg/translator/testdata/collector_config/traceconverter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/traceconverter_defaults.yaml
@@ -10,7 +10,9 @@ processors:
     usage: {}
 exporters:
     otlphttp/Trace_Converter_1:
-        endpoint: ${STRAWS_REFINERY_POD_IP}:4318
+        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+        tls:
+            insecure: true
 extensions:
     honeycomb: {}
 service:

--- a/pkg/translator/testdata/hpsf/traceconverter_all.yaml
+++ b/pkg/translator/testdata/hpsf/traceconverter_all.yaml
@@ -12,7 +12,7 @@ components:
         value:
           x-honeycomb-dataset: "custom"
           x-honeycomb-team: "${HONEYCOMB_API_KEY}"
-      - name: Insecure
+      - name: Secure
         value: true
 connections:
   - source:

--- a/pkg/translator/testdata/hpsf/traceconverter_all.yaml
+++ b/pkg/translator/testdata/hpsf/traceconverter_all.yaml
@@ -12,7 +12,7 @@ components:
         value:
           x-honeycomb-dataset: "custom"
           x-honeycomb-team: "${HONEYCOMB_API_KEY}"
-      - name: Secure
+      - name: UseTLS
         value: true
 connections:
   - source:


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes https://github.com/honeycombio/pipeline-team/issues/383

We found the following issues with the traceconverter default install:
1. it uses the `{STRAWS_REFINERY_POD_IP}` env var that the collector does not have access to. 
2. Sets default otlp http port to 4318, but refinery listens for otlp http on port 80
3. Configures the otlphttp exporter to communicate using TLS, but Refinery is not using TLS.
4. The property is named Host, which implies a schema (http/https) does not need to be provided, but the default does not provide it.

## Short description of the changes

- Updated env var to `${STRAWS_REFINERY_SERVICE}`. We'll update the helm chart to set this env var using the refinery service name it generates: https://github.com/honeycombio/helm-charts/pull/488
- update default port to 80
- update default TLS to be insecure. We changed the property name to be `Secure` instead of `Insecure` so a default value of `false` meant that the exporter would be rendered with `insecure: true`. We needed to inverted it since setting a boolean property to `false` via the HPSF config is not possible; the engine sees that as "not set".
- update rendered endpoint to set `http`/`https` based on `Secure` property.

