### PR TITLE
maint: update env vars to use HTP_ prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	docker run -d --name smoke-refinery \
 		-v ./tmp/refinery-config.yaml:/etc/refinery/refinery.yaml \
 		-v ./tmp/refinery-rules.yaml:/etc/refinery/rules.yaml \
-		-e HONEYCOMB_EXPORTER_APIKEY=hccik_01jj2jj42424jjjjjjj2jjjjjj424jjj2jjjjjjjjjjjjjjj4jjjjj24jj \
+		-e HTP_HONEYCOMB_EXPORTER_APIKEY=hccik_01jj2jj42424jjjjjjj2jjjjjj424jjj2jjjjjjjjjjjjjjj4jjjjj24jj \
 		honeycombio/refinery:latest || exit 1
 	sleep 1
 
@@ -141,8 +141,8 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	docker run -d --name smoke-collector \
 		--entrypoint /otelcol-contrib \
 		-v ./tmp/collector-config.yaml:/etc/otelcol-contrib/config.yaml \
-		-e STRAWS_COLLECTOR_POD_IP=localhost \
-		-e STRAWS_REFINERY_POD_IP=localhost \
+		-e HTP_COLLECTOR_POD_IP=localhost \
+		-e HTP_REFINERY_POD_IP=localhost \
 		honeycombio/supervised-collector:latest \
 		--config /etc/otelcol-contrib/config.yaml || exit 1
 	sleep 1

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	docker run -d --name smoke-refinery \
 		-v ./tmp/refinery-config.yaml:/etc/refinery/refinery.yaml \
 		-v ./tmp/refinery-rules.yaml:/etc/refinery/rules.yaml \
-		-e HTP_HONEYCOMB_EXPORTER_APIKEY=hccik_01jj2jj42424jjjjjjj2jjjjjj424jjj2jjjjjjjjjjjjjjj4jjjjj24jj \
+		-e HTP_EXPORTER_APIKEY=hccik_01jj2jj42424jjjjjjj2jjjjjj424jjj2jjjjjjjjjjjjjjj4jjjjj24jj \
 		honeycombio/refinery:latest || exit 1
 	sleep 1
 

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -36,7 +36,7 @@ properties:
     type: string
     validations:
       - noblanks
-    default: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
+    default: ${HTP_EXPORTER_APIKEY}
     advanced: true
   - name: MetricsDataset
     summary: The Honeycomb dataset metrics will be sent to.

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -36,7 +36,7 @@ properties:
     type: string
     validations:
       - noblanks
-    default: ${HONEYCOMB_EXPORTER_APIKEY}
+    default: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
     advanced: true
   - name: MetricsDataset
     summary: The Honeycomb dataset metrics will be sent to.

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -37,7 +37,7 @@ properties:
     validations:
       - noblanks
       - hostorip
-    default: ${STRAWS_COLLECTOR_POD_IP}
+    default: ${HTP_COLLECTOR_POD_IP}
     advanced: true
   - name: GRPCPort
     summary: The port on which to listen for gRPC traffic.

--- a/pkg/data/components/StartSampling.yaml
+++ b/pkg/data/components/StartSampling.yaml
@@ -36,7 +36,7 @@ properties:
     type: string
     validations:
       - noblanks
-    default: ${STRAWS_REFINERY_SERVICE}
+    default: ${HTP_REFINERY_SERVICE}
     advanced: true
   - name: Port
     summary: The port on which Refinery is listening for HTTP traffic.

--- a/pkg/data/templates/s3.yaml
+++ b/pkg/data/templates/s3.yaml
@@ -21,7 +21,7 @@ components:
     kind: HoneycombExporter
     properties:
       - name: APIKey
-        value: ${HONEYCOMB_EXPORTER_APIKEY}
+        value: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
   - name: EMA Throughput Sampler_1
     kind: EMAThroughput
     properties:

--- a/pkg/data/templates/s3.yaml
+++ b/pkg/data/templates/s3.yaml
@@ -21,7 +21,7 @@ components:
     kind: HoneycombExporter
     properties:
       - name: APIKey
-        value: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
+        value: ${HTP_EXPORTER_APIKEY}
   - name: EMA Throughput Sampler_1
     kind: EMAThroughput
     properties:

--- a/pkg/translator/testdata/collector_config/default.yaml
+++ b/pkg/translator/testdata/collector_config/default.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/OTel_Receiver_1:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/filterlogbyseverity_all.yaml
+++ b/pkg/translator/testdata/collector_config/filterlogbyseverity_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     filter/FilterMyLogs:
         error_mode: ignore

--- a/pkg/translator/testdata/collector_config/filterlogbyseverity_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/filterlogbyseverity_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     filter/FilterMyLogs:
         error_mode: ignore

--- a/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     filter/drop_container_1:
         traces:

--- a/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/filterprocessor_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/honeycombexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/honeycombexporter_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:
@@ -24,7 +24,7 @@ exporters:
         tls:
             insecure: true
     otlphttp/refinery:
-        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+        endpoint: http://${HTP_REFINERY_SERVICE}:80
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/honeycombexporter_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:
@@ -12,7 +12,7 @@ exporters:
         endpoint: api.honeycomb.io:443
         headers:
             x-honeycomb-dataset: metrics
