### PR TITLE
maint: Update existing component ports wit a consistent order

### DIFF
--- a/pkg/data/components/FilterProcessor.yaml
+++ b/pkg/data/components/FilterProcessor.yaml
@@ -19,12 +19,21 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
+  - name: Traces
+    direction: output
+    type: OTelTraces
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Logs
+    direction: output
+    type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Metrics
+    direction: output
+    type: OTelMetrics
 properties:
   - name: Rules
     type: rule

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -20,12 +20,12 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 properties:
   - name: APIKey
     summary: The API key to use to authenticate with Honeycomb.

--- a/pkg/data/components/NopExporter.yaml
+++ b/pkg/data/components/NopExporter.yaml
@@ -21,12 +21,12 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 templates:
   - kind: collector_config
     name: nop_exporter_collector

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -19,14 +19,14 @@ tags:
   - signal:OTelLogs
 ports:
   - name: Traces
-    direction: output
+    direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: output
-    type: OTelMetrics
   - name: Logs
-    direction: output
+    direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 templates:
   - kind: collector_config
     name: nop_receiver_collector

--- a/pkg/data/components/OTelDebugExporter.yaml
+++ b/pkg/data/components/OTelDebugExporter.yaml
@@ -20,12 +20,12 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 properties:
   - name: Verbosity
     summary: The verbosity level of the debug output.

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -18,12 +18,12 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 properties:
   - name: Headers
     summary: Headers to emit when sending gRPC traffic.

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -18,12 +18,12 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 properties:
   - name: Headers
     summary: Headers to emit when sending HTTP traffic.

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -19,12 +19,12 @@ ports:
   - name: Traces
     direction: output
     type: OTelTraces
-  - name: Metrics
-    direction: output
-    type: OTelMetrics
   - name: Logs
     direction: output
     type: OTelLogs
+  - name: Metrics
+    direction: output
+    type: OTelMetrics
 properties:
   - name: Host
     summary: The hostname or IP address on which to listen

--- a/pkg/data/components/ParseAttributeAsJSON.yaml
+++ b/pkg/data/components/ParseAttributeAsJSON.yaml
@@ -14,18 +14,18 @@ tags:
   - signal:OTelTraces
   - signal:OTelLogs
 ports:
+  - name: Traces
+    direction: input
+    type: OTelTraces
+  - name: Traces
+    direction: output
+    type: OTelTraces
   - name: Logs
     direction: input
     type: OTelLogs
   - name: Logs
     direction: output
     type: OTelLogs
-  - name: Spans
-    direction: input
-    type: OTelTraces
-  - name: Spans
-    direction: output
-    type: OTelTraces
 properties:
   - name: Attribute
     type: string

--- a/pkg/data/components/RedactionProcessor.yaml
+++ b/pkg/data/components/RedactionProcessor.yaml
@@ -19,12 +19,21 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
+  - name: Traces
+    direction: output
+    type: OTelTraces
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Logs
+    direction: output
+    type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Metrics
+    direction: output
+    type: OTelMetrics
 properties:
   - name: AttributeNamePatternsToRedact
     summary: Regular expression patterns of attribute names to redact.

--- a/pkg/data/components/SendToS3Archive.yaml
+++ b/pkg/data/components/SendToS3Archive.yaml
@@ -18,12 +18,12 @@ ports:
   - name: Traces
     direction: input
     type: OTelTraces
-  - name: Metrics
-    direction: input
-    type: OTelMetrics
   - name: Logs
     direction: input
     type: OTelLogs
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
 properties:
   - name: Bucket
     summary: The S3 bucket in which to store the data.

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -15,15 +15,15 @@ tags:
   - signal:HoneycombEvents
   - vendor:Honeycomb
 ports:
+  - name: Events
+    direction: output
+    type: HoneycombEvents
   - name: Traces
     direction: input
     type: OTelTraces
   - name: Logs
     direction: input
     type: OTelLogs
-  - name: Events
-    direction: output
-    type: HoneycombEvents
 properties:
   - name: Host
     summary: The hostname or IP address on which to listen.


### PR DESCRIPTION
## Which problem is this PR solving?

Component ports should follow a consistent order definition consistency and predictably constructing workflows and minimising crossed connections. The order of the ports is used in the builder when drawing the components.

- Closes https://github.com/honeycombio/pipeline-team/issues/496

## Short description of the changes

- Updates all existing components to ports are defined in the following order:
  - Events -> Traces -> Logs -> Metrics
- Adds missing output port entries for the filter and redaction processors
- Update the NopExporter ports from outputs to inputs
- Rename Spans port to Traces for ParseAttributeAsJSON processor