### PR TITLE
maint: Add a couple of Refinery scenario tests

### DIFF
--- a/tests/scenario_tests/sampling_first_pipe_test.go
+++ b/tests/scenario_tests/sampling_first_pipe_test.go
@@ -1,0 +1,57 @@
+package hpsftests
+
+import (
+	"testing"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirstSamplingPipe(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/firstSamplingPipe.yaml")
+
+	// Verify the traces pipeline exists and has the correct components
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
+	require.True(t, getResult.Found, "Expected traces pipeline to be found")
+
+	// Check pipeline components
+	assert.Len(t, receivers, 1, "Expected 1 receiver")
+	assert.Contains(t, receivers, "otlp/OTel_Receiver_1", "Expected OTel receiver")
+
+	// Sampling components are translated to Refinery rules, not collector processors
+	assert.Len(t, processors, 1, "Expected 1 processor (usage)")
+	assert.Contains(t, processors, "usage", "Expected usage processor")
+
+	assert.Len(t, exporters, 1, "Expected 1 exporter")
+	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected SamplingSequencer exporter")
+
+	// Verify Refinery rules configuration
+	assert.Len(t, rulesConfig.Samplers, 1, "Expected 1 sampler in refinery config")
+
+	// Check that the __default__ environment has a sampler
+	defaultSampler, exists := rulesConfig.Samplers["__default__"]
+	require.True(t, exists, "Expected __default__ sampler to exist")
+
+	// Verify the sampler is a RulesBasedSampler with one rule
+	require.NotNil(t, defaultSampler.RulesBasedSampler, "Expected RulesBasedSampler configuration")
+	assert.Len(t, defaultSampler.RulesBasedSampler.Rules, 1, "Expected 1 rule in the sampler")
+
+	// Verify the rule has the expected conditions and sampler
+	rule := defaultSampler.RulesBasedSampler.Rules[0]
+	assert.Len(t, rule.Conditions, 1, "Expected 1 condition in the rule")
+
+	// Check the condition is a LongDurationCondition
+	condition := rule.Conditions[0]
+	assert.Equal(t, "duration_ms", condition.Field, "Expected duration_ms field")
+	assert.Equal(t, ">=", condition.Operator, "Expected >= operator")
+	assert.Equal(t, 1000, condition.Value, "Expected duration value of 1000")
+	assert.Equal(t, "int", condition.Datatype, "Expected int datatype")
+
+	// Check the rule has SampleRate: 1 (KeepAllSampler is translated to SampleRate: 1)
+	assert.Equal(t, 1, rule.SampleRate, "Expected sample rate of 1")
+}

--- a/tests/scenario_tests/sampling_two_pipes_test.go
+++ b/tests/scenario_tests/sampling_two_pipes_test.go
@@ -1,0 +1,66 @@
+package hpsftests
+
+import (
+	"testing"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTwoSamplingPipes(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/twoSamplingPipes.yaml")
+
+	// Verify the traces pipeline exists and has the correct components
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
+	require.True(t, getResult.Found, "Expected traces pipeline to be found")
+
+	// Check pipeline components
+	assert.Len(t, receivers, 1, "Expected 1 receiver")
+	assert.Contains(t, receivers, "otlp/OTel_Receiver_1", "Expected OTel receiver")
+
+	// Sampling components are translated to Refinery rules, not collector processors
+	assert.Len(t, processors, 1, "Expected 1 processor (usage)")
+	assert.Contains(t, processors, "usage", "Expected usage processor")
+
+	assert.Len(t, exporters, 1, "Expected 1 exporter")
+	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected SamplingSequencer exporter")
+
+	// Verify Refinery rules configuration
+	assert.Len(t, rulesConfig.Samplers, 1, "Expected 1 sampler in refinery config")
+
+	// Check that the __default__ environment has a sampler
+	defaultSampler, exists := rulesConfig.Samplers["__default__"]
+	require.True(t, exists, "Expected __default__ sampler to exist")
+
+	require.NotNil(t, defaultSampler.RulesBasedSampler, "Expected RulesBasedSampler configuration")
+	assert.Len(t, defaultSampler.RulesBasedSampler.Rules, 2, "Expected 2 rules in the sampler")
+
+	// Rule 1: http.status_code >= 400, SampleRate: 100
+	rule1 := defaultSampler.RulesBasedSampler.Rules[0]
+	assert.Len(t, rule1.Conditions, 1, "Expected 1 condition in the first rule")
+	cond1 := rule1.Conditions[0]
+	assert.ElementsMatch(t, []string{"http.status_code", "http.response.status_code"}, cond1.Fields, "Expected http status fields")
+	assert.Equal(t, ">=", cond1.Operator, "Expected >= operator")
+	assert.Equal(t, 400, cond1.Value, "Expected value 400")
+	assert.Equal(t, "int", cond1.Datatype, "Expected int datatype")
+	assert.Equal(t, 100, rule1.SampleRate, "Expected sample rate of 100")
+
+	// Rule 2: error exists AND duration_ms >= 1000, SampleRate: 1
+	rule2 := defaultSampler.RulesBasedSampler.Rules[1]
+	assert.Len(t, rule2.Conditions, 2, "Expected 2 conditions in the second rule")
+	cond2a := rule2.Conditions[0]
+	assert.ElementsMatch(t, []string{"error"}, cond2a.Fields, "Expected error field")
+	assert.Equal(t, "exists", cond2a.Operator, "Expected exists operator")
+	assert.Nil(t, cond2a.Value, "Expected value nil for exists operator")
+	cond2b := rule2.Conditions[1]
+	assert.Equal(t, "duration_ms", cond2b.Field, "Expected duration_ms field")
+	assert.Equal(t, ">=", cond2b.Operator, "Expected >= operator")
+	assert.Equal(t, 1000, cond2b.Value, "Expected value 1000")
+	assert.Equal(t, "int", cond2b.Datatype, "Expected int datatype")
+	assert.Equal(t, 1, rule2.SampleRate, "Expected sample rate of 1")
+}

--- a/tests/scenario_tests/testdata/firstSamplingPipe.yaml
+++ b/tests/scenario_tests/testdata/firstSamplingPipe.yaml
@@ -1,0 +1,66 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Long Duration_1
+    kind: LongDurationCondition
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Long Duration_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Long Duration_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+layout:
+  components:
+    - name: OTel Receiver_1
+      position:
+        x: 50
+        y: 0
+    - name: Start Sampling_1
+      position:
+        x: 282
+        y: 0
+    - name: Long Duration_1
+      position:
+        x: 478
+        y: 0
+    - name: Keep All_1
+      position:
+        x: 669
+        y: 0
+    - name: Send to Honeycomb_1
+      position:
+        x: 853
+        y: 0

--- a/tests/scenario_tests/testdata/twoSamplingPipes.yaml
+++ b/tests/scenario_tests/testdata/twoSamplingPipes.yaml
@@ -1,0 +1,116 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Error Exists_1
+    kind: ErrorExistsCondition
+  - name: Long Duration_1
+    kind: LongDurationCondition
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+  - name: HTTP Status_1
+    kind: HTTPStatusCondition
+  - name: Deterministic Sampler_1
+    kind: DeterministicSampler
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 2
+      type: SampleData
+    destination:
+      component: Error Exists_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Error Exists_1
+      port: And
+      type: SampleData
+    destination:
+      component: Long Duration_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Long Duration_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: HTTP Status_1
+      port: Match
+      type: SampleData
+  - source:
+      component: HTTP Status_1
+      port: And
+      type: SampleData
+    destination:
+      component: Deterministic Sampler_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Deterministic Sampler_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+layout:
+  components:
+    - name: OTel Receiver_1
+      position:
+        x: 50
+        y: 0
+    - name: Start Sampling_1
+      position:
+        x: 282
+        y: 0
+    - name: Error Exists_1
+      position:
+        x: 478
+        y: 0
+    - name: Long Duration_1
+      position:
+        x: 653
+        y: 0
+    - name: Keep All_1
+      position:
+        x: 844
+        y: 0
+    - name: Send to Honeycomb_1
+      position:
+        x: 1028
+        y: 0
+    - name: HTTP Status_1
+      position:
+        x: 480
+        y: 120
+    - name: Deterministic Sampler_1
+      position:
+        x: 700
+        y: 140


### PR DESCRIPTION

## Which problem is this PR solving?

- The new refinery stuff didn't have any scenario tests. This adds two of them

## Short description of the changes

- The scenarios were ones I built during my manual testing. I had cursor help me write the test code that validates them, then hand-inspected it. It's pretty specific, but seems correct.