### PR TITLE
feat: use batch config in exporters

### DIFF
--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -70,19 +70,6 @@ func (f *collectorConfigFormat) injectHoneycombUsageComponents() {
 	}
 }
 
-// injectBatchProcessor ensures the collector configuration always has the necessary components
-// for batching records together.
-func (f *collectorConfigFormat) injectBatchProcessor() {
-	// ensure the batch is configured for all pipelines
-	if f.Processors == nil {
-		f.Processors = make(map[string]any)
-	}
-	f.Processors["batch"] = map[string]any{}
-	for _, x := range f.Service.Pipelines {
-		x.Processors = append(x.Processors, "batch")
-	}
-}
-
 func dedup[T comparable](slice []T) []T {
 	keys := make(map[T]struct{})
 	list := []T{}
@@ -174,7 +161,6 @@ func (cc *CollectorConfig) RenderYAML() ([]byte, error) {
 	}
 
 	f.injectHoneycombUsageComponents()
-	f.injectBatchProcessor()
 
 	// now marshal from the struct to yaml
 	data, err = y.Marshal(f)

--- a/pkg/config/tmpl/collectorconfig_test.go
+++ b/pkg/config/tmpl/collectorconfig_test.go
@@ -18,7 +18,6 @@ receivers:
         endpoint: localhost
         port: "4317"
 processors:
-    batch: {}
     usage: {}
 extensions:
     honeycomb: {}
@@ -27,7 +26,7 @@ service:
     pipelines:
         traces:
             receivers: [otlp]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: []
 `
 	got, err := cc.RenderYAML()

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -59,6 +59,36 @@ properties:
     type: bool
     default: false
     advanced: true
+  - name: BatchTimeout
+    summary: How long to wait to before sending a batch, regardless of size.
+    description: |
+      Configure how long to wait before sending a batch. The batch will be sent after
+      this timeout.
+    type: duration
+    default: 60s
+    validations:
+      - duration
+      - nonempty
+    advanced: true
+  - name: BatchSize
+    summary: The size of a batch.
+    description: |
+      The size of a batch, measured by span/datapoint/log record count. Once a batch reaches this size it will be sent.
+    type: int
+    default: 100_000
+    validations:
+      - nonempty
+    advanced: true
+  - name: QueueSize
+    summary: The size of a exporting queue.
+    description: |
+      The size of the exporting queue, measured by span/datapoint/log record count.
+      Items will be kept in the queue while the batch is being created.
+    type: int
+    default: 1_000_000
+    validations:
+      - nonempty
+    advanced: true
 templates:
   - kind: collector_config
     name: otel_grpc_exporter_collector
@@ -76,4 +106,16 @@ templates:
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"
+      - key: "{{ .ComponentName }}.sending_queue.queue_size"
+        value: "{{ .Values.QueueSize | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.enabled"
+        value: "{{ true | encodeAsBool}}"
+      - key: "{{ .ComponentName }}.sending_queue.sizer"
+        value: "items"
+      - key: "{{ .ComponentName }}.sending_queue.flush_timeout"
+        value: "{{ .Values.BatchTimeout }}"
+      - key: "{{ .ComponentName }}.sending_queue.min_size"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.max_size"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -65,7 +65,7 @@ properties:
       Configure how long to wait before sending a batch. The batch will be sent after
       this timeout.
     type: duration
-    default: 60s
+    default: 200ms
     validations:
       - duration
       - nonempty
@@ -75,7 +75,7 @@ properties:
     description: |
       The size of a batch, measured by span/datapoint/log record count. Once a batch reaches this size it will be sent.
     type: int
-    default: 100_000
+    default: 8192
     validations:
       - nonempty
     advanced: true
@@ -85,7 +85,7 @@ properties:
       The size of the exporting queue, measured by span/datapoint/log record count.
       Items will be kept in the queue while the batch is being created.
     type: int
-    default: 1_000_000
+    default: 100_000
     validations:
       - nonempty
     advanced: true

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -65,7 +65,7 @@ properties:
       Configure how long to wait before sending a batch. The batch will be sent after
       this timeout.
     type: duration
-    default: 60s
+    default: 200ms
     validations:
       - duration
       - nonempty
@@ -75,7 +75,7 @@ properties:
     description: |
       The size of a batch, measured by span/datapoint/log record count. Once a batch reaches this size it will be sent.
     type: int
-    default: 100_000
+    default: 8192
     validations:
       - nonempty
     advanced: true
@@ -85,7 +85,7 @@ properties:
       The size of the exporting queue, measured by span/datapoint/log record count.
       Items will be kept in the queue while the batch is being created.
     type: int
-    default: 1_000_000
+    default: 100_000
     validations:
       - nonempty
     advanced: true

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -59,6 +59,36 @@ properties:
     type: bool
     default: false
     advanced: true
+  - name: BatchTimeout
+    summary: How long to wait to before sending a batch, regardless of size.
+    description: |
+      Configure how long to wait before sending a batch. The batch will be sent after
+      this timeout.
+    type: duration
+    default: 60s
+    validations:
+      - duration
+      - nonempty
+    advanced: true
+  - name: BatchSize
+    summary: The size of a batch.
+    description: |
+      The size of a batch, measured by span/datapoint/log record count. Once a batch reaches this size it will be sent.
+    type: int
+    default: 100_000
+    validations:
+      - nonempty
+    advanced: true
+  - name: QueueSize
+    summary: The size of a exporting queue.
+    description: |
+      The size of the exporting queue, measured by span/datapoint/log record count.
+      Items will be kept in the queue while the batch is being created.
+    type: int
+    default: 1_000_000
+    validations:
+      - nonempty
+    advanced: true
 templates:
   - kind: collector_config
     name: otel_http_exporter_collector
@@ -76,4 +106,16 @@ templates:
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"
+      - key: "{{ .ComponentName }}.sending_queue.queue_size"
+        value: "{{ .Values.QueueSize | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.enabled"
+        value: "{{ true | encodeAsBool}}"
+      - key: "{{ .ComponentName }}.sending_queue.sizer"
+        value: "items"
+      - key: "{{ .ComponentName }}.sending_queue.flush_timeout"
+        value: "{{ .Values.BatchTimeout }}"
+      - key: "{{ .ComponentName }}.sending_queue.min_size"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.max_size"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -63,9 +63,39 @@ properties:
     type: bool
     default: false
     advanced: true
+  - name: BatchTimeout
+    summary: How long to wait to before sending a batch, regardless of size.
+    description: |
+      Configure how long to wait before sending a batch. The batch will be sent after
+      this timeout.
+    type: duration
+    default: 60s
+    validations:
+      - duration
+      - nonempty
+    advanced: true
+  - name: BatchSize
+    summary: The size of a batch.
+    description: |
+      The size of a batch, measured by span/log record count. Once a batch reaches this size it will be sent.
+    type: int
+    default: 100_000
+    validations:
+      - nonempty
+    advanced: true
+  - name: QueueSize
+    summary: The size of a exporting queue.
+    description: |
+      The size of the exporting queue, measured by span/log record count.
+      Items will be kept in the queue while the batch is being created.
+    type: int
+    default: 1_000_000
+    validations:
+      - nonempty
+    advanced: true
 templates:
   - kind: collector_config
-    name: otel_receiver_collector
+    name: otel_http_exporter_collector
     format: collector
     meta:
       componentSection: exporters
@@ -80,4 +110,16 @@ templates:
       - key: "{{ .ComponentName }}.headers"
         value: "{{ .HProps.Headers | encodeAsMap }}"
         suppress_if: "{{ not .HProps.Headers }}"
+      - key: "{{ .ComponentName }}.sending_queue.queue_size"
+        value: "{{ .Values.QueueSize | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.enabled"
+        value: "{{ true | encodeAsBool}}"
+      - key: "{{ .ComponentName }}.sending_queue.sizer"
+        value: "items"
+      - key: "{{ .ComponentName }}.sending_queue.flush_timeout"
+        value: "{{ .Values.BatchTimeout }}"
+      - key: "{{ .ComponentName }}.sending_queue.min_size"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
+      - key: "{{ .ComponentName }}.sending_queue.max_size"
+        value: "{{ .Values.BatchSize | encodeAsInt }}"
       # service is not part of the template, it's generated automatically by the collectorConfig

--- a/pkg/data/components/TraceConverter.yaml
+++ b/pkg/data/components/TraceConverter.yaml
@@ -69,7 +69,7 @@ properties:
       Configure how long to wait before sending a batch. The batch will be sent after
       this timeout.
     type: duration
-    default: 60s
+    default: 200ms
     validations:
       - duration
       - nonempty
@@ -77,19 +77,19 @@ properties:
   - name: BatchSize
     summary: The size of a batch.
     description: |
-      The size of a batch, measured by span/log record count. Once a batch reaches this size it will be sent.
+      The size of a batch, measured by span/datapoint/log record count. Once a batch reaches this size it will be sent.
     type: int
-    default: 100_000
+    default: 8192
     validations:
       - nonempty
     advanced: true
   - name: QueueSize
     summary: The size of a exporting queue.
     description: |
-      The size of the exporting queue, measured by span/log record count.
+      The size of the exporting queue, measured by span/datapoint/log record count.
       Items will be kept in the queue while the batch is being created.
     type: int
-    default: 1_000_000
+    default: 100_000
     validations:
       - nonempty
     advanced: true

--- a/pkg/translator/testdata/collector_config/default.yaml
+++ b/pkg/translator/testdata/collector_config/default.yaml
@@ -6,13 +6,19 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlphttp/OTel_HTTP_Exporter_1:
         endpoint: https://api.honeycomb.io:443
         headers:
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -20,13 +26,13 @@ service:
     pipelines:
         logs:
             receivers: [otlp/OTel_Receiver_1]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/OTel_HTTP_Exporter_1]
         metrics:
             receivers: [otlp/OTel_Receiver_1]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/OTel_HTTP_Exporter_1]
         traces:
             receivers: [otlp/OTel_Receiver_1]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/OTel_HTTP_Exporter_1]

--- a/pkg/translator/testdata/collector_config/default.yaml
+++ b/pkg/translator/testdata/collector_config/default.yaml
@@ -14,10 +14,10 @@ exporters:
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     filter/drop_container_1:
         traces:
             span:
@@ -15,6 +14,13 @@ processors:
 exporters:
     otlphttp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -22,5 +28,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, filter/drop_container_1, batch]
+            processors: [usage, filter/drop_container_1]
             exporters: [otlphttp/otlp_out]

--- a/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
@@ -16,10 +16,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
@@ -12,10 +12,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
@@ -6,11 +6,17 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlphttp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -18,5 +24,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/otlp_out]

--- a/pkg/translator/testdata/collector_config/logdeduplicationprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/logdeduplicationprocessor_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     logdedup/DedupMyLogs:
         interval: 10s
         log_count_attribute: another_value
@@ -14,6 +13,13 @@ processors:
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -21,5 +27,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp/otlp_in]
-            processors: [usage, logdedup/DedupMyLogs, batch]
+            processors: [usage, logdedup/DedupMyLogs]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/logdeduplicationprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/logdeduplicationprocessor_all.yaml
@@ -15,10 +15,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/logdeduplicationprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/logdeduplicationprocessor_defaults.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     logdedup/DedupMyLogs:
         interval: 60s
         log_count_attribute: sampleRate
@@ -14,6 +13,13 @@ processors:
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -21,5 +27,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp/otlp_in]
-            processors: [usage, logdedup/DedupMyLogs, batch]
+            processors: [usage, logdedup/DedupMyLogs]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/logdeduplicationprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/logdeduplicationprocessor_defaults.yaml
@@ -15,10 +15,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/nopexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/nopexporter_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     nop/otlp_out: {}
@@ -17,5 +16,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [nop/otlp_out]

--- a/pkg/translator/testdata/collector_config/nopexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/nopexporter_defaults.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     nop/otlp_out: {}
@@ -17,5 +16,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [nop/otlp_out]

--- a/pkg/translator/testdata/collector_config/nopreceiver_all.yaml
+++ b/pkg/translator/testdata/collector_config/nopreceiver_all.yaml
@@ -7,10 +7,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/nopreceiver_all.yaml
+++ b/pkg/translator/testdata/collector_config/nopreceiver_all.yaml
@@ -1,11 +1,17 @@
 receivers:
     nop/otlp_in: {}
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -13,5 +19,5 @@ service:
     pipelines:
         logs:
             receivers: [nop/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/nopreceiver_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/nopreceiver_defaults.yaml
@@ -7,10 +7,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/nopreceiver_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/nopreceiver_defaults.yaml
@@ -1,11 +1,17 @@
 receivers:
     nop/otlp_in: {}
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -13,5 +19,5 @@ service:
     pipelines:
         logs:
             receivers: [nop/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/oteldebugexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/oteldebugexporter_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     debug/otlp_out:
@@ -18,5 +17,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [debug/otlp_out]

--- a/pkg/translator/testdata/collector_config/oteldebugexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/oteldebugexporter_defaults.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     debug/otlp_out:
@@ -18,5 +17,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [debug/otlp_out]

--- a/pkg/translator/testdata/collector_config/otelgrpcexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelgrpcexporter_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlp/otlp_out:
@@ -14,6 +13,13 @@ exporters:
         headers:
             x-honeycomb-dataset: custom
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
+        sending_queue:
+            enabled: true
+            flush_timeout: 30s
+            max_size: 200000
+            min_size: 200000
+            queue_size: 2000000
+            sizer: items
         tls:
             insecure: true
 extensions:
@@ -23,5 +29,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/otelgrpcexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelgrpcexporter_defaults.yaml
@@ -12,10 +12,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/otelgrpcexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelgrpcexporter_defaults.yaml
@@ -6,11 +6,17 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -18,5 +24,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlphttp/otlp_out:
@@ -14,6 +13,13 @@ exporters:
         headers:
             x-honeycomb-dataset: custom
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
+        sending_queue:
+            enabled: true
+            flush_timeout: 30s
+            max_size: 200000
+            min_size: 200000
+            queue_size: 2000000
+            sizer: items
         tls:
             insecure: true
 extensions:
@@ -23,5 +29,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/otlp_out]

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
@@ -12,10 +12,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
@@ -6,11 +6,17 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlphttp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -18,5 +24,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/otlp_out]

--- a/pkg/translator/testdata/collector_config/otelreceiver_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelreceiver_all.yaml
@@ -12,10 +12,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/otelreceiver_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelreceiver_all.yaml
@@ -6,11 +6,17 @@ receivers:
             http:
                 endpoint: testtest:1234
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -18,5 +24,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/otelreceiver_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelreceiver_defaults.yaml
@@ -12,10 +12,10 @@ exporters:
         endpoint: https://api.honeycomb.io:443
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
 extensions:
     honeycomb: {}

--- a/pkg/translator/testdata/collector_config/otelreceiver_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelreceiver_defaults.yaml
@@ -6,11 +6,17 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlp/otlp_out:
         endpoint: https://api.honeycomb.io:443
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -18,5 +24,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlp/otlp_out]

--- a/pkg/translator/testdata/collector_config/s3exporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     awss3/s3_out:
@@ -32,5 +31,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [awss3/s3_out]

--- a/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/s3exporter_defaults.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     awss3/s3_out:
@@ -27,5 +26,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [awss3/s3_out]

--- a/pkg/translator/testdata/collector_config/traceconverter_all.yaml
+++ b/pkg/translator/testdata/collector_config/traceconverter_all.yaml
@@ -6,7 +6,6 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlphttp/Trace_Converter_1:
@@ -14,6 +13,13 @@ exporters:
         headers:
             x-honeycomb-dataset: custom
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
+        sending_queue:
+            enabled: true
+            flush_timeout: 30s
+            max_size: 200000
+            min_size: 200000
+            queue_size: 2000000
+            sizer: items
 extensions:
     honeycomb: {}
 service:
@@ -21,5 +27,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/Trace_Converter_1]

--- a/pkg/translator/testdata/collector_config/traceconverter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/traceconverter_defaults.yaml
@@ -6,11 +6,17 @@ receivers:
             http:
                 endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
 processors:
-    batch: {}
     usage: {}
 exporters:
     otlphttp/Trace_Converter_1:
         endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+        sending_queue:
+            enabled: true
+            flush_timeout: 60s
+            max_size: 100000
+            min_size: 100000
+            queue_size: 1000000
+            sizer: items
         tls:
             insecure: true
 extensions:
@@ -20,5 +26,5 @@ service:
     pipelines:
         traces:
             receivers: [otlp/otlp_in]
-            processors: [usage, batch]
+            processors: [usage]
             exporters: [otlphttp/Trace_Converter_1]

--- a/pkg/translator/testdata/collector_config/traceconverter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/traceconverter_defaults.yaml
@@ -12,10 +12,10 @@ exporters:
         endpoint: http://${STRAWS_REFINERY_SERVICE}:80
         sending_queue:
             enabled: true
-            flush_timeout: 60s
-            max_size: 100000
-            min_size: 100000
-            queue_size: 1000000
+            flush_timeout: 200ms
+            max_size: 8192
+            min_size: 8192
+            queue_size: 100000
             sizer: items
         tls:
             insecure: true

--- a/pkg/translator/testdata/hpsf/otelgrpcexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/otelgrpcexporter_all.yaml
@@ -14,6 +14,12 @@ components:
           x-honeycomb-team: "${HONEYCOMB_API_KEY}"
       - name: Insecure
         value: true
+      - name: BatchTimeout
+        value: 30s
+      - name: BatchSize
+        value: 200_000
+      - name: QueueSize
+        value: 2_000_000
 connections:
   - source:
       component: otlp_in

--- a/pkg/translator/testdata/hpsf/otelhttpexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/otelhttpexporter_all.yaml
@@ -14,6 +14,12 @@ components:
           x-honeycomb-team: "${HONEYCOMB_API_KEY}"
       - name: Insecure
         value: true
+      - name: BatchTimeout
+        value: 30s
+      - name: BatchSize
+        value: 200_000
+      - name: QueueSize
+        value: 2_000_000
 connections:
   - source:
       component: otlp_in

--- a/pkg/translator/testdata/hpsf/traceconverter_all.yaml
+++ b/pkg/translator/testdata/hpsf/traceconverter_all.yaml
@@ -14,6 +14,12 @@ components:
           x-honeycomb-team: "${HONEYCOMB_API_KEY}"
       - name: UseTLS
         value: true
+      - name: BatchTimeout
+        value: 30s
+      - name: BatchSize
+        value: 200_000
+      - name: QueueSize
+        value: 2_000_000
 connections:
   - source:
       component: otlp_in


### PR DESCRIPTION
## Which problem is this PR solving?

- This removes the need for the separate batch processor and instead uses the batching configuration on the OTLP exporters directly. It cleans up the code used to inject the batch processor.

## Short description of the changes

- update templates for otel grpc/http exporters and traceconverter
- update the tests

