### PR TITLE
feat(components): Rename TraceConverter to StartSampling

### DIFF
--- a/examples/hpsfComposedComponents.yaml
+++ b/examples/hpsfComposedComponents.yaml
@@ -1,8 +1,8 @@
 components:
   - name: OTel Receiver_1
     kind: OTelReceiver
-  - name: Trace Converter_1
-    kind: TraceConverter
+  - name: Start Sampling_1
+    kind: StartSampling
   - name: Sample Based on Errors_1
     kind: SampleByHTTPStatus
     properties:
@@ -29,11 +29,11 @@ connections:
       port: Traces
       type: OTelTraces
     destination:
-      component: Trace Converter_1
+      component: Start Sampling_1
       port: Traces
       type: OTelTraces
   - source:
-      component: Trace Converter_1
+      component: Start Sampling_1
       port: Events
       type: HoneycombEvents
     destination:

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -1,13 +1,12 @@
-kind: TraceConverter
-name: Trace Converter
+kind: StartSampling
+name: Start Sampling
 style: processor
 type: base
 status: alpha
 version: v0.1.0
-summary: Sends telemetry to Refinery via HTTP for further processing.
+summary: Converts traces and logs to a format for sampling
 description: |
-  Sends OTel telemetry via HTTP.
-  This component forwards the data to Refinery over HTTP for processing.
+  Converts traces and logs to a format for advanced tail-based sampling with Refinery.
 tags:
   - category:converter
   - service:refinery

--- a/pkg/data/templates/emathroughput.yaml
+++ b/pkg/data/templates/emathroughput.yaml
@@ -11,8 +11,8 @@ description: |
 components:
   - name: OTel Receiver 1
     kind: OTelReceiver
-  - name: Trace Converter 1
-    kind: TraceConverter
+  - name: Start Sampling 1
+    kind: StartSampling
   - name: EMA Throughput 1
     kind: EMAThroughput
     properties:
@@ -28,11 +28,11 @@ connections:
       port: Traces
       type: OTelTraces
     destination:
-      component: Trace Converter 1
+      component: Start Sampling 1
       port: Traces
       type: OTelTraces
   - source:
-      component: Trace Converter 1
+      component: Start Sampling 1
       port: Events
       type: HoneycombEvents
     destination:
@@ -53,7 +53,7 @@ layout:
       position:
         x: -340
         y: 0
-    - name: Trace Converter 1
+    - name: Start Sampling 1
       position:
         x: 0
         y: 0

--- a/pkg/data/templates/s3.yaml
+++ b/pkg/data/templates/s3.yaml
@@ -9,8 +9,8 @@ description: |
 components:
   - name: OTel Receiver_1
     kind: OTelReceiver
-  - name: Trace Converter_1
-    kind: TraceConverter
+  - name: Start Sampling_1
+    kind: StartSampling
   - name: OTel HTTP Exporter_1
     kind: OTelHTTPExporter
     properties:
@@ -37,7 +37,7 @@ connections:
       port: Traces
       type: OTelTraces
     destination:
-      component: Trace Converter_1
+      component: Start Sampling_1
       port: Traces
       type: OTelTraces
   - source:
@@ -49,7 +49,7 @@ connections:
       port: Metrics
       type: OTelMetrics
   - source:
-      component: Trace Converter_1
+      component: Start Sampling_1
       port: Events
       type: HoneycombEvents
     destination:

--- a/pkg/translator/testdata/collector_config/startsampling_all.yaml
+++ b/pkg/translator/testdata/collector_config/startsampling_all.yaml
@@ -8,18 +8,19 @@ receivers:
 processors:
     usage: {}
 exporters:
-    otlphttp/Trace_Converter_1:
-        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+    otlphttp/Start_Sampling_1:
+        endpoint: https://myhost.com:1234
+        headers:
+            x-honeycomb-dataset: custom
+            x-honeycomb-team: ${HONEYCOMB_API_KEY}
         sending_queue:
             batch:
