### PR TITLE
fix: minor updates to component names & properties

### DIFF
--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -1,13 +1,14 @@
 kind: HoneycombExporter
-name: Honeycomb Exporter
+name: Send to Honeycomb
 style: exporter
 logo: honeycomb
 type: base
 status: alpha
 version: v0.1.0
-summary: Sends traces to Honeycomb in Honeycomb's event format.
+summary: Sends telemetry to Honeycomb's data store for real-time analysis.
 description: |
-  This component exports traces to Honeycomb in Honeycomb's event format.
+  This component sends telemetry traces, logs, metrics, and Honeycomb-formatted 
+  events to the Honeycomb's data store for real-time analysis.
 tags:
   - category:exporter
   - service:refinery

--- a/pkg/data/components/NopExporter.yaml
+++ b/pkg/data/components/NopExporter.yaml
@@ -4,7 +4,7 @@ version: v0.1.0
 style: exporter
 logo: opentelemetry
 type: base
-status: alpha
+status: development
 summary: An "exporter" that does nothing, but might be useful for testing.
 description: |
   A simple no-op exporter.

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -3,7 +3,7 @@ name: DefaultNopReceiver
 version: v0.1.0
 style: receiver
 logo: opentelemetry
-type: base
+type: development
 status: alpha
 summary: A no-op "receiver" that does nothing, but might be useful for testing.
 description: |

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -3,8 +3,8 @@ name: DefaultNopReceiver
 version: v0.1.0
 style: receiver
 logo: opentelemetry
-type: development
-status: alpha
+type: base
+status: development
 summary: A no-op "receiver" that does nothing, but might be useful for testing.
 description: |
   A simple no-op receiver.

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -1,11 +1,11 @@
 kind: OTelGRPCExporter
-name: OTel gRPC Exporter
+name: Send OTel via gRPC
 type: base
 style: exporter
 logo: opentelemetry
 status: alpha
 version: v0.1.0
-summary: Sends telemetry in OTLP (OpenTelemetry) format via gRPC.
+summary: Sends telemetry in OpenTelemetry (OTLP) format via gRPC.
 description: |
   Exports OpenTelemetry signals using OTLP via gRPC.
 tags:

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -1,11 +1,11 @@
 kind: OTelHTTPExporter
-name: Send to Honeycomb
+name: Send OTel via HTTP
 style: exporter
 logo: opentelemetry
 type: base
 status: alpha
 version: v0.1.0
-summary: Sends telemetry in OTLP (OpenTelemetry) format via HTTP.
+summary: Sends telemetry in OpenTelemetry (OTLP) format via HTTP.
 description: |
   Exports OpenTelemetry signals using OTLP via HTTP.
 tags:

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -56,6 +56,7 @@ properties:
       configured. This properties supports sending a map of header keys and
       values.
     type: map
+    advanced: true
   - name: UseTLS
     summary: Provide a way to enable TLS export.
     description: |


### PR DESCRIPTION
## Which problem is this PR solving?

While building a pipeline, I accidentally pulled in the OTel HTTP exporter because it was called "Send to Honeycomb". This should be the name of the Honeycomb exporter. So I went into to make that update, and made a few more related ones while I was here.

## Short description of the changes

- Renamed OTelHTTPExporter from "Send to Honeycomb" to "Send OTel via HTTP"
- Renamed OTelGRPCExporter from "OTel gRPC Exporter" to "Send OTel via gRPC" (to match)
- Renamed HoneycombExporter from "Honeycomb Exporter" to "Send to Honeycomb"
- Hid the Nop receiver and exporter, because they don't guide users enough to be valuable right now.
- Moved the Headers property in the StartSampling component into Advanced, as discussed in a previous Slack thread.
- Made some minor updates to summaries and descriptions.

