### PR TITLE
test: Added make target for regenerating the translator config tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,9 @@ unsmoke:
 	@echo
 	docker stop smoke-proxy
 
-.PHONY: regenerate_translator_tests
-regenerate_translator_tests:
+.PHONY: regenerate_translator_testdata
+regenerate_translator_testdata:
 	@echo
-	@echo "+++ regenerating translator tests"
+	@echo "+++ regenerating translator testdata"
 	@echo
 	OVERWRITE_TESTDATA=1 go test ./pkg/translator/

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -22,6 +22,7 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 	// config files if they are different
 	var overwrite bool = false
 
+	// this allows for the make target regenerate_translator_testdata to work instead of editing
 	if os.Getenv("OVERWRITE_TESTDATA") == "1" {
 		overwrite = true
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

Generating the `_all` and `_default` tests in `pkg/translator` is cumbersome and involves editing the code.

## Short description of the changes

Move the test to use an env var, and add a make target for it.

