### PR TITLE
feat(hpsf): Added an upper function to the go templates

### DIFF
--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -50,6 +50,7 @@ func helpers() template.FuncMap {
 		"nonempty":      nonempty,
 		"now":           now,
 		"split":         split,
+		"upper":         strings.ToUpper,
 		"yamlf":         yamlf,
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Adds a way to convert a template parameter to Uppercase

## Short description of the changes

Added `upper` as a template helper that delegates to `strings.ToUpper`

