### PR TITLE
fix: Fix rule rendering bug related to indexing

### DIFF
--- a/pkg/config/tmpl/dottedconfig.go
+++ b/pkg/config/tmpl/dottedconfig.go
@@ -207,12 +207,6 @@ func (dc DottedConfig) Merge(other TemplateConfig) TemplateConfig {
 	}
 	baseIndices := dc.FindIndexedValues()
 	for k, v := range otherDotted {
-		// if we haven't seen this key before, we can just add it
-		if _, ok := dc[k]; !ok {
-			dc[k] = v
-			continue
-		}
-
 		// let's check if we need to adjust the value based on indices
 		otherKey, otherIndex, ok := findIndexedValue(k)
 		if ok {

--- a/tests/scenario_tests/sampler_rule_override_test.go
+++ b/tests/scenario_tests/sampler_rule_override_test.go
@@ -1,0 +1,31 @@
+package hpsftests
+
+import (
+	"testing"
+
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSamplerRuleOverride(t *testing.T) {
+	rulesConfig, _, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/sampler_rule_override.yaml")
+
+	assert.Len(t, rulesConfig.Samplers, 1)
+
+	assert.Len(t, rulesConfig.Samplers["__default__"].RulesBasedSampler.Rules, 4)
+	rules := rulesConfig.Samplers["__default__"].RulesBasedSampler.Rules
+	assert.Contains(t, rules[0].Name, "Keep traces")
+	assert.Equal(t, 1, rules[0].SampleRate)
+	assert.Equal(t, "exists", rules[0].Conditions[0].Operator)
+
+	assert.Contains(t, rules[1].Name, "500")
+	assert.Equal(t, 1, rules[1].SampleRate)
+	assert.Equal(t, ">=", rules[1].Conditions[0].Operator)
+
+	assert.Contains(t, rules[2].Name, "400")
+	assert.Equal(t, 10, rules[2].SampleRate)
+	assert.Equal(t, "400", rules[2].Conditions[0].Value)
+
+	assert.Contains(t, rules[3].Name, "remainder")
+	assert.Equal(t, 100, rules[3].SampleRate)
+}

--- a/tests/scenario_tests/testdata/sampler_rule_override.yaml
+++ b/tests/scenario_tests/testdata/sampler_rule_override.yaml
@@ -1,0 +1,45 @@
+# This validates that multiple samplers can compose their rules
+components:
+  - name: receiver
+    kind: OTelReceiver
+  - name: Start Sampling 1
+    kind: StartSampling
+  - name: Keep Errors_1
+    kind: KeepErrors
+  - name: Sample Based on HTTP Status_1
+    kind: SampleByHTTPStatus
+  - name: honeycomb
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: receiver
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling 1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling 1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Keep Errors_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Keep Errors_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Sample Based on HTTP Status_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Sample Based on HTTP Status_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: honeycomb
+      port: Events
+      type: HoneycombEvents


### PR DESCRIPTION
## Which problem is this PR solving?

- Composing samplers could fail because the indexing rule was being skipped naively.

## Short description of the changes

- Delete optimization
- Add a scenario test for it

