### PR TITLE
fix: Add subtype to HoneycombExporter Mode property

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -66,6 +66,7 @@ properties:
       not be used. Defaults to 'all', which means all
       the traffic will be exported using the configured APIKey.
     type: string
+    subtype: oneof(all, none)
     validations:
       - oneof(all, none)
     default: all


### PR DESCRIPTION
## Which problem is this PR solving?

Adds a subtype for the HoneycombExporter Mode property to match the validation rule. The subtype is used to determine the property editor component.

Before (textbox):
<img width="285" alt="image" src="https://github.com/user-attachments/assets/a056c624-2dfa-42b6-84c0-5717b01dffa2" />

After (dropdown):
<img width="278" alt="image" src="https://github.com/user-attachments/assets/8cfc8a25-c6b8-4f2e-92aa-256052612cef" />


## Short description of the changes

- Add subtype to Mode property

