### PR TITLE
maint: bump sampling components to alpha

### DIFF
--- a/pkg/data/components/ErrorExists.yaml
+++ b/pkg/data/components/ErrorExists.yaml
@@ -2,7 +2,7 @@ kind: ErrorExistsCondition
 name: Check for Errors
 style: condition
 type: base
-status: development
+status: alpha
 version: v0.1.0
 summary: Checks if an error exists in any span of a trace
 description: |

--- a/pkg/data/components/LongDuration.yaml
+++ b/pkg/data/components/LongDuration.yaml
@@ -2,7 +2,7 @@ kind: LongDurationCondition
 name: Check Duration
 style: condition
 type: base
-status: development
+status: alpha
 version: v0.1.0
 summary: Makes a decision based on root span duration
 description: |

--- a/pkg/data/components/SamplerDrop.yaml
+++ b/pkg/data/components/SamplerDrop.yaml
@@ -2,7 +2,7 @@ kind: Dropper
 name: Drop
 style: dropper
 type: base
-status: development
+status: alpha
 version: v0.1.0
 summary: Drops all traces
 description: |

--- a/pkg/data/components/SamplerKeepAll.yaml
+++ b/pkg/data/components/SamplerKeepAll.yaml
@@ -2,7 +2,7 @@ kind: KeepAllSampler
 name: Keep All
 style: sampler
 type: base
-status: development
+status: alpha
 version: v0.1.0
 summary: Keeps all traces that reach this sampler.
 description: |

--- a/pkg/data/components/SamplingSequencer.yaml
+++ b/pkg/data/components/SamplingSequencer.yaml
@@ -2,7 +2,7 @@ kind: SamplingSequencer
 name: Start Sampling
 style: startsampling
 type: base
-status: development
+status: alpha
 version: v0.1.0
 summary: Converts traces and logs to a format for sampling
 description: |


### PR DESCRIPTION
## Which problem is this PR solving?

- bumps sampling components to alpha so our new sampling UX works

## Short description of the changes

- update ErrorExistsCondition to alpha
- update LongDurationCondition to alpha
- update Dropper to alpha
- update KeepAllSampler to alpha
- update SamplingSequencer to alpha