### PR TITLE
rel: Revert the revert for "fix: Remove environment property from samplers"

### DIFF
--- a/examples/hpsf.yaml
+++ b/examples/hpsf.yaml
@@ -11,13 +11,6 @@ components:
       - name: Events
         direction: output
         type: HoneycombEvents
-    properties:
-      - name: Environment
-        value: __default__
-        type: string
-      - name: SampleRate
-        value: 10
-        type: int
   - name: HoneycombExporter_2
     kind: HoneycombExporter
     ports:

--- a/examples/hpsf2.yaml
+++ b/examples/hpsf2.yaml
@@ -4,8 +4,6 @@ components:
     properties:
       - name: SampleRate
         value: 99
-      - name: Environment
-        value: staging
   - name: HoneycombExporter_2
     kind: HoneycombExporter
   - name: HoneycombExporter_1

--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -24,14 +24,6 @@ ports:
     type: HoneycombEvents
     note: "The traces that are sampled"
 properties:
-  - name: Environment
-    summary: The environment in which to enable the sampler.
-    description: |
-      The environment in which to enable the sampler. If this field is
-      not specified, the sampler will be enabled in the __default__ environment,
-      which is what is used if the environment specified in the trace is not found.
-    type: string
-    default: "__default__"
   - name: SampleRate
     summary: The target SampleRate.
     description: |
@@ -48,7 +40,7 @@ templates:
     name: DeterministicSampler_RefineryRules
     format: rules
     meta:
-      env: "{{ .Values.Environment }}"
+      env: "__default__"
       sampler: DeterministicSampler
     data:
       - key: SampleRate

--- a/pkg/data/components/EmaThroughput.yaml
+++ b/pkg/data/components/EmaThroughput.yaml
@@ -27,14 +27,6 @@ ports:
     type: HoneycombEvents
     note: "The traces that are sampled (retained for further processing)"
 properties:
-  - name: Environment
-    summary: The environment in which to enable the sampler.
-    description: |
-      The environment in which to enable the sampler. If this field is
-      not specified, the sampler will be enabled in the __default__ environment,
-      which is what is used if the environment specified in the trace is not found.
-    type: string
-    default: "__default__"
   - name: GoalThroughputPerSec
     summary: The target throughput to achieve (in events per second).
     description: |
@@ -79,7 +71,7 @@ templates:
     name: EMA_Throughput_Rules
     format: rules
     meta:
-      env: "{{ .Values.Environment }}"
+      env: "__default__"
       sampler: EMAThroughputSampler
     data:
       - key: GoalThroughputPerSec

--- a/pkg/data/components/KeepErrors.yaml
+++ b/pkg/data/components/KeepErrors.yaml
@@ -24,14 +24,6 @@ ports:
     direction: output
     type: HoneycombEvents
 properties:
-  - name: Environment
-    summary: The environment in which to enable the sampler.
-    description: |
-      The environment in which to enable the sampler. If this field is
-      not specified, the sampler will be enabled in the __default__ environment,
-      which is what is used if the environment specified in the trace is not found.
-    type: string
-    default: "__default__"
   - name: FieldName
     summary: The name of the field to check for errors.
     description: |
@@ -53,7 +45,7 @@ templates:
     name: KeepErrors_RefineryRules
     format: rules
     meta:
-      env: "{{ .Values.Environment }}"
+      env: "__default__"
       sampler: RulesBasedSampler
     data:
       - key: Rules[0].Name

--- a/pkg/data/components/SampleByHTTPStatus.yaml
+++ b/pkg/data/components/SampleByHTTPStatus.yaml
@@ -26,14 +26,6 @@ ports:
     direction: output
     type: HoneycombEvents
 properties:
-  - name: Environment
-    summary: The environment in which to enable the sampler.
-    description: |
-      The environment in which to enable the sampler. If this field is
-      not specified, the sampler will be enabled in the __default__ environment,
-      which is what is used if the environment specified in the trace is not found.
-    type: string
-    default: "__default__"
   - name: ErrorRate
     summary: The sample rate to use if the trace contains error spans (http 500s).
     description: |
@@ -63,7 +55,7 @@ templates:
     name: Drop_RefineryRules
     format: rules
     meta:
-      env: "{{ .Values.Environment }}"
+      env: "__default__"
       sampler: RulesBasedSampler
     data:
       - key: Rules[0].Name

