### PR TITLE
fix: Update redaction component tests logs pipeline names

### DIFF
--- a/pkg/translator/testdata/collector_config/redactionprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/redactionprocessor_all.yaml
@@ -34,7 +34,7 @@ extensions:
 service:
     extensions: [honeycomb]
     pipelines:
-        logs:
+        logs/2e6-4c3:
             receivers: [otlp/otlp_in]
             processors: [usage, redaction/redaction_processor_1]
             exporters: [otlphttp/otlp_out]

--- a/pkg/translator/testdata/collector_config/redactionprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/redactionprocessor_defaults.yaml
@@ -28,7 +28,7 @@ extensions:
 service:
     extensions: [honeycomb]
     pipelines:
-        logs:
+        logs/2e6-4c3:
             receivers: [otlp/otlp_in]
             processors: [usage, redaction/redaction_processor_1]
             exporters: [otlphttp/otlp_out]


### PR DESCRIPTION
## Which problem is this PR solving?

There was an undetected merge conflict after merging the redaction processor which caused some of it's tests to fail because the logs pipeline names were different.

## Short description of the changes

- Update logs pipeline names so tests pass

