### PR TITLE
feat: Add APIPort parameter to HoneycombExporter

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -55,7 +55,17 @@ properties:
     validations:
       - noblanks
       - url
-    default: https://api.honeycomb.io:443
+    default: https://api.honeycomb.io
+    advanced: true
+  - name: APIPort
+    summary: The port on which to send traffic.
+    description: |
+      The port on which to send outgoing traffic. Default is 443, which is
+      the value expected by Honeycomb.
+    type: int
+    validations:
+      - inrange(1, 65535)
+    default: 443
     advanced: true
   - name: Mode
     summary: Configures when to use the the APIKey.
@@ -115,7 +125,7 @@ templates:
     format: dotted
     data:
       - key: Network.HoneycombAPI
-        value: "{{ .Values.APIEndpoint }}"
+        value: "{{ .Values.APIEndpoint }}:{{ .Values.APIPort }}"
       - key: AccessKeys.SendKey
         value: "{{ .Values.APIKey }}"
         suppress_if: '{{ eq "none" (or .Values.APIKey .User.APIKey) }}'
@@ -130,7 +140,7 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "{{ .Values.APIEndpoint }}"
+        value: "{{ .Values.APIEndpoint }}:{{ .Values.APIPort }}"
       - key: "{{ .ComponentName }}.tls.insecure"
         value: "{{ .Values.Insecure | encodeAsBool }}"
         suppress_if: "{{ not .Values.Insecure }}"

--- a/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/hpsf/honeycombexporter_all.yaml
@@ -7,7 +7,9 @@ components:
     kind: HoneycombExporter
     properties:
       - name: APIEndpoint
-        value: https://alternative.honeycomb.io:8080
+        value: https://alternative.honeycomb.io
+      - name: APIPort
+        value: 8080
       - name: APIKey
         value: abcdef1234567890abcdef1 # a validly-formatted key
       - name: Mode


### PR DESCRIPTION
## Which problem is this PR solving?

The HoneycombExporter's APIEndpoint parameter is expected to include a port when overriding. This fails validation rules which expect no port to be provide. This PR adds a new APIPort parameter.

The following PR improves validation logic and would highly this problem:
- https://github.com/honeycombio/hpsf/pull/136

## Short description of the changes

- Adds a new APIPort parameter to the HoneycombExporter component
- Update tests to use new parameter

