### PR TITLE
feat: update s3 exporter with batch config

### DIFF
--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -76,17 +76,17 @@ properties:
       Configure how long to wait before sending a batch. The batch will be sent after
       this timeout even if min size has not been met.
     type: duration
-    default: 60s
+    default: 30s
     validations:
       - duration
       - nonempty
     advanced: true
-  - name: BatchMaxSize
-    summary: Max size of a batch.
+  - name: BatchSize
+    summary: The size of a batch.
     description: |
-      The max size of a batch. Once a batch reaches this size it will be sent.
+      The size of a batch. Once a batch reaches this size it will be sent.
     type: int
-    default: 100_000_000
+    default: 50_000_000
     validations:
       - nonempty
     advanced: true
@@ -125,6 +125,6 @@ templates:
       - key: "{{ .ComponentName }}.sending_queue.flush_timeout"
         value: "{{ .Values.BatchTimeout }}"
       - key: "{{ .ComponentName }}.sending_queue.min_size"
-        value: "{{ 1 | encodeAsInt }}"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
       - key: "{{ .ComponentName }}.sending_queue.max_size"
-        value: "{{ .Values.BatchMaxSize | encodeAsInt }}"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"

--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -76,7 +76,7 @@ properties:
       Configure how long to wait before sending a batch. The batch will be sent after
       this timeout even if min size has not been met.
     type: duration
-    default: 30s
+    default: 60s
     validations:
       - duration
       - nonempty
@@ -84,9 +84,19 @@ properties:
   - name: BatchSize
     summary: The size of a batch.
     description: |
-      The size of a batch. Once a batch reaches this size it will be sent.
+      The size of a batch, measured by span/datapoint/log record count. Once a batch reaches this size it will be sent.
     type: int
-    default: 50_000_000
+    default: 100_000
+    validations:
+      - nonempty
+    advanced: true
+  - name: QueueSize
+    summary: The size of a exporting queue.
+    description: |
+      The size of the exporting queue, measured by span/datapoint/log record count.
+      Items will be kept in the queue while the batch is being created.
+    type: int
+    default: 1_000_000
     validations:
       - nonempty
     advanced: true
@@ -118,10 +128,12 @@ templates:
         suppress_if: "{{ not .HProps.Marshaler }}"
       - key: "{{ .ComponentName }}.compression"
         value: "gzip"
+      - key: "{{ .ComponentName }}.sending_queue.queue_size"
+        value: "{{ .Values.QueueSize | encodeAsInt }}"
       - key: "{{ .ComponentName }}.sending_queue.enabled"
         value: "{{ true | encodeAsBool}}"
       - key: "{{ .ComponentName }}.sending_queue.sizer"
-        value: "bytes"
+        value: "items"
       - key: "{{ .ComponentName }}.sending_queue.flush_timeout"
         value: "{{ .Values.BatchTimeout }}"
       - key: "{{ .ComponentName }}.sending_queue.min_size"

--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -70,6 +70,26 @@ properties:
     validations:
       - oneof(otlp_json, otlp_proto)
     advanced: true
+  - name: BatchTimeout
+    summary: How long to wait to before sending a batch, regardless of size.
+    description: |
+      Configure how long to wait before sending a batch. The batch will be sent after
+      this timeout even if min size has not been met.
+    type: duration
+    default: 60s
+    validations:
+      - duration
+      - nonempty
+    advanced: true
+  - name: BatchMaxSize
+    summary: Max size of a batch.
+    description: |
+      The max size of a batch. Once a batch reaches this size it will be sent.
+    type: int
+    default: 100_000_000
+    validations:
+      - nonempty
+    advanced: true
 templates:
   - name: s3_exporter_collector
     kind: collector_config
@@ -96,3 +116,15 @@ templates:
       - key: "{{ .ComponentName }}.marshaler"
         value: "{{ .Values.Marshaler }}"
         suppress_if: "{{ not .HProps.Marshaler }}"
+      - key: "{{ .ComponentName }}.compression"
+        value: "gzip"
+      - key: "{{ .ComponentName }}.sending_queue.enabled"
+        value: "{{ true | encodeAsBool}}"
+      - key: "{{ .ComponentName }}.sending_queue.sizer"
+        value: "bytes"
+      - key: "{{ .ComponentName }}.sending_queue.flush_timeout"
+        value: "{{ .Values.BatchTimeout }}"
+      - key: "{{ .ComponentName }}.sending_queue.min_size"
+        value: "{{ 1 | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.max_size"
+        value: "{{ .Values.BatchMaxSize | encodeAsInt }}"

