### PR TITLE
fix: update emathroughput template to use updated fields

### DIFF
--- a/pkg/data/templates/emathroughput.yaml
+++ b/pkg/data/templates/emathroughput.yaml
@@ -29,24 +29,24 @@ connections:
       type: OTelTraces
     destination:
       component: Trace Converter 1
-      port: Input
+      port: Traces
       type: OTelTraces
   - source:
       component: Trace Converter 1
-      port: Output
-      type: Honeycomb
+      port: Events
+      type: HoneycombEvents
     destination:
       component: EMA Throughput 1
-      port: Input
-      type: Honeycomb
+      port: Traces
+      type: HoneycombEvents
   - source:
       component: EMA Throughput 1
-      port: Kept
-      type: Honeycomb
+      port: SampledOutput
+      type: HoneycombEvents
     destination:
       component: Honeycomb Exporter 1
       port: Traces
-      type: Honeycomb
+      type: HoneycombEvents
 layout:
   components:
     - name: OTel Receiver 1
@@ -54,14 +54,14 @@ layout:
         x: -340
         y: 0
     - name: Trace Converter 1
-      position:    
+      position:
         x: 0
         y: 0
-    - name: Honeycomb Exporter 1
+    - name: EMA Throughput 1
       position:
         x: 240
         y: 0
-    - name: EMA Throughput 1
+    - name: Honeycomb Exporter 1
       position:
         x: 540
         y: 0


### PR DESCRIPTION
## Which problem is this PR solving?

- closes https://github.com/honeycombio/pipeline-team/issues/442

## Short description of the changes

- Update to use new fields like Input -> Traces, Output -> Events, Honeycomb -> HoneycombEvents, Kept -> SampledOutput

To test the config is valid, I added an API key to the HoneycombExporter and ran `make smoke`. I might try to update that in a separate PR to add that when testing, because if we were running this in CI we would catch this.

```yaml
  - name: Honeycomb Exporter 1
    kind: HoneycombExporter
    properties:
      - name: APIKey
        value: hccik_01jj2jj42424jjjjjjj2jjjjjj424jjj2jjjjjjjjjjjjjjj4jjjjj24jj # its fake no worries
```