### PR TITLE
test: Added test for the various multiple pipeline scenarios

### DIFF
--- a/tests/scenario_tests/multiple_pipelines_test.go
+++ b/tests/scenario_tests/multiple_pipelines_test.go
@@ -24,14 +24,14 @@ func TestMultiplePipelines(t *testing.T) {
 	assert.NotEqual(t, secondLogsPipeline.Exporters[0], firstLogsPipeline.Exporters[0], "Expected different exporters in pipelines")
 
 	//  pipelines:
-	// 	  logs:
-	// 	    receivers: [otlp/OTel_Receiver_1]
-	// 	    processors: [usage, filter/Filter_Logs_by_Severity_1]
-	// 	    exporters: [otlphttp/Honeycomb_Exporter_1]
-	// 	  logs/1:
-	// 	    receivers: [otlp/OTel_Receiver_1]
+	//    logs:
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage, filter/Filter_Logs_by_Severity_1]
+	//      exporters: [otlphttp/Honeycomb_Exporter_1]
+	//    logs/1:
+	//      receivers: [otlp/OTel_Receiver_1]
 	//      processors: [usage]
-	// 	    exporters: [awss3/Send_to_S3_Archive_1]
+	//      exporters: [awss3/Send_to_S3_Archive_1]
 
 }
 
@@ -77,11 +77,11 @@ func TestMultiplePipelinesMultipleExporters(t *testing.T) {
 	//    logs/1:
 	//      receivers: [otlp/OTel_Receiver_1]
 	//      processors: [usage]
-	//     e xporters: [awss3/Send_to_S3_Archive_1]
+	//      exporters: [awss3/Send_to_S3_Archive_1]
 	//    logs/2:
 	//      receivers: [otlp/OTel_Receiver_1]
 	//      processors: [usage, filter/Filter_Logs_by_Severity_1]
-	//     e xporters: [otlphttp/Send_to_OTLP]
+	//      exporters: [otlphttp/Send_to_OTLP]
 
 }
 
@@ -134,17 +134,17 @@ func TestMultiplePipelinesSubProcessors(t *testing.T) {
 
 	// pipelines:
 	//    logs:
-	// 	    receivers: [otlp/OTel_Receiver_1]
-	// 	    processors: [usage, filter/Filter_Logs_by_Severity_1, transform/Parse_Log_Body_As_JSON_1]
-	// 	    exporters: [otlphttp/Send_to_OTLP]
-	// 	  logs/1:
-	// 	    receivers: [otlp/OTel_Receiver_1]
-	// 	    processors: [usage]
-	// 	    exporters: [awss3/Send_to_S3_Archive_1]
-	// 	  logs/2:
-	// 	    receivers: [otlp/OTel_Receiver_1]
-	// 	    processors: [usage, filter/Filter_Logs_by_Severity_1]
-	// 	   exporters: [otlphttp/Honeycomb_Exporter_1]
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage, filter/Filter_Logs_by_Severity_1, transform/Parse_Log_Body_As_JSON_1]
+	//      exporters: [otlphttp/Send_to_OTLP]
+	//    logs/1:
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage]
+	//      exporters: [awss3/Send_to_S3_Archive_1]
+	//    logs/2:
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage, filter/Filter_Logs_by_Severity_1]
+	//     exporters: [otlphttp/Honeycomb_Exporter_1]
 
 }
 
@@ -185,11 +185,11 @@ func TestMultiplePipelinesSingleExporter(t *testing.T) {
 
 	// pipelines:
 	//    logs:
-	// 	    receivers: [otlp/OTel_Receiver_1]
-	// 	    processors: [usage, filter/Info_Logs_only]
-	// 	    exporters: [otlphttp/Honeycomb_Exporter_1]
-	// 	  logs/1:
-	// 	    receivers: [otlp/OTel_Receiver_1]
-	// 	    processors: [usage]
-	// 	    exporters: [otlphttp/Honeycomb_Exporter_1]
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage, filter/Info_Logs_only]
+	//      exporters: [otlphttp/Honeycomb_Exporter_1]
+	//    logs/1:
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage]
+	//      exporters: [otlphttp/Honeycomb_Exporter_1]
 }

