### PR TITLE
fix(validation): Fixed the validation for properties that aren't supplied

### DIFF
--- a/pkg/config/templateProperty.go
+++ b/pkg/config/templateProperty.go
@@ -142,6 +142,10 @@ func positive(val any) bool {
 // ensures that no strings are blank, even in string slices
 // use nonempty to ensure that a slace has at least one value
 func noBlankStrings(val any) bool {
+	// nil happens when there is no default value and no value is supplied
+	if val == nil {
+		return false
+	}
 	switch v := val.(type) {
 	case string:
 		return len(v) > 0

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -138,11 +138,14 @@ func (t *Translator) ValidateConfig(h *hpsf.HPSF) error {
 		}
 
 		// Get the template properties from the template component.
-		tprops := tmpl.Props()
+		templateProperties := tmpl.Props()
+		var mappedSuppliedProperties map[string]hpsf.Property
+
+		mappedSuppliedProperties = make(map[string]hpsf.Property)
 		for _, prop := range c.Properties {
-			// validate each property against the template component's basic validation rules
-			tp, ok := tprops[prop.Name]
-			if !ok {
+			mappedSuppliedProperties[prop.Name] = prop
+			_, foundProperty := templateProperties[prop.Name]
+			if !foundProperty {
 				// If the property is not found in the template component's
 				// properties, something's messed up. This means the property is
 				// not defined in the template component.
@@ -150,17 +153,25 @@ func (t *Translator) ValidateConfig(h *hpsf.HPSF) error {
 					WithComponent(c.Name).
 					WithProperty(prop.Name)
 			}
+		}
+		for _, prop := range templateProperties {
+			// validate each property against the template component's basic validation rules
+			suppliedProperty, foundProperty := mappedSuppliedProperties[prop.Name]
+			if !foundProperty {
+				// If the property is not supplied, use the default value from the template component.
+				suppliedProperty = hpsf.Property{Name: prop.Name, Value: prop.Default}
+			}
 
 			// Now validate the property against the template property's validation rules.
-			if err := tp.Validate(prop); err != nil {
+			if validateError := prop.Validate(suppliedProperty); validateError != nil {
 				// if the property fails validation, add the error to the result
 				// this means the property itself has some issues
 				// we want to include the component name and property name in the error message for clarity
-				herr := hpsf.NewError("failed to validate property").
-					WithCause(err).
+				hspfError := hpsf.NewError("failed to validate property").
+					WithCause(validateError).
 					WithComponent(c.Name).
 					WithProperty(prop.Name)
-				result.Add(herr)
+				result.Add(hspfError)
 			}
 		}
 	}

--- a/pkg/translator/translator_property_validation_test.go
+++ b/pkg/translator/translator_property_validation_test.go
@@ -1,0 +1,75 @@
+package translator
+
+import (
+	"testing"
+
+	"github.com/honeycombio/hpsf/pkg/config"
+	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPropertyValidation(t *testing.T) {
+
+	t.Run("Validate should error if a noblanks string is not supplied and there is no default", func(t *testing.T) {
+		translator := NewEmptyTranslator()
+
+		noBlanksComponent := config.TemplateComponent{
+			Kind: "NoBlanksComponent",
+			Properties: []config.TemplateProperty{
+				{Name: "Mandatory", Type: hpsf.PTYPE_STRING, Validations: []string{"noblanks"}},
+			},
+		}
+
+		translator.InstallComponents(map[string]config.TemplateComponent{
+			noBlanksComponent.Kind: noBlanksComponent,
+		})
+
+		hpsfDocument := hpsf.HPSF{
+			Components: []*hpsf.Component{
+				{
+					Name: "TestComponent",
+					Kind: noBlanksComponent.Kind,
+				},
+			},
+		}
+
+		err := translator.ValidateConfig(&hpsfDocument)
+		require.Error(t, err)
+		require.IsType(t, validator.Result{}, err)
+		validationError := err.(validator.Result)
+		fieldValidationError := validationError.Details[0].(*hpsf.HPSFError)
+		require.Equal(t, noBlanksComponent.Properties[0].Name, fieldValidationError.Property)
+		assert.Equal(t, "failed to validate property", fieldValidationError.Reason)
+		assert.Equal(t, "TestComponent", fieldValidationError.Component)
+		assert.Equal(t, hpsf.ErrorSeverity("E"), fieldValidationError.Severity)
+	})
+
+	t.Run("Validate should error if a noblanks string is not supplied and there is a default", func(t *testing.T) {
+		translator := NewEmptyTranslator()
+
+		noBlanksComponent := config.TemplateComponent{
+			Kind: "NoBlanksComponent",
+			Properties: []config.TemplateProperty{
+				{Name: "Mandatory", Type: hpsf.PTYPE_STRING, Validations: []string{"noblanks"}, Default: "default"},
+			},
+		}
+
+		translator.InstallComponents(map[string]config.TemplateComponent{
+			noBlanksComponent.Kind: noBlanksComponent,
+		})
+
+		hpsfDocument := hpsf.HPSF{
+			Components: []*hpsf.Component{
+				{
+					Name: "TestComponent",
+					Kind: noBlanksComponent.Kind,
+				},
+			},
+		}
+
+		err := translator.ValidateConfig(&hpsfDocument)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Validation logic for non-supplied parameters wasn't working

## Short description of the changes

- Inverted the loops for checking the properties so it uses the TemplateComponent as the source, and not the user supplied information.
- Added tests
