### PR TITLE
maint: rename receivers components to match naming guidelines

### DIFF
--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -1,5 +1,5 @@
 kind: NopReceiver
-name: DefaultNopReceiver
+name: Receive Nothing
 version: v0.1.0
 style: receiver
 logo: opentelemetry

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -1,5 +1,5 @@
 kind: OTelReceiver
-name: OTel Receiver
+name: Receive OTel
 style: receiver
 logo: opentelemetry
 type: base


### PR DESCRIPTION
## Which problem is this PR solving?

- related to https://github.com/honeycombio/pipeline-team/issues/526

## Short description of the changes

- Update all the receivers components to match naming decisions from https://honeycomb.quip.com/EtZVAykv9zYU/HPSF-Component-Naming-Refactor-Discussion