--- a/tests/scenario_tests/multiple_pipelines_test.go
+++ b/tests/scenario_tests/multiple_pipelines_test.go
@@ -1,0 +1,195 @@
+package hpsftests
+
+import (
+	"testing"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+)
+
+func TestMultiplePipelines(t *testing.T) {
+	_, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/multiple_pipelines.yaml")
+
+	//verify that there are 2 logs pipelines
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 2, "Expected 2 logs pipelines, got %v", logsPipelineNames)
+
+	firstLogsPipeline := collectorConfig.Service.Pipelines[logsPipelineNames[0]]
+	assert.Len(t, firstLogsPipeline.Exporters, 1, "Expected 1 exporter in pipeline")
+
+	secondLogsPipeline := collectorConfig.Service.Pipelines[logsPipelineNames[1]]
+	assert.Len(t, secondLogsPipeline.Exporters, 1, "Expected 1 exporter in pipeline")
+	assert.NotEqual(t, secondLogsPipeline.Exporters[0], firstLogsPipeline.Exporters[0], "Expected different exporters in pipelines")
+
+	//  pipelines:
+	// 	  logs:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	// 	    processors: [usage, filter/Filter_Logs_by_Severity_1]
+	// 	    exporters: [otlphttp/Honeycomb_Exporter_1]
+	// 	  logs/1:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage]
+	// 	    exporters: [awss3/Send_to_S3_Archive_1]
+
+}
+
+func TestMultiplePipelinesMultipleExporters(t *testing.T) {
+	_, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/multiple_pipelines_multiple_exporters.yaml")
+
+	usageProcessor := component.MustNewID("usage")
+	filterProcessor := component.MustNewIDWithName("filter", "Filter_Logs_by_Severity_1")
+	otelReceiver := component.MustNewIDWithName("otlp", "OTel_Receiver_1")
+	honeycombExporter := component.MustNewIDWithName("otlphttp", "Honeycomb_Exporter_1")
+	otlpExporter := component.MustNewIDWithName("otlphttp", "Send_to_OTLP")
+	s3Exporter := component.MustNewIDWithName("awss3", "Send_to_S3_Archive_1")
+
+	//verify that there are 2 logs pipelines
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 3, "Expected 2 logs pipelines, got %v", logsPipelineNames)
+
+	for _, pipelineName := range logsPipelineNames {
+		pipeline := collectorConfig.Service.Pipelines[pipelineName]
+
+		for _, exporter := range pipeline.Exporters {
+			if exporter == honeycombExporter || exporter == otlpExporter {
+				assert.Len(t, pipeline.Processors, 2, "Expected 2 processors in the pipeline for %s but got %s", exporter.String(), pipeline.Processors)
+				assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+				assert.Contains(t, pipeline.Processors, filterProcessor, "Expected filter processor")
+
+				assert.Len(t, pipeline.Receivers, 1, "Expected 1 receiver  in the pipeline for %s but got %s", exporter.String(), pipeline.Receivers)
+				assert.Contains(t, pipeline.Receivers, otelReceiver, "Expected OTel receiver")
+			} else if exporter == s3Exporter {
+				assert.Len(t, pipeline.Processors, 1, "Expected 1 processor in pipeline got %s", pipeline.Processors)
+				assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+			} else {
+				t.Errorf("Unexpected exporter %s in pipeline %s", exporter.String(), pipelineName.String())
+			}
+		}
+	}
+
+	//  pipelines:
+	//    logs:
+	//       receivers: [otlp/OTel_Receiver_1]
+	//       processors: [usage, filter/Filter_Logs_by_Severity_1]
+	//       exporters: [otlphttp/Honeycomb_Exporter_1]
+	//    logs/1:
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage]
+	//     e xporters: [awss3/Send_to_S3_Archive_1]
+	//    logs/2:
+	//      receivers: [otlp/OTel_Receiver_1]
+	//      processors: [usage, filter/Filter_Logs_by_Severity_1]
+	//     e xporters: [otlphttp/Send_to_OTLP]
+
+}
+
+func TestMultiplePipelinesSubProcessors(t *testing.T) {
+	_, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/multiple_pipelines_sub_processors.yaml")
+
+	usageProcessor := component.MustNewID("usage")
+	filterProcessor := component.MustNewIDWithName("filter", "Filter_Logs_by_Severity_1")
+	transformProcessor := component.MustNewIDWithName("transform", "Parse_Log_Body_As_JSON_1")
+	otelReceiver := component.MustNewIDWithName("otlp", "OTel_Receiver_1")
+	honeycombExporter := component.MustNewIDWithName("otlphttp", "Honeycomb_Exporter_1")
+	otlpExporter := component.MustNewIDWithName("otlphttp", "Send_to_OTLP")
+	s3Exporter := component.MustNewIDWithName("awss3", "Send_to_S3_Archive_1")
+
+	//verify that there are 2 logs pipelines
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+
+	for _, pipelineName := range logsPipelineNames {
+		pipeline := collectorConfig.Service.Pipelines[pipelineName]
+
+		for _, exporter := range pipeline.Exporters {
+			if exporter == otlpExporter {
+				assert.Len(t, pipeline.Processors, 3, "Expected 3 processors in pipeline got %s", pipeline.Processors)
+				assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+				assert.Contains(t, pipeline.Processors, filterProcessor, "Expected filter processor")
+				assert.Contains(t, pipeline.Processors, transformProcessor, "Expected transform processor")
+
+				assert.Len(t, pipeline.Receivers, 1, "Expected 1 receiver in pipeline got %s", pipeline.Receivers)
+				assert.Contains(t, pipeline.Receivers, otelReceiver, "Expected OTel receiver")
+
+			} else if exporter == s3Exporter {
+				assert.Len(t, pipeline.Processors, 1, "Expected 1 processor in pipeline got %s", pipeline.Processors)
+				assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+
+				assert.Len(t, pipeline.Receivers, 1, "Expected 1 receiver in pipeline got %s", pipeline.Receivers)
+				assert.Contains(t, pipeline.Receivers, otelReceiver, "Expected OTel receiver")
+
+			} else if exporter == honeycombExporter {
+				assert.Len(t, pipeline.Processors, 2, "Expected 2 processors in pipeline got %s", pipeline.Processors)
+				assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+				assert.Contains(t, pipeline.Processors, filterProcessor, "Expected filter processor")
+
+				assert.Len(t, pipeline.Receivers, 1, "Expected 1 receiver in pipeline got %s", pipeline.Receivers)
+				assert.Contains(t, pipeline.Receivers, otelReceiver, "Expected OTel receiver")
+			} else {
+				t.Errorf("Unexpected exporter %s in pipeline %s", exporter.String(), pipelineName.String())
+			}
+		}
+	}
+
+	// pipelines:
+	//    logs:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	// 	    processors: [usage, filter/Filter_Logs_by_Severity_1, transform/Parse_Log_Body_As_JSON_1]
+	// 	    exporters: [otlphttp/Send_to_OTLP]
+	// 	  logs/1:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	// 	    processors: [usage]
+	// 	    exporters: [awss3/Send_to_S3_Archive_1]
+	// 	  logs/2:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	// 	    processors: [usage, filter/Filter_Logs_by_Severity_1]
+	// 	   exporters: [otlphttp/Honeycomb_Exporter_1]
+
+}
+
+func TestMultiplePipelinesSingleExporter(t *testing.T) {
+	_, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/multiple_pipelines_single_exporter.yaml")
+
+	usageProcessor := component.MustNewID("usage")
+	filterProcessor := component.MustNewIDWithName("filter", "Info_Logs_only")
+	otelReceiver := component.MustNewIDWithName("otlp", "OTel_Receiver_1")
+	honeycombExporter := component.MustNewIDWithName("otlphttp", "Honeycomb_Exporter_1")
+
+	//verify that there are 2 logs pipelines
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 2, "Expected 2 logs pipelines, got %v", logsPipelineNames)
+
+	if len(collectorConfig.Service.Pipelines[logsPipelineNames[0]].Processors) ==
+		len(collectorConfig.Service.Pipelines[logsPipelineNames[1]].Processors) {
+		t.Errorf("Expected pipelines to have different number of processors")
+	}
+
+	for _, pipelineName := range logsPipelineNames {
+		pipeline := collectorConfig.Service.Pipelines[pipelineName]
+		assert.Len(t, pipeline.Exporters, 1, "Expected 1 exporter in pipeline")
+		assert.Equal(t, pipeline.Exporters[0], honeycombExporter, "Expected Honeycomb exporter")
+
+		assert.Len(t, pipeline.Receivers, 1, "Expected 1 receiver in pipeline got %s", pipeline.Receivers)
+		assert.Contains(t, pipeline.Receivers, otelReceiver, "Expected OTel receiver")
+
+		if len(pipeline.Processors) == 1 {
+			assert.Len(t, pipeline.Processors, 1, "Expected 1 processor in pipeline got %s", pipeline.Processors)
+			assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+		} else {
+			assert.Len(t, pipeline.Processors, 2, "Expected 2 processors in pipeline got %s", pipeline.Processors)
+			assert.Contains(t, pipeline.Processors, usageProcessor, "Expected usage processor")
+			assert.Contains(t, pipeline.Processors, filterProcessor, "Expected filter processor")
+		}
+	}
+
+	// pipelines:
+	//    logs:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	// 	    processors: [usage, filter/Info_Logs_only]
+	// 	    exporters: [otlphttp/Honeycomb_Exporter_1]
+	// 	  logs/1:
+	// 	    receivers: [otlp/OTel_Receiver_1]
+	// 	    processors: [usage]
+	// 	    exporters: [otlphttp/Honeycomb_Exporter_1]
+}