--- a/pkg/data/components/SampleByTraceDuration.yaml
+++ b/pkg/data/components/SampleByTraceDuration.yaml
@@ -24,14 +24,6 @@ ports:
     direction: output
     type: HoneycombEvents
 properties:
-  - name: Environment
-    summary: The environment in which to enable the sampler.
-    description: |
-      The environment in which to enable the sampler. If this field is
-      not specified, the sampler will be enabled in the __default__ environment,
-      which is what is used if the environment specified in the trace is not found.
-    type: string
-    default: "__default__"
   - name: Duration
     summary: Traces longer than this duration (in milliseconds) will be sampled at the specified rate.
     description: |
@@ -56,7 +48,7 @@ templates:
     name: KeepErrors_RefineryRules
     format: rules
     meta:
-      env: "{{ .Values.Environment }}"
+      env: "__default__"
       sampler: RulesBasedSampler
     data:
       - key: Rules[0].Name

--- a/pkg/data/testdata/DeterministicSampler_output_refinery_rules.yaml
+++ b/pkg/data/testdata/DeterministicSampler_output_refinery_rules.yaml
@@ -2,7 +2,4 @@ RulesVersion: 2
 Samplers:
     __default__:
         DeterministicSampler:
-            SampleRate: 1
-    staging:
-        DeterministicSampler:
             SampleRate: 42

--- a/pkg/data/testdata/EmaThroughput_output_refinery_rules.yaml
+++ b/pkg/data/testdata/EmaThroughput_output_refinery_rules.yaml
@@ -1,9 +1,6 @@
 RulesVersion: 2
 Samplers:
     __default__:
-        DeterministicSampler:
-            SampleRate: 1
-    staging:
         EMAThroughputSampler:
             AdjustmentInterval: 120s
             FieldList:

--- a/pkg/translator/testdata/bad_hpsf/missing_port.yaml
+++ b/pkg/translator/testdata/bad_hpsf/missing_port.yaml
@@ -6,8 +6,6 @@ components:
   - name: EMAThroughput_1
     kind: EMAThroughput
     properties:
-      - name: Environment
-        value: test
       - name: AdjustmentInterval
         value: 120
       - name: FieldList

--- a/pkg/translator/testdata/hpsf/deterministicsampler_all.yaml
+++ b/pkg/translator/testdata/hpsf/deterministicsampler_all.yaml
@@ -6,8 +6,6 @@ components:
   - name: DeterministicSampler_1
     kind: DeterministicSampler
     properties:
-      - name: Environment
-        value: test
       - name: SampleRate
         value: 90
 connections:

--- a/pkg/translator/testdata/hpsf/emathroughput_all.yaml
+++ b/pkg/translator/testdata/hpsf/emathroughput_all.yaml
@@ -6,8 +6,6 @@ components:
   - name: EMAThroughput_1
     kind: EMAThroughput
     properties:
-      - name: Environment
-        value: test
       - name: AdjustmentInterval
         value: 120
       - name: FieldList

--- a/pkg/translator/testdata/hpsf/keeperrors_all.yaml
+++ b/pkg/translator/testdata/hpsf/keeperrors_all.yaml
@@ -6,8 +6,6 @@ components:
   - name: sampler
     kind: KeepErrors
     properties:
-      - name: Environment
-        value: test
       - name: SampleRate
         value: 123
       - name: FieldName

--- a/pkg/translator/testdata/hpsf/samplebyhttpstatus_all.yaml
+++ b/pkg/translator/testdata/hpsf/samplebyhttpstatus_all.yaml
@@ -6,8 +6,6 @@ components:
   - name: sampler
     kind: SampleByHTTPStatus
     properties:
-      - name: Environment
-        value: test
       - name: ErrorRate
         value: 90
       - name: UserErrorRate

--- a/pkg/translator/testdata/hpsf/samplebytraceduration_all.yaml
+++ b/pkg/translator/testdata/hpsf/samplebytraceduration_all.yaml
@@ -6,8 +6,6 @@ components:
   - name: sampler
     kind: SampleByTraceDuration
     properties:
-      - name: Environment
-        value: test
       - name: SampleRate
         value: 17
       - name: Duration

--- a/pkg/translator/testdata/refinery_rules/deterministicsampler_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/deterministicsampler_all.yaml
@@ -2,7 +2,4 @@ RulesVersion: 2
 Samplers:
     __default__:
         DeterministicSampler:
-            SampleRate: 1
-    test:
-        DeterministicSampler:
             SampleRate: 90

--- a/pkg/translator/testdata/refinery_rules/emathroughput_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/emathroughput_all.yaml
@@ -1,9 +1,6 @@
 RulesVersion: 2
 Samplers:
     __default__:
-        DeterministicSampler:
-            SampleRate: 1
-    test:
         EMAThroughputSampler:
             AdjustmentInterval: 120s
             FieldList:

--- a/pkg/translator/testdata/refinery_rules/keeperrors_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/keeperrors_all.yaml
@@ -1,9 +1,6 @@
 RulesVersion: 2
 Samplers:
     __default__:
-        DeterministicSampler:
-            SampleRate: 1
-    test:
         RulesBasedSampler:
             Rules:
                 - Conditions:

--- a/pkg/translator/testdata/refinery_rules/samplebyhttpstatus_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/samplebyhttpstatus_all.yaml
@@ -1,9 +1,6 @@
 RulesVersion: 2
 Samplers:
     __default__:
-        DeterministicSampler:
-            SampleRate: 1
-    test:
         RulesBasedSampler:
             Rules:
                 - Conditions:

--- a/pkg/translator/testdata/refinery_rules/samplebytraceduration_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/samplebytraceduration_all.yaml
@@ -1,9 +1,6 @@
 RulesVersion: 2
 Samplers:
     __default__:
-        DeterministicSampler:
-            SampleRate: 1
-    test:
         RulesBasedSampler:
             Rules:
                 - Conditions:

--- a/tests/scenario_tests/keep_errors_test.go
+++ b/tests/scenario_tests/keep_errors_test.go
@@ -16,16 +16,16 @@ func TestKeepErrors(t *testing.T) {
 	// Verify that the refinery rules config was generated successfully
 	assert.Equal(t, 2, rulesConfig.RulesVersion)
 
-	// Check that the production environment sampler was created
-	productionSampler, exists := rulesConfig.Samplers["production"]
-	require.True(t, exists, "Expected 'production' environment sampler to exist")
+	// Check that the default environment defaultSampler was created
+	defaultSampler, exists := rulesConfig.Samplers["__default__"]
+	require.True(t, exists, "Expected '__default__' environment sampler to exist")
 
 	// Verify that it's a RulesBasedSampler
-	require.NotNil(t, productionSampler.RulesBasedSampler, "Expected production sampler to be a RulesBasedSampler")
+	require.NotNil(t, defaultSampler.RulesBasedSampler, "Expected __default__ sampler to be a RulesBasedSampler")
 
 	// Check that there's exactly one rule
-	rules := productionSampler.RulesBasedSampler.Rules
-	assert.Len(t, rules, 1, "Expected 1 rule in production sampler")
+	rules := defaultSampler.RulesBasedSampler.Rules
+	assert.Len(t, rules, 1, "Expected 1 rule in __default__ sampler")
 
 	// Verify the rule properties from the KeepErrors template
 	rule := rules[0]
@@ -47,15 +47,6 @@ func TestKeepErrors(t *testing.T) {
 
 	// Test operator (from template: o=exists)
 	assert.Equal(t, "exists", condition.Operator)
-
-	// Verify that the default environment also has a sampler (should be DeterministicSampler)
-	defaultSampler, exists := rulesConfig.Samplers["__default__"]
-	require.True(t, exists, "Expected '__default__' environment sampler to exist")
-
-	// The default should be a DeterministicSampler with rate 1
-	require.NotNil(t, defaultSampler.DeterministicSampler, "Expected default sampler to be a DeterministicSampler")
-
-	assert.Equal(t, 1, defaultSampler.DeterministicSampler.SampleRate)
 
 	// verify that the the collectorconfig pipeline includes the exporter to refinery
 	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")

--- a/tests/scenario_tests/testdata/keep_errors.yaml
+++ b/tests/scenario_tests/testdata/keep_errors.yaml
@@ -12,8 +12,6 @@ components:
   - name: Error Sampler
     kind: KeepErrors
     properties:
-      - name: Environment
-        value: production
       - name: FieldName
         value: error_field
       - name: SampleRate


### PR DESCRIPTION
Puts the environment removal code back, which we moved out of the way to release v0.11.0.