-            x-honeycomb-team: ${HONEYCOMB_EXPORTER_APIKEY}
+            x-honeycomb-team: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
         sending_queue:
             batch:
                 flush_timeout: 200ms
@@ -22,7 +22,7 @@ exporters:
             queue_size: 100000
             sizer: items
     otlphttp/refinery:
-        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+        endpoint: http://${HTP_REFINERY_SERVICE}:80
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/honeycombexporter_defaults.yaml
@@ -12,7 +12,7 @@ exporters:
         endpoint: api.honeycomb.io:443
         headers:
             x-honeycomb-dataset: metrics
-            x-honeycomb-team: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
+            x-honeycomb-team: ${HTP_EXPORTER_APIKEY}
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/logdeduplicationprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/logdeduplicationprocessor_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     logdedup/DedupMyLogs:
         interval: 10s

--- a/pkg/translator/testdata/collector_config/logdeduplicationprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/logdeduplicationprocessor_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     logdedup/DedupMyLogs:
         interval: 60s

--- a/pkg/translator/testdata/collector_config/nopexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/nopexporter_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/nopexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/nopexporter_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/oteldebugexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/oteldebugexporter_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/oteldebugexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/oteldebugexporter_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/otelgrpcexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelgrpcexporter_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/otelgrpcexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelgrpcexporter_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_all.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelhttpexporter_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/otelreceiver_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/otelreceiver_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/parseattributeasjson_all.yaml
+++ b/pkg/translator/testdata/collector_config/parseattributeasjson_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     transform/json_parser_1:
         error_mode: ignore

--- a/pkg/translator/testdata/collector_config/parseattributeasjson_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/parseattributeasjson_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     transform/json_parser_1:
         error_mode: ignore

--- a/pkg/translator/testdata/collector_config/parselogbodyasjson_all.yaml
+++ b/pkg/translator/testdata/collector_config/parselogbodyasjson_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     transform/json_parser_1:
         error_mode: ignore

--- a/pkg/translator/testdata/collector_config/parselogbodyasjson_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/parselogbodyasjson_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     transform/json_parser_1:
         error_mode: ignore

--- a/pkg/translator/testdata/collector_config/redactionprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/redactionprocessor_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     redaction/redaction_processor_1:
         allow_all_keys: true

--- a/pkg/translator/testdata/collector_config/redactionprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/redactionprocessor_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     redaction/redaction_processor_1:
         allow_all_keys: true

--- a/pkg/translator/testdata/collector_config/sendtos3archive_all.yaml
+++ b/pkg/translator/testdata/collector_config/sendtos3archive_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/sendtos3archive_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/sendtos3archive_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:

--- a/pkg/translator/testdata/collector_config/startsampling_all.yaml
+++ b/pkg/translator/testdata/collector_config/startsampling_all.yaml
@@ -2,14 +2,14 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:
     otlphttp/Start_Sampling_1:
-        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+        endpoint: http://${HTP_REFINERY_SERVICE}:80
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/startsampling_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/startsampling_defaults.yaml
@@ -2,14 +2,14 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     usage: {}
 exporters:
     otlphttp/Start_Sampling_1:
-        endpoint: http://${STRAWS_REFINERY_SERVICE}:80
+        endpoint: http://${HTP_REFINERY_SERVICE}:80
         sending_queue:
             batch:
                 flush_timeout: 200ms

--- a/pkg/translator/testdata/collector_config/symbolicatorprocessor_all.yaml
+++ b/pkg/translator/testdata/collector_config/symbolicatorprocessor_all.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     symbolicator/symbolicator:
         gcs_source_maps:

--- a/pkg/translator/testdata/collector_config/symbolicatorprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/symbolicatorprocessor_defaults.yaml
@@ -2,9 +2,9 @@ receivers:
     otlp/otlp_in:
         protocols:
             grpc:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4317
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4317
             http:
-                endpoint: ${STRAWS_COLLECTOR_POD_IP}:4318
+                endpoint: ${HTP_COLLECTOR_POD_IP}:4318
 processors:
     symbolicator/symbolicator:
         s3_source_maps:

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_defaults.yaml
@@ -1,5 +1,5 @@
 AccessKeys:
-    SendKey: ${HONEYCOMB_EXPORTER_APIKEY}
+    SendKey: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
     SendKeyMode: all
 General:
     ConfigurationVersion: 2

--- a/pkg/translator/testdata/refinery_config/honeycombexporter_defaults.yaml
+++ b/pkg/translator/testdata/refinery_config/honeycombexporter_defaults.yaml
@@ -1,5 +1,5 @@
 AccessKeys:
-    SendKey: ${HTP_HONEYCOMB_EXPORTER_APIKEY}
+    SendKey: ${HTP_EXPORTER_APIKEY}
     SendKeyMode: all
 General:
     ConfigurationVersion: 2


### PR DESCRIPTION
## Which problem is this PR solving?

- related to https://github.com/honeycombio/pipeline-team/issues/517

## Short description of the changes

- Replace `STRAWS_` with `HTP_`.
- Prefix `HONEYCOMB_EXPORTER_APIKEY` with `HTP_`.