--- a/tests/scenario_tests/testdata/multiple_pipelines.yaml
+++ b/tests/scenario_tests/testdata/multiple_pipelines.yaml
@@ -1,0 +1,34 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Honeycomb Exporter_1
+    kind: HoneycombExporter
+  - name: Send to S3 Archive_1
+    kind: SendToS3Archive
+  - name: Filter Logs by Severity_1
+    kind: FilterLogBySeverity
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to S3 Archive_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Honeycomb Exporter_1
+      port: Logs
+      type: OTelLogs

--- a/tests/scenario_tests/testdata/multiple_pipelines_multiple_exporters.yaml
+++ b/tests/scenario_tests/testdata/multiple_pipelines_multiple_exporters.yaml
@@ -1,0 +1,44 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Honeycomb Exporter_1
+    kind: HoneycombExporter
+  - name: Send to S3 Archive_1
+    kind: SendToS3Archive
+  - name: Filter Logs by Severity_1
+    kind: FilterLogBySeverity
+  - name: Send to OTLP
+    kind: OTelHTTPExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to S3 Archive_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Honeycomb Exporter_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to OTLP
+      port: Logs
+      type: OTelLogs

--- a/tests/scenario_tests/testdata/multiple_pipelines_single_exporter.yaml
+++ b/tests/scenario_tests/testdata/multiple_pipelines_single_exporter.yaml
@@ -1,0 +1,32 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Info Logs only
+    kind: FilterLogBySeverity
+  - name: Honeycomb Exporter_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Info Logs only
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Info Logs only
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Honeycomb Exporter_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Honeycomb Exporter_1
+      port: Logs
+      type: OTelLogs

--- a/tests/scenario_tests/testdata/multiple_pipelines_sub_processors.yaml
+++ b/tests/scenario_tests/testdata/multiple_pipelines_sub_processors.yaml
@@ -1,0 +1,54 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Honeycomb Exporter_1
+    kind: HoneycombExporter
+  - name: Send to S3 Archive_1
+    kind: SendToS3Archive
+  - name: Filter Logs by Severity_1
+    kind: FilterLogBySeverity
+  - name: Send to OTLP
+    kind: OTelHTTPExporter
+  - name: Parse Log Body As JSON_1
+    kind: ParseLogBodyAsJSON
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to S3 Archive_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: OTel Receiver_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Honeycomb Exporter_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Parse Log Body As JSON_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Parse Log Body As JSON_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to OTLP
+      port: Logs
+      type: OTelLogs


### PR DESCRIPTION
## Which problem is this PR solving?

No validation that HPSF definitions that should generate distinct pipelines is actually doing that.

## Short description of the changes

This is only tests to ensure that changes don't break that functionality. These should be resilient to pipeline consolidation when that happens.
