### PR TITLE
feat: new rules components

### DIFF
--- a/pkg/config/rulestemplate.go
+++ b/pkg/config/rulestemplate.go
@@ -47,25 +47,10 @@ func (r *rulesCondition) Render(prefix string) (map[string]any, error) {
 		dc[c+".Datatype"] = "string"
 	case "int", "i":
 		dc[c+".Datatype"] = "int"
-		if cv, err := strconv.Atoi(r.value); err != nil {
-			return nil, fmt.Errorf("value %q is not a valid int for datatype int", r.value)
-		} else {
-			dc[c+".Value"] = cv
-		}
 	case "float", "f":
 		dc[c+".Datatype"] = "float"
-		if cv, err := strconv.ParseFloat(r.value, 64); err != nil {
-			return nil, fmt.Errorf("value %q is not a valid float for datatype float", r.value)
-		} else {
-			dc[c+".Value"] = cv
-		}
 	case "bool", "b":
 		dc[c+".Datatype"] = "bool"
-		if r.value == "true" || r.value == "false" {
-			dc[c+".Value"] = r.value
-		} else {
-			return nil, fmt.Errorf("value %q is not a valid bool for datatype bool", r.value)
-		}
 	case "":
 		// if the datatype is empty, don't set it
 	default:

--- a/pkg/data/components/KeepErrors.yaml
+++ b/pkg/data/components/KeepErrors.yaml
@@ -33,9 +33,8 @@ properties:
   - name: FieldName
     summary: The name of the field to check for errors.
     description: |
-      The name of the field to check. If this field is not specified,
-      the default is 'error'. If this field exists, the trace will be
-      sampled at the specified rate.
+      The name of the field to check (default 'error'). If a field of this name
+      exists, the trace will be sampled at the specified rate.
     type: string
     default: "error"
   - name: SampleRate

--- a/pkg/data/components/KeepErrors.yaml
+++ b/pkg/data/components/KeepErrors.yaml
@@ -1,0 +1,63 @@
+kind: KeepErrors
+name: Keep Errors
+style: sampler
+type: base
+status: development
+version: v0.1.0
+summary: Keeps traces with errors at a specified rate.
+description: |
+  Any trace that contains any span with an error field will be sampled
+  at the specified rate (default 1). The name of the error field can be
+  overridden (default 'error').
+tags:
+  - category:refinery_rule
+  - service:refinery
+  - vendor:Honeycomb
+  - type:error
+ports:
+  - name: In
+    direction: input
+    type: HoneycombEvents
+  - name: Out
+    direction: output
+    type: HoneycombEvents
+properties:
+  - name: Environment
+    summary: The environment in which to enable the sampler.
+    description: |
+      The environment in which to enable the sampler. If this field is
+      not specified, the sampler will be enabled in the __default__ environment,
+      which is what is used if the environment specified in the trace is not found.
+    type: string
+    default: "__default__"
+  - name: FieldName
+    summary: The name of the field to check for errors.
+    description: |
+      The name of the field to check. If this field is not specified,
+      the default is 'error'. If this field exists, the trace will be
+      sampled at the specified rate.
+    type: string
+    default: "error"
+  - name: SampleRate
+    summary: The sample rate to use if the trace contains error spans.
+    description: |
+      The sample rate to use if the rule matches. Example: 10 to keep 1 out of
+      10 traces.
+    type: int
+    default: 1
+    validations:
+      - positive
+templates:
+  - kind: refinery_rules
+    name: KeepErrors_RefineryRules
+    format: rules
+    meta:
+      env: "{{ .Values.Environment }}"
+      sampler: RulesBasedSampler
+    data:
+      - key: Rules[0].Name
+        value: "Keep traces with errors at a sample rate of {{ .Values.SampleRate }}"
+      - key: Rules[0].SampleRate
+        value: "{{ .Values.SampleRate | encodeAsInt }}"
+      - key: "Rules[0].!condition!"
+        value: "ix=0;f={{ .Values.FieldName }};o=exists"

--- a/pkg/data/components/KeepSlowTraces.yaml
+++ b/pkg/data/components/KeepSlowTraces.yaml
@@ -1,0 +1,65 @@
+kind: KeepSlowTraces
+name: Keep Slow Traces
+style: sampler
+type: base
+status: development
+version: v0.1.0
+summary: Keeps traces where the root span exceeds a specified duration.
+description: |
+  This sampler checks the duration of the root span in a trace.
+  If the root span exceeds the specified duration, the trace will be sampled
+  at the specified rate (default 1).
+tags:
+  - category:refinery_rule
+  - service:refinery
+  - vendor:Honeycomb
+  - type:error
+ports:
+  - name: In
+    direction: input
+    type: HoneycombEvents
+  - name: Out
+    direction: output
+    type: HoneycombEvents
+properties:
+  - name: Environment
+    summary: The environment in which to enable the sampler.
+    description: |
+      The environment in which to enable the sampler. If this field is
+      not specified, the sampler will be enabled in the __default__ environment,
+      which is what is used if the environment specified in the trace is not found.
+    type: string
+    default: "__default__"
+  - name: Duration
+    summary: Traces longer than this duration will be sampled at the specified rate.
+    description: |
+      The duration (in milliseconds) that the root span must exceed for the trace
+      to be sampled. If the root span's duration is greater than this value, the
+      trace will be sampled at the specified rate.
+    type: int
+    default: 1000
+    validations:
+      - positive
+  - name: SampleRate
+    summary: The sample rate to use if the trace exceeds the duration.
+    description: |
+      The sample rate to use if the rule matches. Example: 10 to keep 1 out of
+      10 traces.
+    type: int
+    default: 1
+    validations:
+      - positive
+templates:
+  - kind: refinery_rules
+    name: KeepErrors_RefineryRules
+    format: rules
+    meta:
+      env: "{{ .Values.Environment }}"
+      sampler: RulesBasedSampler
+    data:
+      - key: Rules[0].Name
+        value: "If a trace lasts longer than {{ .Values.Duration }}, sample at {{ .Values.SampleRate }}"
+      - key: Rules[0].SampleRate
+        value: "{{ .Values.SampleRate | encodeAsInt }}"
+      - key: "Rules[0].!condition!"
+        value: "ix=0;f=duration_ms;o=>=;v={{ .Values.Duration }};d=i"

--- a/pkg/translator/testdata/hpsf/keeperrors_all.yaml
+++ b/pkg/translator/testdata/hpsf/keeperrors_all.yaml
@@ -1,0 +1,31 @@
+components:
+  - name: honeycomb_in
+    kind: TraceConverter
+  - name: honeycomb_out
+    kind: HoneycombExporter
+  - name: sampler
+    kind: KeepErrors
+    properties:
+      - name: Environment
+        value: test
+      - name: SampleRate
+        value: 123
+      - name: FieldName
+        value: phred
+connections:
+  - source:
+      component: honeycomb_in
+      port: TraceOut
+      type: Honeycomb
+    destination:
+      component: sampler
+      port: Input
+      type: Honeycomb
+  - source:
+      component: sampler
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: honeycomb_out
+      port: Traces
+      type: Honeycomb

--- a/pkg/translator/testdata/hpsf/keeperrors_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/keeperrors_defaults.yaml
@@ -1,0 +1,24 @@
+components:
+  - name: honeycomb_in
+    kind: TraceConverter
+  - name: honeycomb_out
+    kind: HoneycombExporter
+  - name: Sampler_1
+    kind: KeepErrors
+connections:
+  - source:
+      component: honeycomb_in
+      port: TraceOut
+      type: Honeycomb
+    destination:
+      component: Sampler_1
+      port: Input
+      type: Honeycomb
+  - source:
+      component: Sampler_1
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: honeycomb_out
+      port: Traces
+      type: Honeycomb

--- a/pkg/translator/testdata/hpsf/keepslowtraces_all.yaml
+++ b/pkg/translator/testdata/hpsf/keepslowtraces_all.yaml
@@ -1,0 +1,31 @@
+components:
+  - name: honeycomb_in
+    kind: TraceConverter
+  - name: honeycomb_out
+    kind: HoneycombExporter
+  - name: sampler
+    kind: KeepSlowTraces
+    properties:
+      - name: Environment
+        value: test
+      - name: SampleRate
+        value: 17
+      - name: Duration
+        value: 45
+connections:
+  - source:
+      component: honeycomb_in
+      port: TraceOut
+      type: Honeycomb
+    destination:
+      component: sampler
+      port: Input
+      type: Honeycomb
+  - source:
+      component: sampler
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: honeycomb_out
+      port: Traces
+      type: Honeycomb

--- a/pkg/translator/testdata/hpsf/keepslowtraces_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/keepslowtraces_defaults.yaml
@@ -1,0 +1,24 @@
+components:
+  - name: honeycomb_in
+    kind: TraceConverter
+  - name: honeycomb_out
+    kind: HoneycombExporter
+  - name: Sampler_1
+    kind: KeepSlowTraces
+connections:
+  - source:
+      component: honeycomb_in
+      port: TraceOut
+      type: Honeycomb
+    destination:
+      component: Sampler_1
+      port: Input
+      type: Honeycomb
+  - source:
+      component: Sampler_1
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: honeycomb_out
+      port: Traces
+      type: Honeycomb

--- a/pkg/translator/testdata/hpsf/sampleerrors_all.yaml
+++ b/pkg/translator/testdata/hpsf/sampleerrors_all.yaml
@@ -1,5 +1,33 @@
-RulesVersion: 2
-Samplers:
-    __default__:
-        DeterministicSampler:
-            SampleRate: 1
+components:
+  - name: honeycomb_in
+    kind: TraceConverter
+  - name: honeycomb_out
+    kind: HoneycombExporter
+  - name: sampler
+    kind: SampleErrors
+    properties:
+      - name: Environment
+        value: test
+      - name: ErrorRate
+        value: 90
+      - name: UserErrorRate
+        value: 91
+      - name: DefaultRate
+        value: 92
+connections:
+  - source:
+      component: honeycomb_in
+      port: TraceOut
+      type: Honeycomb
+    destination:
+      component: sampler
+      port: Input
+      type: Honeycomb
+  - source:
+      component: sampler
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: honeycomb_out
+      port: Traces
+      type: Honeycomb

--- a/pkg/translator/testdata/hpsf/sampleerrors_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/sampleerrors_defaults.yaml
@@ -1,3 +1,24 @@
 components:
-  - name: se_out
+  - name: honeycomb_in
+    kind: TraceConverter
+  - name: honeycomb_out
+    kind: HoneycombExporter
+  - name: Sampler_1
     kind: SampleErrors
+connections:
+  - source:
+      component: honeycomb_in
+      port: TraceOut
+      type: Honeycomb
+    destination:
+      component: Sampler_1
+      port: Input
+      type: Honeycomb
+  - source:
+      component: Sampler_1
+      port: Kept
+      type: Honeycomb
+    destination:
+      component: honeycomb_out
+      port: Traces
+      type: Honeycomb

--- a/pkg/translator/testdata/refinery_rules/keeperrors_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/keeperrors_all.yaml
@@ -1,0 +1,13 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 1
+    test:
+        RulesBasedSampler:
+            Rules:
+                - Conditions:
+                    - Field: phred
+                      Operator: exists
+                  Name: Keep traces with errors at a sample rate of 123
+                  SampleRate: 123

--- a/pkg/translator/testdata/refinery_rules/keeperrors_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/keeperrors_defaults.yaml
@@ -1,0 +1,10 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Conditions:
+                    - Field: error
+                      Operator: exists
+                  Name: Keep traces with errors at a sample rate of 1
+                  SampleRate: 1

--- a/pkg/translator/testdata/refinery_rules/keepslowtraces_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/keepslowtraces_all.yaml
@@ -1,0 +1,15 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 1
+    test:
+        RulesBasedSampler:
+            Rules:
+                - Conditions:
+                    - Datatype: int
+                      Field: duration_ms
+                      Operator: '>='
+                      Value: "45"
+                  Name: If a trace lasts longer than 45, sample at 17
+                  SampleRate: 17

--- a/pkg/translator/testdata/refinery_rules/keepslowtraces_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/keepslowtraces_defaults.yaml
@@ -1,0 +1,12 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Conditions:
+                    - Datatype: int
+                      Field: duration_ms
+                      Operator: '>='
+                      Value: "1000"
+                  Name: If a trace lasts longer than 1000, sample at 1
+                  SampleRate: 1

--- a/pkg/translator/testdata/refinery_rules/sampleerrors_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/sampleerrors_all.yaml
@@ -3,3 +3,26 @@ Samplers:
     __default__:
         DeterministicSampler:
             SampleRate: 1
+    test:
+        RulesBasedSampler:
+            Rules:
+                - Conditions:
+                    - Datatype: int
+                      Fields:
+                        - http.status_code
+                        - http.response.status_code
+                      Operator: '>='
+                      Value: "500"
+                  Name: Sample 500 statuses at 90
+                  SampleRate: 90
+                - Conditions:
+                    - Datatype: int
+                      Fields:
+                        - http.status_code
+                        - http.response.status_code
+                      Operator: '>='
+                      Value: "400"
+                  Name: Sample 400 statuses at 91
+                  SampleRate: 91
+                - Name: Sample remainder at 92
+                  SampleRate: 92

--- a/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/sampleerrors_defaults.yaml
@@ -9,7 +9,7 @@ Samplers:
                         - http.status_code
                         - http.response.status_code
                       Operator: '>='
-                      Value: 500
+                      Value: "500"
                   Name: Sample 500 statuses at 1
                   SampleRate: 1
                 - Conditions:
@@ -18,7 +18,7 @@ Samplers:
                         - http.status_code
                         - http.response.status_code
                       Operator: '>='
-                      Value: 400
+                      Value: "400"
                   Name: Sample 400 statuses at 10
                   SampleRate: 10
                 - Name: Sample remainder at 100


### PR DESCRIPTION

## Which problem is this PR solving?

- We needed more examples of rules components
- There were some test problems with existing rules tests
- We were enforcing value's type before evaluation of templates; this was wrong. I removed it for now. A separate PR will add it back soon.

## Short description of the changes

- Add some new rules components
   - KeepSlowTraces
   - KeepErrors
- Fix some test problems
   - Test file for SampleErrors was completely wrong 
- Remove type enforcement before template expansion

