### PR TITLE
feat: add s3 template

### DIFF
--- a/pkg/data/templates/s3.yaml
+++ b/pkg/data/templates/s3.yaml
@@ -1,0 +1,124 @@
+name: S3 Cold Storage
+kind: TemplateS3
+version: v0.1.0
+summary: A template for sending OpenTelemetry traces and logs to S3 for cold storage.
+description: |
+  This forwards all OpenTelemetry traces and logs to S3 for cold storage.
+  Traces are also sent through an EMAThroughput Sampler so a subset are available
+  in Honeycomb. OpenTelemetry metrics are also sent to Honeycomb.
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Trace Converter_1
+    kind: TraceConverter
+  - name: OTel HTTP Exporter_1
+    kind: OTelHTTPExporter
+    properties:
+      - name: Headers
+        value:
+          x-honeycomb-team: ${HONEYCOMB_API_KEY}
+  - name: Honeycomb Exporter_1
+    kind: HoneycombExporter
+    properties:
+      - name: APIKey
+        value: ${HONEYCOMB_EXPORTER_APIKEY}
+  - name: EMA Throughput Sampler_1
+    kind: EMAThroughput
+    properties:
+      - name: FieldList
+        value:
+          - http.request.method
+          - http.method
+          - http.status_code
+  - name: S3 Exporter_1
+    kind: S3Exporter
+    properties:
+      - name: Bucket
+        value: otel-demo-for-enhance
+      - name: Region
+        value: us-east-1
+      - name: Prefix
+        value: enhance
+      - name: Timeout
+        value: 60s
+      - name: BatchTimeout
+        value: 30s
+      - name: BatchSize
+        value: 1000000
+      - name: QueueSize
+        value: 20000000
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Trace Converter_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: OTel Receiver_1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: OTel HTTP Exporter_1
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: Trace Converter_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: EMA Throughput Sampler_1
+      port: Traces
+      type: HoneycombEvents
+  - source:
+      component: EMA Throughput Sampler_1
+      port: SampledOutput
+      type: HoneycombEvents
+    destination:
+      component: Honeycomb Exporter_1
+      port: Traces
+      type: HoneycombEvents
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: S3 Exporter_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: S3 Exporter_1
+      port: Logs
+      type: OTelLogs
+layout:
+  components:
+    - name: OTel Receiver_1
+      position:
+        x: 60
+        y: -160
+    - name: Trace Converter_1
+      position:
+        x: 340
+        y: -220
+    - name: OTel HTTP Exporter_1
+      position:
+        x: 720
+        y: 20
+    - name: Honeycomb Exporter_1
+      position:
+        x: 800
+        y: -220
+    - name: EMA Throughput Sampler_1
+      position:
+        x: 540
+        y: -220
+    - name: S3 Exporter_1
+      position:
+        x: 380
+        y: -440


### PR DESCRIPTION
## Which problem is this PR solving?

- closes https://github.com/honeycombio/pipeline-team/issues/439

## Short description of the changes

- Add template for S3 exporter common workflow
  - otel receiver
  - logs to s3 exporter
  - metrics to otlphttp exporter
  - traces split - to s3 exporter, and through emathroughput sampler to honeycomb 

