### PR TITLE
feat: Update logs dedup processor port names

### DIFF
--- a/pkg/data/components/LogDeduplicationProcessor.yaml
+++ b/pkg/data/components/LogDeduplicationProcessor.yaml
@@ -13,10 +13,10 @@ tags:
   - service:collector
   - signal:OTelLogs
 ports:
-  - name: LogsIn
+  - name: Logs
     direction: input
     type: OTelLogs
-  - name: LogsOut
+  - name: Logs
     direction: output
     type: OTelLogs
 properties:


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the Logs Dedup processor's ports to conform to standard naming.

## Short description of the changes

- Rename LogsIn/Out to just `Logs`
