### PR TITLE
maint: Use numbers wherever possible in sampler

### DIFF
--- a/pkg/config/rulestemplate.go
+++ b/pkg/config/rulestemplate.go
@@ -47,10 +47,25 @@ func (r *rulesCondition) Render(prefix string) (map[string]any, error) {
 		dc[c+".Datatype"] = "string"
 	case "int", "i":
 		dc[c+".Datatype"] = "int"
+		if cv, err := strconv.Atoi(r.value); err != nil {
+			return nil, fmt.Errorf("value %q is not a valid int for datatype int", r.value)
+		} else {
+			dc[c+".Value"] = cv
+		}
 	case "float", "f":
 		dc[c+".Datatype"] = "float"
+		if cv, err := strconv.ParseFloat(r.value, 64); err != nil {
+			return nil, fmt.Errorf("value %q is not a valid float for datatype float", r.value)
+		} else {
+			dc[c+".Value"] = cv
+		}
 	case "bool", "b":
 		dc[c+".Datatype"] = "bool"
+		if r.value == "true" || r.value == "false" {
+			dc[c+".Value"] = r.value
+		} else {
+			return nil, fmt.Errorf("value %q is not a valid bool for datatype bool", r.value)
+		}
 	case "":
 		// if the datatype is empty, don't set it
 	default:

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -374,6 +374,12 @@ func (t *TemplateComponent) applyTemplate(tmplVal any, userdata map[string]any) 
 		return k, nil
 	case []string:
 		return k, nil
+	case int:
+		return k, nil
+	case float64:
+		return k, nil
+	case bool:
+		return k, nil
 	default:
 		return "", fmt.Errorf("invalid templated variable type %T", k)
 	}

--- a/pkg/data/components/SampleErrors.yaml
+++ b/pkg/data/components/SampleErrors.yaml
@@ -67,16 +67,16 @@ templates:
       - key: Rules[0].Name
         value: "Sample 500 statuses at {{ .Values.ErrorRate }}"
       - key: Rules[0].SampleRate
-        value: "{{ .Values.ErrorRate }}"
+        value: "{{ .Values.ErrorRate | encodeAsInt }}"
       - key: "Rules[0].!condition!"
         value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=500"
       - key: Rules[1].Name
         value: "Sample 400 statuses at {{ .Values.UserErrorRate }}"
       - key: Rules[1].SampleRate
-        value: "{{ .Values.UserErrorRate }}"
+        value: "{{ .Values.UserErrorRate | encodeAsInt }}"
       - key: "Rules[1].!condition!"
         value: "ix=0;fs=http.status_code,http.response.status_code;o=>=;d=i;v=400"
       - key: Rules[2].Name
         value: "Sample remainder at {{ .Values.DefaultRate }}"
       - key: Rules[2].SampleRate
-        value: "{{ .Values.DefaultRate }}"
+        value: "{{ .Values.DefaultRate | encodeAsInt }}"

--- a/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
@@ -9,17 +9,17 @@ Samplers:
                         - http.status_code
                         - http.response.status_code
                       Operator: '>='
-                      Value: "500"
+                      Value: 500
                   Name: Sample 500 statuses at 1
-                  SampleRate: "1"
+                  SampleRate: 1
                 - Conditions:
                     - Datatype: int
                       Fields:
                         - http.status_code
                         - http.response.status_code
                       Operator: '>='
-                      Value: "400"
+                      Value: 400
                   Name: Sample 400 statuses at 10
-                  SampleRate: "10"
+                  SampleRate: 10
                 - Name: Sample remainder at 100
-                  SampleRate: "100"
+                  SampleRate: 100


### PR DESCRIPTION
## Which problem is this PR solving?

- The sampler was generating a lot of strings where numbers should have been. This fixes that

## Short description of the changes

- Use encodeAsInt for sample rates
- Make the condition encoder smarter
- Don't insist on strings in the templates
- Fix a test