-                flush_timeout: 200ms
-                max_size: 8192
-                min_size: 8192
+                flush_timeout: 30s
+                max_size: 200000
+                min_size: 200000
             enabled: true
-            queue_size: 100000
+            queue_size: 2000000
             sizer: items
-        tls:
-            insecure: true
 extensions:
     honeycomb: {}
 service:
@@ -28,4 +29,4 @@ service:
         traces:
             receivers: [otlp/otlp_in]
             processors: [usage]
-            exporters: [otlphttp/Trace_Converter_1]
+            exporters: [otlphttp/Start_Sampling_1]

--- a/pkg/translator/testdata/collector_config/startsampling_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/startsampling_defaults.yaml
@@ -8,19 +8,18 @@ receivers:
 processors:
     usage: {}
 exporters:
-    otlphttp/Trace_Converter_1:
-        endpoint: https://myhost.com:1234
-        headers:
-            x-honeycomb-dataset: custom
-            x-honeycomb-team: ${HONEYCOMB_API_KEY}
+    otlphttp/Start_Sampling_1:
+        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
         sending_queue:
             batch:
-                flush_timeout: 30s
-                max_size: 200000
-                min_size: 200000
+                flush_timeout: 200ms
+                max_size: 8192
+                min_size: 8192
             enabled: true
-            queue_size: 2000000
+            queue_size: 100000
             sizer: items
+        tls:
+            insecure: true
 extensions:
     honeycomb: {}
 service:
@@ -29,4 +28,4 @@ service:
         traces:
             receivers: [otlp/otlp_in]
             processors: [usage]
-            exporters: [otlphttp/Trace_Converter_1]
+            exporters: [otlphttp/Start_Sampling_1]

--- a/pkg/translator/testdata/hpsf/deterministicsampler_all.yaml
+++ b/pkg/translator/testdata/hpsf/deterministicsampler_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: DeterministicSampler_1

--- a/pkg/translator/testdata/hpsf/deterministicsampler_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/deterministicsampler_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: DeterministicSampler_1

--- a/pkg/translator/testdata/hpsf/emathroughput_all.yaml
+++ b/pkg/translator/testdata/hpsf/emathroughput_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: EMAThroughput_1

--- a/pkg/translator/testdata/hpsf/emathroughput_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/emathroughput_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: EMAThroughput_1

--- a/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
@@ -2,7 +2,7 @@ components:
   - name: otlp
     kind: OTelReceiver
   - name: refinery
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb
     kind: HoneycombExporter
     properties:

--- a/pkg/translator/testdata/hpsf/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_defaults.yaml
@@ -2,7 +2,7 @@ components:
   - name: otlp
     kind: OTelReceiver
   - name: refinery
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb
     kind: HoneycombExporter
 connections:

--- a/pkg/translator/testdata/hpsf/keeperrors_all.yaml
+++ b/pkg/translator/testdata/hpsf/keeperrors_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: sampler

--- a/pkg/translator/testdata/hpsf/keeperrors_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/keeperrors_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: Sampler_1

--- a/pkg/translator/testdata/hpsf/samplebyhttpstatus_all.yaml
+++ b/pkg/translator/testdata/hpsf/samplebyhttpstatus_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: sampler

--- a/pkg/translator/testdata/hpsf/samplebyhttpstatus_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/samplebyhttpstatus_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: Sampler_1

--- a/pkg/translator/testdata/hpsf/samplebytraceduration_all.yaml
+++ b/pkg/translator/testdata/hpsf/samplebytraceduration_all.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: sampler

--- a/pkg/translator/testdata/hpsf/samplebytraceduration_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/samplebytraceduration_defaults.yaml
@@ -1,6 +1,6 @@
 components:
   - name: honeycomb_in
-    kind: TraceConverter
+    kind: StartSampling
   - name: honeycomb_out
     kind: HoneycombExporter
   - name: Sampler_1

