### PR TITLE
fix: automatically set otlp http exporter scheme based on insecure

### DIFF
--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -102,7 +102,7 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "http{{ if not .Values.Insecure }}s{{ end }}://{{ .Values.Host }}:{{ .Values.Port }}"
+        value: "{{ buildurl .Values.Insecure .Values.Host .Values.Port }}"
       - key: "{{ .ComponentName }}.tls.insecure"
         value: "{{ .Values.Insecure | encodeAsBool }}"
         suppress_if: "{{ not .Values.Insecure }}"

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -102,13 +102,13 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "{{ .Values.Host }}:{{ .Values.Port }}"
+        value: "http{{ if not .Values.Insecure }}s{{ end }}://{{ .Values.Host }}:{{ .Values.Port }}"
       - key: "{{ .ComponentName }}.tls.insecure"
-        value: "{{ .HProps.Insecure | encodeAsBool }}"
-        suppress_if: "{{ not .HProps.Insecure }}"
+        value: "{{ .Values.Insecure | encodeAsBool }}"
+        suppress_if: "{{ not .Values.Insecure }}"
       - key: "{{ .ComponentName }}.headers"
-        value: "{{ .HProps.Headers | encodeAsMap }}"
-        suppress_if: "{{ not .HProps.Headers }}"
+        value: "{{ .Values.Headers | encodeAsMap }}"
+        suppress_if: "{{ not .Values.Headers }}"
       - key: "{{ .ComponentName }}.sending_queue.queue_size"
         value: "{{ .Values.QueueSize | encodeAsInt }}"
       - key: "{{ .ComponentName }}.sending_queue.enabled"

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -106,7 +106,7 @@ templates:
       collectorComponentName: otlphttp
     data:
       - key: "{{ .ComponentName }}.endpoint"
-        value: "http{{ if .Values.UseTLS }}s{{ end }}://{{ .Values.Host }}:{{ .Values.Port }}"
+        value: "{{ buildurl (not .Values.UseTLS) .Values.Host .Values.Port }}"
       - key: "{{ .ComponentName }}.tls.insecure"
         value: "{{ not .Values.UseTLS | encodeAsBool }}"
         suppress_if: "{{ .Values.UseTLS }}"

--- a/pkg/translator/testdata/collector_config/default.yaml
+++ b/pkg/translator/testdata/collector_config/default.yaml
@@ -9,7 +9,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/OTel_HTTP_Exporter_1:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         headers:
             x-honeycomb-team: ${HONEYCOMB_API_KEY}
         sending_queue:

--- a/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
@@ -13,7 +13,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
@@ -9,7 +9,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_all.yaml
@@ -9,7 +9,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: myhost.com:1234
+        endpoint: http://myhost.com:1234
         headers:
             x-honeycomb-dataset: custom
             x-honeycomb-team: ${HONEYCOMB_API_KEY}

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
@@ -9,7 +9,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/parseattributeasjson_all.yaml
+++ b/pkg/translator/testdata/collector_config/parseattributeasjson_all.yaml
@@ -18,7 +18,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/parseattributeasjson_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/parseattributeasjson_defaults.yaml
@@ -18,7 +18,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/parselogbodyasjson_all.yaml
+++ b/pkg/translator/testdata/collector_config/parselogbodyasjson_all.yaml
@@ -18,7 +18,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/parselogbodyasjson_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/parselogbodyasjson_defaults.yaml
@@ -18,7 +18,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/redactionprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/redactionprocessor_all.yaml
@@ -20,7 +20,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/redactionprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/redactionprocessor_defaults.yaml
@@ -14,7 +14,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/symbolicatorprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/symbolicatorprocessor_all.yaml
@@ -14,7 +14,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/symbolicatorprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/symbolicatorprocessor_defaults.yaml
@@ -15,7 +15,7 @@ processors:
     usage: {}
 exporters:
     otlphttp/otlp_out:
-        endpoint: api.honeycomb.io:443
+        endpoint: https://api.honeycomb.io:443
         sending_queue:
             batch:
                 flush_timeout: 200ms


### PR DESCRIPTION
## Which problem is this PR solving?

- We updated the validators to enforce that the Host property is a host or IP, like we wanted, but we also needed to update the template to set the scheme since it was no longer settable via the Host property.

The otlp http exporter now sets the http scheme based on the `insecure` property. This follows the same strategy the StartSampling component uses.

## Short description of the changes

- Update OTLP HTTP exporter component to set an http scheme based on Insecure propty.
- Update template to use `.Values`.
- Update tests.  


