### PR TITLE
fix: Update StartSampling UseTLS label

### DIFF
--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -60,7 +60,7 @@ properties:
       Can be used to send data with TLS.
       Since Refinery does not use TLS, this is off by default.
     type: bool
-    subtype: label("Disable TLS export")
+    subtype: label("Enable TLS export")
     default: false
     advanced: true
   - name: BatchTimeout


### PR DESCRIPTION
## Which problem is this PR solving?

The StartSampling's embedded label is wrong. It should be Enabled instead of Disable.

- Failing test will be fixed by https://github.com/honeycombio/hpsf/pull/137

## Short description of the changes

- Update StartSampling component's UI label