--- a/pkg/translator/testdata/hpsf/startsampling_all.yaml
+++ b/pkg/translator/testdata/hpsf/startsampling_all.yaml
@@ -1,8 +1,8 @@
 components:
   - name: otlp_in
     kind: OTelReceiver
-  - name: Trace Converter 1
-    kind: TraceConverter
+  - name: Start Sampling 1
+    kind: StartSampling
     properties:
       - name: Host
         value: myhost.com
@@ -26,6 +26,6 @@ connections:
       port: Traces
       type: OTelTraces
     destination:
-      component: Trace Converter 1
+      component: Start Sampling 1
       port: Input
       type: OTelTraces

--- a/pkg/translator/testdata/hpsf/startsampling_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/startsampling_defaults.yaml
@@ -1,14 +1,14 @@
 components:
   - name: otlp_in
     kind: OTelReceiver
-  - name: Trace Converter 1
-    kind: TraceConverter
+  - name: Start Sampling 1
+    kind: StartSampling
 connections:
   - source:
       component: otlp_in
       port: Traces
       type: OTelTraces
     destination:
-      component: Trace Converter 1
+      component: Start Sampling 1
       port: Input
       type: OTelTraces

--- a/tests/scenario_tests/keep_errors_test.go
+++ b/tests/scenario_tests/keep_errors_test.go
@@ -3,6 +3,7 @@ package hpsftests
 import (
 	"testing"
 
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
 	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,7 +11,7 @@ import (
 
 func TestKeepErrors(t *testing.T) {
 	// Test the HPSF parsing and KeepErrors sampler configuration
-	rulesConfig, _, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/keep_errors.yaml")
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/keep_errors.yaml")
 
 	// Verify that the refinery rules config was generated successfully
 	assert.Equal(t, 2, rulesConfig.RulesVersion)
@@ -55,4 +56,10 @@ func TestKeepErrors(t *testing.T) {
 	require.NotNil(t, defaultSampler.DeterministicSampler, "Expected default sampler to be a DeterministicSampler")
 
 	assert.Equal(t, 1, defaultSampler.DeterministicSampler.SampleRate)
+
+	// verify that the the collectorconfig pipeline includes the exporter to refinery
+	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "traces")
+	require.True(t, getResult.Found, "Expected pipeline to be found")
+	assert.Len(t, exporters, 1, "Expected 1 exporter, got %s", exporters)
+	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected OTel HTTP exporter")
 }

--- a/tests/scenario_tests/testdata/keep_errors.yaml
+++ b/tests/scenario_tests/testdata/keep_errors.yaml
@@ -2,13 +2,13 @@ name: keep_errors_test
 version: v0.1.0
 summary: Test for KeepErrors sampler component
 description: |
-  Test configuration with an OTel receiver, TraceConverter, KeepErrors sampler, and HoneycombExporter
+  Test configuration with an OTel receiver, StartSampling, KeepErrors sampler, and HoneycombExporter
 
 components:
   - name: OTel Receiver 1
     kind: OTelReceiver
-  - name: Trace Converter 1
-    kind: TraceConverter
+  - name: Start Sampling 1
+    kind: StartSampling
   - name: Error Sampler
     kind: KeepErrors
     properties:
@@ -27,11 +27,11 @@ connections:
       port: Traces
       type: OTelTraces
     destination:
-      component: Trace Converter 1
+      component: Start Sampling 1
       port: TracesIn
       type: OTelTraces
   - source:
-      component: Trace Converter 1
+      component: Start Sampling 1
       port: TraceOut
       type: Honeycomb
     destination:


### PR DESCRIPTION
## Which problem is this PR solving?

Rename the TraceConverter to StartSampling

Closes: https://github.com/honeycombio/pipeline-team/issues/452

## Short description of the changes

Renames the component and all associated tests, also updates the summary/description and adds a new assertion in a test ensure the pipeline is created.