--- a/pkg/data/components/S3Exporter.yaml
+++ b/pkg/data/components/S3Exporter.yaml
@@ -74,7 +74,7 @@ properties:
     summary: How long to wait to before sending a batch, regardless of size.
     description: |
       Configure how long to wait before sending a batch. The batch will be sent after
-      this timeout even if min size has not been met.
+      this timeout.
     type: duration
     default: 60s
     validations:

--- a/pkg/translator/testdata/collector_config/s3exporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_all.yaml
@@ -19,10 +19,11 @@ exporters:
             s3_prefix: my-prefix
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 90000000
-            min_size: 90000000
-            sizer: bytes
+            flush_timeout: 30s
+            max_size: 200000
+            min_size: 200000
+            queue_size: 2000000
+            sizer: items
         timeout: 30s
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/s3exporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_all.yaml
@@ -19,9 +19,9 @@ exporters:
             s3_prefix: my-prefix
         sending_queue:
             enabled: true
-            flush_timeout: 30s
-            max_size: 50000000
-            min_size: 1
+            flush_timeout: 60s
+            max_size: 90000000
+            min_size: 90000000
             sizer: bytes
         timeout: 30s
 extensions:

--- a/pkg/translator/testdata/collector_config/s3exporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_all.yaml
@@ -10,12 +10,19 @@ processors:
     usage: {}
 exporters:
     awss3/s3_out:
+        compression: gzip
         marshaler: otlp_json
         s3uploader:
             region: my-region
             s3_bucket: my-bucket
             s3_partition_format: my-partition-format
             s3_prefix: my-prefix
+        sending_queue:
+            enabled: true
+            flush_timeout: 30s
+            max_size: 50000000
+            min_size: 1
+            sizer: bytes
         timeout: 30s
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
@@ -15,9 +15,9 @@ exporters:
             s3_bucket: my-bucket
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000000
-            min_size: 1
+            flush_timeout: 30s
+            max_size: 50000000
+            min_size: 50000000
             sizer: bytes
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
@@ -10,8 +10,15 @@ processors:
     usage: {}
 exporters:
     awss3/s3_out:
+        compression: gzip
         s3uploader:
             s3_bucket: my-bucket
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000000
+            min_size: 1
+            sizer: bytes
 extensions:
     honeycomb: {}
 service:

--- a/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
@@ -15,10 +15,11 @@ exporters:
             s3_bucket: my-bucket
         sending_queue:
             enabled: true
-            flush_timeout: 30s
-            max_size: 50000000
-            min_size: 50000000
-            sizer: bytes
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:

--- a/pkg/translator/testdata/hpsf/s3exporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/s3exporter_all.yaml
@@ -16,6 +16,10 @@ components:
         value: 30s
       - name: Marshaler
         value: otlp_json
+      - name: BatchTimeout
+        value: 30s
+      - name: BatchMaxSize
+        value: 50_000_000
 connections:
   - source:
       component: otlp_in

--- a/pkg/translator/testdata/hpsf/s3exporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/s3exporter_all.yaml
@@ -17,9 +17,9 @@ components:
       - name: Marshaler
         value: otlp_json
       - name: BatchTimeout
-        value: 30s
-      - name: BatchMaxSize
-        value: 50_000_000
+        value: 60s
+      - name: BatchSize
+        value: 90_000_000
 connections:
   - source:
       component: otlp_in

--- a/pkg/translator/testdata/hpsf/s3exporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/s3exporter_all.yaml
@@ -17,9 +17,11 @@ components:
       - name: Marshaler
         value: otlp_json
       - name: BatchTimeout
-        value: 60s
+        value: 30s
       - name: BatchSize
-        value: 90_000_000
+        value: 200_000
+      - name: QueueSize
+        value: 2_000_000
 connections:
   - source:
       component: otlp_in


### PR DESCRIPTION
## Which problem is this PR solving?

- closes https://github.com/honeycombio/pipeline-team/issues/318

## Short description of the changes

- add configuration specific to data activation. flush timeout and batch size are configurable, but the sizer unit is not. We're using `items` instead of `bytes` based on some testing that found `bytes` was incredible inefficient in the collector.

