### PR TITLE
feat: Add subtype labels for bool properties

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -75,7 +75,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
-    subtype: label("Enable TLS export")
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -75,6 +75,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
+    subtype: label("Enable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -57,6 +57,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
+    subtype: label("Enable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -57,7 +57,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
-    subtype: label("Enable TLS export")
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -57,6 +57,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
+    subtype: label("Enable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -57,7 +57,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
-    subtype: label("Enable TLS export")
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -60,6 +60,7 @@ properties:
       Can be used to send data with TLS.
       Since Refinery does not use TLS, this is off by default.
     type: bool
+    subtype: label("Enable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -60,7 +60,7 @@ properties:
       Can be used to send data with TLS.
       Since Refinery does not use TLS, this is off by default.
     type: bool
-    subtype: label("Enable TLS export")
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout


### PR DESCRIPTION
## Which problem is this PR solving?

Updates existing components that have a bool property to set a label name using it's subtype.

- Part of https://github.com/honeycombio/pipeline-team/issues/265
- Related to https://github.com/honeycombio/hound/pull/24759

## Short description of the changes

- Updates the following components to add a label in their bool subtype property:
  - StartSampling - UseTLS
  - HoneycombExporter - Insecure
  - OTelHTTPExporter - Insecure
  - OTelGRPCExporter - Insecure