### PR TITLE
fix: make it easier to run smoke tests for templates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ jobs:
           key: v1-go-mod-{{ checksum "go.sum" }}
           paths:
             - /home/circleci/go/pkg/mod
+  smoke_test:
+    machine:
+      image: ubuntu-2204:2024.01.1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Run Smoke Tests
+          command: make smoke
 
   publish_github:
     docker:
@@ -36,10 +46,17 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - smoke_test:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
+            - smoke_test
           filters:
             tags:
               only: /^v[0-9].*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
-      - run: make test
+      # - run: make test
       - run: make validate_all
       - store_test_results:
           path: test_results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
-      # - run: make test
+      - run: make test
       - run: make validate_all
       - store_test_results:
           path: test_results/
@@ -17,16 +17,6 @@ jobs:
           key: v1-go-mod-{{ checksum "go.sum" }}
           paths:
             - /home/circleci/go/pkg/mod
-  smoke_test:
-    machine:
-      image: ubuntu-2204:2024.01.1
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Run Smoke Tests
-          command: make smoke
 
   publish_github:
     docker:
@@ -45,17 +35,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - smoke_test:
-          requires:
-            - test
-          filters:
-            tags:
-              only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
-            - smoke_test
           filters:
             tags:
               only: /^v[0-9].*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             - v1-go-mod-{{ checksum "go.sum" }}
       - run: make test
       - run: make validate_all
+      - run: make smoke
       - store_test_results:
           path: test_results/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
             - v1-go-mod-{{ checksum "go.sum" }}
       - run: make test
       - run: make validate_all
-      - run: make smoke
       - store_test_results:
           path: test_results/
       - save_cache:

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	docker run -d --name smoke-refinery \
 		-v ./tmp/refinery-config.yaml:/etc/refinery/refinery.yaml \
 		-v ./tmp/refinery-rules.yaml:/etc/refinery/rules.yaml \
+		-e HONEYCOMB_EXPORTER_APIKEY=hccik_01jj2jj42424jjjjjjj2jjjjjj424jjj2jjjjjjjjjjjjjjj4jjjjj24jj \
 		honeycombio/refinery:latest || exit 1
 	sleep 1
 
@@ -98,6 +99,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		echo "+++ container is running"; \
 		docker kill 'smoke-refinery'; \
 		docker rm 'smoke-refinery'; \
+		echo "+++ refinery successfully started up for $(FILE)"; \
 	fi
 
 .PHONY: .smoke_collector
@@ -124,7 +126,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		echo "+++ yq version is less than 4.0.0, please update it"; \
 		exit 1; \
 	fi
-	
+
 	# use yq to remove the usage processor and honeycomb extension from collector config
 	yq -i e \
 		'del(.processors.usage) | \
@@ -155,6 +157,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		echo "+++ container is running"; \
 		docker kill 'smoke-collector'; \
 		docker rm 'smoke-collector'; \
+		echo "+++ collector successfully started up for $(FILE)"; \
 	fi
 
 .PHONY: smoke


### PR DESCRIPTION
## Which problem is this PR solving?

- template was broken and could've been caught sooner

## Short description of the changes

* honeycomb exporter requires an API key in order to run. that is the only thing preventing these templates from running
successfully in a smoke test, so set a fake api key in the test to ensure everything else works as expected.
* This still only checks templates, not all components, so it is still quick to run but adds a ton of confidence for templates.

This would be nice to run in CI but in a quick timebox found it needed a few more things to be successful (install yq for instance). May revisit later but in the meantime this is still useful to see "will it run"
