### PR TITLE
fix: arrays in keys in components

### DIFF
--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -134,6 +134,7 @@ func (cc *CollectorConfig) RenderToMap(m map[string]any) map[string]any {
 		m = make(map[string]any)
 	}
 	for section := range cc.Sections {
+		cc.Sections[section] = cc.Sections[section].RenderToMap(nil)
 		for k, v := range cc.Sections[section] {
 			key := section + "." + k
 			cc.renderInto(m, key, v)

--- a/pkg/config/tmpl/dottedconfig_test.go
+++ b/pkg/config/tmpl/dottedconfig_test.go
@@ -91,7 +91,8 @@ func Test_processIndices(t *testing.T) {
 		want map[string]any
 	}{
 		{"0", map[string]any{}, map[string]any{}},
-		{"1", map[string]any{"a[0]": map[string]any{"a": "b"}}, map[string]any{"a": []map[string]any{{"a": "b"}}}},
+		{"1", map[string]any{"a[0]": map[string]any{"a": "b"}}, map[string]any{"a": []any{map[string]any{"a": "b"}}}},
+		{"2", map[string]any{"a[0]": "item1", "a[1]": "item2"}, map[string]any{"a": []any{"item1", "item2"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

When a collector component results in arrays, they don't get translated into arrays and keep their indexed data

## Short description of the changes

I've made the collector rendering call RenderToMap, but also, processIndices wasn't recursing properly.
