### PR TITLE
test: Update Tests to support named pipelines

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -66,6 +66,7 @@ properties:
       not be used. Defaults to 'all', which means all
       the traffic will be exported using the configured APIKey.
     type: string
+    subtype: oneof(all, none)
     validations:
       - oneof(all, none)
     default: all

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -75,6 +75,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -57,6 +57,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -57,6 +57,7 @@ properties:
     description: |
       Can be used to send data without TLS.
     type: bool
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -60,6 +60,7 @@ properties:
       Can be used to send data with TLS.
       Since Refinery does not use TLS, this is off by default.
     type: bool
+    subtype: label("Disable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,15 +3,19 @@ module github.com/honeycombio/hpsf/tests
 go 1.24.1
 
 require (
-	github.com/honeycombio/hpsf v0.0.0-00010101000000-000000000000
+	github.com/honeycombio/hpsf v0.6.1
 	github.com/honeycombio/opentelemetry-collector-configs/honeycombextension v0.0.0-20250529172854-29e92f8bd7cb
 	github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.1.0
 	github.com/honeycombio/refinery v1.21.1-0.20250604165426-312ddc7c2c94
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.127.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.127.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.127.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.127.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/exporter v0.127.0
 	go.opentelemetry.io/collector/extension v1.33.0
 	go.opentelemetry.io/collector/receiver v1.33.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace github.com/honeycombio/opentelemetry-collector-configs/usageprocessor => github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.0.0-20250529172854-29e92f8bd7cb
@@ -42,6 +46,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/expr-lang/expr v1.17.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -60,11 +65,8 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-telemetry/opamp-go v0.19.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.127.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.127.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.127.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.127.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.127.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -143,7 +145,6 @@ require (
 	golang.org/x/crypto v0.38.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -193,7 +194,7 @@ require (
 	go.opentelemetry.io/collector/otelcol v0.127.0
 	go.opentelemetry.io/collector/pdata v1.33.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.127.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.127.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.127.0
 	go.opentelemetry.io/collector/processor v1.33.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.127.0 // indirect
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.127.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -65,6 +65,8 @@ github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbD
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 h1:ucRHb6/lvW/+mTEIGbvhcYU3S8+uSNkuMjx/qZFfhtM=
+github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371 h1:bz5ApY1kzFBvw3yckuyRBCtqGvprWrKswYK468nm+Gs=
@@ -319,8 +321,12 @@ go.opentelemetry.io/collector/config/configtls v1.33.0 h1:4pGT0nFM24KCtyyq8ng7VW
 go.opentelemetry.io/collector/config/configtls v1.33.0/go.mod h1:50tvOLlI6iedkrQ9/HMO1KWxzzx0Nu28MgSRXxTwSkY=
 go.opentelemetry.io/collector/confmap v1.33.0 h1:dCLSrONMssTWhnbELZZpJoWMn+P+DVJc8r10JJCeS/4=
 go.opentelemetry.io/collector/confmap v1.33.0/go.mod h1:fq5ccP4lzF3IVK/Cs0kWsiH0dynejXkMc8gaNwvkvtk=
+go.opentelemetry.io/collector/confmap/provider/envprovider v1.33.0 h1:A61tuCM6vlBH6Pk1YoJnkOeFUwUnH/vZMQHTKqEL3eo=
+go.opentelemetry.io/collector/confmap/provider/envprovider v1.33.0/go.mod h1:nbNjPiB6XBrGo4L+IR3W2NjK3AS1eK84yY1g2iDWgto=
 go.opentelemetry.io/collector/confmap/provider/fileprovider v1.33.0 h1:T7rVBmAKgLDLXYKQbCrgw15eD9sAhHqvnSGxYv735ew=
 go.opentelemetry.io/collector/confmap/provider/fileprovider v1.33.0/go.mod h1:JlAC1QMaaPiPx7x8hQYRcxxf2GiOeHYaM8uEIri1dPg=
+go.opentelemetry.io/collector/confmap/provider/httpprovider v1.33.0 h1:4Ut8IiBf+4BvlmwCw5HLduWaQH2jwKF30M/NeXzt64w=
+go.opentelemetry.io/collector/confmap/provider/httpprovider v1.33.0/go.mod h1:lL5ooXkstIKKhVTnUlGE61IzspudCQxwGZMfrsHfhT0=
 go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.33.0 h1:M14VV2/mSU9TMnxfZeHi/fVgzPMv0caPPDNgFXoN8SU=
 go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.33.0/go.mod h1:8yugd3piWlNFCssSTlSdc9KAWGGah+dJ86Yr2wdFg9I=
 go.opentelemetry.io/collector/confmap/xconfmap v0.127.0 h1:isSNkBXltLxUWstxJyHcJ3qVo9qp9GABCVhzIvZgIdM=
@@ -383,6 +389,8 @@ go.opentelemetry.io/collector/internal/telemetry v0.127.0 h1:/wAnPmFjUN7MwnRyDYJ
 go.opentelemetry.io/collector/internal/telemetry v0.127.0/go.mod h1:Un7Zn//l0BkE6hk6wirsTGwnJJpxw/gJWgzYL3eSruk=
 go.opentelemetry.io/collector/otelcol v0.127.0 h1:nCOfC4IpJe36QOmLcFubwyFjeTfo268uWpMmRo5R0I4=
 go.opentelemetry.io/collector/otelcol v0.127.0/go.mod h1:jN1rfCDqohNNy/KnLhIEWLSUz0ZQC+GuI6VkNMdjZZs=
+go.opentelemetry.io/collector/otelcol/otelcoltest v0.127.0 h1:N7OXtsVvII/2k8FOXB52zw95U/v3zhYx8YHwTv1G1qU=
+go.opentelemetry.io/collector/otelcol/otelcoltest v0.127.0/go.mod h1:GjpUndRH/PPLsLo8aH9EkmWkvIuM7B4Jg2gANm5wBY8=
 go.opentelemetry.io/collector/pdata v1.33.0 h1:PuqiZzdCoBJo9NmMzuYfzazpeFZyLmbDVcRrvb497lg=
 go.opentelemetry.io/collector/pdata v1.33.0/go.mod h1:TDvbHuvIK+g6xqu1gxtz8ti4pB2x1WcBpjFob5KfleU=
 go.opentelemetry.io/collector/pdata/pprofile v0.127.0 h1:t0fpwMunK+dkUTPFc0zim8qfAan086eMqpSufnt+H30=

--- a/tests/providers/collector/config_helpers.go
+++ b/tests/providers/collector/config_helpers.go
@@ -78,6 +78,17 @@ func GetPipelineConfig(collectorConfig *otelcol.Config, pipelineName string) (re
 
 }
 
+func GetPipelinesByType(collectorConfig *otelcol.Config, pipelineType string) (pipelines []pipeline.ID) {
+	signalType := convertTypeNameToSignal(pipelineType)
+	pipelines = make([]pipeline.ID, 0)
+	for name, _ := range collectorConfig.Service.Pipelines {
+		if name.Signal() == signalType {
+			pipelines = append(pipelines, name)
+		}
+	}
+	return pipelines
+}
+
 func convertTypeNameToSignal(typeName string) pipeline.Signal {
 	switch typeName {
 	case "logs":

--- a/tests/scenario_tests/filter_logs_by_severity_test.go
+++ b/tests/scenario_tests/filter_logs_by_severity_test.go
@@ -14,7 +14,10 @@ func TestFilterLogsBySeverityDefaults(t *testing.T) {
 	_, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/filter_logs_by_severity_defaults.yaml")
 
 	// Verify the logs pipeline exists and has the correct components
-	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "logs")
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 1, "Expected 1 logs pipeline, got %v", logsPipelineNames)
+
+	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, logsPipelineNames[0].String())
 	require.True(t, getResult.Found, "Expected logs pipeline to be found")
 
 	// Check pipeline components
@@ -38,7 +41,10 @@ func TestFilterLogsBySeverityCustomSeverity(t *testing.T) {
 	_, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/filter_logs_by_severity_all.yaml")
 
 	// Verify the logs pipeline exists and has the correct components
-	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "logs")
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 1, "Expected 1 logs pipeline, got %v", logsPipelineNames)
+
+	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, logsPipelineNames[0].String())
 	require.True(t, getResult.Found, "Expected logs pipeline to be found")
 
 	assert.Len(t, processors, 2, "Expected 2 processors (usage + filter)")

--- a/tests/scenario_tests/keep_errors_test.go
+++ b/tests/scenario_tests/keep_errors_test.go
@@ -58,7 +58,10 @@ func TestKeepErrors(t *testing.T) {
 	assert.Equal(t, 1, defaultSampler.DeterministicSampler.SampleRate)
 
 	// verify that the the collectorconfig pipeline includes the exporter to refinery
-	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "traces")
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
 	require.True(t, getResult.Found, "Expected pipeline to be found")
 	assert.Len(t, exporters, 1, "Expected 1 exporter, got %s", exporters)
 	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected OTel HTTP exporter")

--- a/tests/scenario_tests/multiple_otlp_exporters_test.go
+++ b/tests/scenario_tests/multiple_otlp_exporters_test.go
@@ -14,7 +14,10 @@ func TestMultipleOTLPExporters(t *testing.T) {
 
 	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/multiple_otlp_exporters.yaml")
 
-	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "traces")
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
 	require.True(t, getResult.Found, "Expected pipeline to be found")
 	assert.Len(t, exporters, 2, "Expected 2 exporters, got %s", exporters)
 

--- a/tests/scenario_tests/parseattributeasjson_processor_test.go
+++ b/tests/scenario_tests/parseattributeasjson_processor_test.go
@@ -15,11 +15,17 @@ func TestParseAttributeAsJSONDefaults(t *testing.T) {
 
 	assert.Len(t, rulesConfig.Samplers, 1)
 
-	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "traces")
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
 	require.True(t, getResult.Found)
 	assert.Contains(t, processors, "transform/json_parser_1")
 
-	_, processors, _, getResult = collectorprovider.GetPipelineConfig(collectorConfig, "logs")
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 1, "Expected 1 logs pipeline, got %v", logsPipelineNames)
+
+	_, processors, _, getResult = collectorprovider.GetPipelineConfig(collectorConfig, logsPipelineNames[0].String())
 	require.True(t, getResult.Found)
 	assert.Contains(t, processors, "transform/json_parser_1")
 

--- a/tests/scenario_tests/parselogbodyasjson_processor_test.go
+++ b/tests/scenario_tests/parselogbodyasjson_processor_test.go
@@ -16,13 +16,12 @@ func TestParseLogBodyAsJSONProcessor(t *testing.T) {
 	assert.Len(t, rulesConfig.Samplers, 1)
 
 	// Should only have logs pipeline since ParseLogBodyAsJSON only works with logs
-	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "logs")
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 1, "Expected 1 logs pipeline, got %v", logsPipelineNames)
+
+	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, logsPipelineNames[0].String())
 	require.True(t, getResult.Found)
 	assert.Contains(t, processors, "transform/json_parser_1")
