### PR TITLE
fix: Remove nonempty validators for redact properties

### DIFF
--- a/pkg/data/components/RedactionProcessor.yaml
+++ b/pkg/data/components/RedactionProcessor.yaml
@@ -34,7 +34,6 @@ properties:
     type: stringarray
     validations:
       - noblanks
-      - nonempty
     default: []
   - name: AttributeValuePatternsToRedact
     summary: Regular expression patterns of attribute values to redact.
@@ -44,7 +43,6 @@ properties:
     type: stringarray
     validations:
       - noblanks
-      - nonempty
     default:
       - 4[0-9]{12}(?:[0-9]{3})? ## Visa credit card number
       - (5[1-5][0-9]{14})       ## MasterCard number
@@ -57,7 +55,6 @@ properties:
     type: stringarray
     validations:
       - noblanks
-      - nonempty
     default: []
     advanced: true
 templates:


### PR DESCRIPTION
## Which problem is this PR solving?

Validation fails for the Redaction processor because it requires at least one, non-empty entry for each of the names to redact, values to redact and names to not redact. Each of these properties should be optional, not requried.

## Short description of the changes
- Remove the `nonempty` validator for each of the properties

