### PR TITLE
fix: honecyomb exporter default values

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -26,6 +26,7 @@ properties:
     validations:
       - noblanks
     default: ${HONEYCOMB_EXPORTER_APIKEY}
+    advanced: true
   - name: APIEndpoint
     summary: The Endpoint URL of the Honeycomb API
     description: |
@@ -37,6 +38,19 @@ properties:
       - url
     default: https://api.honeycomb.io
     advanced: true
+  - name: Mode
+    summary: Configures when to use the the APIKey.
+    description: |
+      Allows configuring when the exporter uses the APIKey.
+      Valid values are 'all' and 'none'.
+      The value 'none' means that the APIKey will
+      not be used. Defaults to 'all', which means all
+      the traffic will be exported using the configured APIKey.
+    type: string
+    validations:
+      - oneof(all, none)
+    default: all
+    advanced: true
 templates:
   - kind: refinery_config
     name: HoneycombExporter_RefineryConfig
@@ -45,7 +59,7 @@ templates:
       - key: Network.HoneycombAPI
         value: "{{ firstNonZero .HProps.APIEndpoint .User.APIEndpoint .Props.APIEndpoint.Default }}"
       - key: AccessKeys.SendKey
-        value: "{{ firstNonZero .HProps.APIKey .User.APIKey }}"
+        value: "{{ firstNonZero .HProps.APIKey .User.APIKey .Props.APIKey.Default }}"
+        suppress_if: '{{ eq "none" (firstNonZero .HProps.APIKey .User.APIKey) }}'
       - key: AccessKeys.SendKeyMode
-        value: "all"
-        suppress_if: "{{ not (nonempty (firstNonZero .HProps.APIKey .User.APIKey)) }}"
+        value: "{{ firstNonZero .HProps.Mode .User.Mode .Props.Mode.Default }}"

--- a/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
@@ -8,6 +8,8 @@ components:
         value: https://alternative.honeycomb.io
       - name: APIKey
         value: abcdef1234567890abcdef1  # a validly-formatted key
+      - name: Mode
+        value: none
 connections:
   - source:
       component: honeycomb_in

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_all.yaml
@@ -1,6 +1,6 @@
 AccessKeys:
     SendKey: abcdef1234567890abcdef1
-    SendKeyMode: all
+    SendKeyMode: none
 General:
     ConfigurationVersion: 2
     MinRefineryVersion: v2.0

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_defaults.yaml
@@ -1,5 +1,6 @@
 AccessKeys:
-    SendKey: ""
+    SendKey: ${HONEYCOMB_EXPORTER_APIKEY}
+    SendKeyMode: all
 General:
     ConfigurationVersion: 2
     MinRefineryVersion: v2.0


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes https://github.com/honeycombio/pipeline-team/issues/382

## Short description of the changes

- update template to use default APIKey value
- add new property to allow disabling Send Key
- update test files.