-
-	// Should not have traces pipeline
-	_, _, _, getResult = collectorprovider.GetPipelineConfig(collectorConfig, "traces")
-	require.False(t, getResult.Found)
 
 	transformConfig, findResult := collectorprovider.GetProcessorConfig[transformprocessor.Config](collectorConfig, "transform/json_parser_1")
 	require.True(t, findResult.Found, "Expected transform processor to be found, found (%v)", findResult.Components)
@@ -43,13 +42,12 @@ func TestParseLogBodyAsJSONProcessorStandalone(t *testing.T) {
 	assert.Len(t, rulesConfig.Samplers, 1)
 
 	// Should only have logs pipeline since ParseLogBodyAsJSON only works with logs
-	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "logs")
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 1, "Expected 1 logs pipeline, got %v", logsPipelineNames)
+
+	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, logsPipelineNames[0].String())
 	require.True(t, getResult.Found)
 	assert.Contains(t, processors, "transform/parse_log_body_1")
-
-	// Should not have traces pipeline
-	_, _, _, getResult = collectorprovider.GetPipelineConfig(collectorConfig, "traces")
-	require.False(t, getResult.Found)
 
 	transformConfig, findResult := collectorprovider.GetProcessorConfig[transformprocessor.Config](collectorConfig, "transform/parse_log_body_1")
 	require.True(t, findResult.Found, "Expected transform processor to be found, found (%v)", findResult.Components)

--- a/tests/scenario_tests/send_to_s3_archive_test.go
+++ b/tests/scenario_tests/send_to_s3_archive_test.go
@@ -18,8 +18,11 @@ func TestSendToS3Archive(t *testing.T) {
 	// First, verify that the refinery config was generated successfully
 	assert.Len(t, rulesConfig.Samplers, 1, "Expected 1 sampler in refinery config")
 
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
 	// Verify the S3 exporter is present in the traces pipeline
-	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, "traces")
+	_, _, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
 	require.True(t, getResult.Found, "Expected pipeline to be found")
 	assert.Len(t, exporters, 1, "Expected 1 exporter, got %s", exporters)
 


### PR DESCRIPTION
## Which problem is this PR solving?

Test tests assumed the first pipeline will not have a suffix

## Short description of the changes

Adds a helper so that you can get the first pipeline of a type