### PR TITLE
feat: Use the sampler name as the rule name when generating refinery configs

### DIFF
--- a/pkg/config/rulestemplate.go
+++ b/pkg/config/rulestemplate.go
@@ -64,6 +64,9 @@ func (t *TemplateComponent) generateRulesConfig(rt *rulesTemplate, compType tmpl
 	}
 	meta[tmpl.MetaSampler] = sampler
 
+	// Add the component name to metadata for use during merge
+	meta["component_name"] = t.hpsf.GetSafeName()
+
 	for _, kv := range rt.kvs {
 		// do the key
 		key, err := t.expandTemplateVariable(kv.key, userdata)
@@ -89,6 +92,7 @@ func (t *TemplateComponent) generateRulesConfig(rt *rulesTemplate, compType tmpl
 			kvs[key] = value
 		}
 	}
+
 	rc := tmpl.NewRulesConfig(compType, meta, kvs)
 	return rc, nil
 }

--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -127,6 +127,11 @@ func isDownstreamSamplerType(samplerType string) bool {
 	}
 }
 
+// Add the Name field if we're creating a rule (keyPrefix starts with "RulesBasedSampler.Rules." but doesn't contain "Conditions")
+func shouldAddNameField(keyPrefix string) bool {
+	return strings.HasPrefix(keyPrefix, "RulesBasedSampler.Rules.") && !strings.Contains(keyPrefix, "Conditions")
+}
+
 func (rc *RulesConfig) Merge(other TemplateConfig) error {
 	otherRC, ok := other.(*RulesConfig)
 	if !ok {
@@ -171,8 +176,8 @@ func (rc *RulesConfig) Merge(other TemplateConfig) error {
 				return err
 			}
 		}
-		// Add the Name field if we're creating a rule (keyPrefix starts with "RulesBasedSampler.Rules." but doesn't contain "Conditions")
-		if strings.HasPrefix(keyPrefix, "RulesBasedSampler.Rules.") && !strings.Contains(keyPrefix, "Conditions") {
+
+		if shouldAddNameField(keyPrefix) {
 			if componentName, exists := otherRC.meta[MetaComponentName]; exists {
 				if err := setMemberValue(keyPrefix+"Name", sampler, componentName); err != nil {
 					return err
@@ -228,8 +233,7 @@ func (rc *RulesConfig) Merge(other TemplateConfig) error {
 					return err
 				}
 			}
-			// Add the Name field if we're creating a rule (keyPrefix starts with "RulesBasedSampler.Rules." but doesn't contain "Conditions")
-			if strings.HasPrefix(keyPrefix, "RulesBasedSampler.Rules.") && !strings.Contains(keyPrefix, "Conditions") {
+			if shouldAddNameField(keyPrefix) {
 				if componentName, exists := otherRC.meta[MetaComponentName]; exists {
 					if err := setMemberValue(keyPrefix+"Name", sampler, componentName); err != nil {
 						return err

--- a/pkg/data/components/SamplerDrop.yaml
+++ b/pkg/data/components/SamplerDrop.yaml
@@ -17,13 +17,6 @@ ports:
   - name: Sample
     direction: input
     type: SampleData
-properties:
-  - name: RuleName
-    summary: The name of the rule (used in Refinery debugging).
-    description: |
-      The rule name that will show up in metadata for traces that match this rule. If not set,
-      the name of this component will be used.
-    type: string
 templates:
   - kind: refinery_rules
     name: DropAll_RefineryRules

--- a/pkg/data/components/SamplerKeepAll.yaml
+++ b/pkg/data/components/SamplerKeepAll.yaml
@@ -21,13 +21,6 @@ ports:
   - name: Events
     direction: output
     type: HoneycombEvents
-properties:
-  - name: RuleName
-    summary: The name of the rule (used in Refinery debugging).
-    description: |
-      The rule name that will show up in metadata for traces that match this rule. If not set,
-      the name of this component will be used.
-    type: string
 templates:
   - kind: refinery_rules
     name: KeepAll_RefineryRules

--- a/pkg/translator/testdata/refinery_rules/dropper_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/dropper_all.yaml
@@ -3,4 +3,5 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - Drop: true
+                - Name: SamplerDrop_Sampler_1
+                  Drop: true

--- a/pkg/translator/testdata/refinery_rules/dropper_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/dropper_defaults.yaml
@@ -3,4 +3,5 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - Drop: true
+                - Name: SamplerDrop_Sampler_1
+                  Drop: true

--- a/pkg/translator/testdata/refinery_rules/errorexistscondition_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/errorexistscondition_all.yaml
@@ -3,7 +3,8 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - SampleRate: 1
+                - Name: Keep_All_1
+                  SampleRate: 1
                   Conditions:
                     - Fields:
                         - error

--- a/pkg/translator/testdata/refinery_rules/errorexistscondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/errorexistscondition_defaults.yaml
@@ -3,7 +3,8 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - SampleRate: 1
+                - Name: Keep_All_1
+                  SampleRate: 1
                   Conditions:
                     - Fields:
                         - error

--- a/pkg/translator/testdata/refinery_rules/httpstatuscondition_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/httpstatuscondition_all.yaml
@@ -3,7 +3,8 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - SampleRate: 1
+                - Name: Keep_All_1
+                  SampleRate: 1
                   Conditions:
                     - Fields:
                         - http.status_code

--- a/pkg/translator/testdata/refinery_rules/httpstatuscondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/httpstatuscondition_defaults.yaml
@@ -3,7 +3,8 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - SampleRate: 1
+                - Name: Keep_All_1
+                  SampleRate: 1
                   Conditions:
                     - Fields:
                         - http.status_code

--- a/pkg/translator/testdata/refinery_rules/longdurationcondition_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/longdurationcondition_all.yaml
@@ -3,7 +3,8 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - SampleRate: 1
+                - Name: Keep_All_1
+                  SampleRate: 1
                   Conditions:
                     - Field: duration_ms
                       Operator: '>='

--- a/pkg/translator/testdata/refinery_rules/longdurationcondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/longdurationcondition_defaults.yaml
@@ -3,7 +3,8 @@ Samplers:
     __default__:
         RulesBasedSampler:
             Rules:
-                - SampleRate: 1
+                - Name: Keep_All_1
+                  SampleRate: 1
                   Conditions:
                     - Field: duration_ms
                       Operator: '>='

--- a/tests/scenario_tests/sampling_first_pipe_test.go
+++ b/tests/scenario_tests/sampling_first_pipe_test.go
@@ -54,4 +54,7 @@ func TestFirstSamplingPipe(t *testing.T) {
 
 	// Check the rule has SampleRate: 1 (KeepAllSampler is translated to SampleRate: 1)
 	assert.Equal(t, 1, rule.SampleRate, "Expected sample rate of 1")
+
+	// Check the rule has the correct Name field
+	assert.Equal(t, "Keep_All_1", rule.Name, "Expected rule name to be the sampler component name")
 }

--- a/tests/scenario_tests/sampling_two_pipes_test.go
+++ b/tests/scenario_tests/sampling_two_pipes_test.go
@@ -49,6 +49,8 @@ func TestTwoSamplingPipes(t *testing.T) {
 	assert.Equal(t, 400, cond1.Value, "Expected value 400")
 	assert.Equal(t, "int", cond1.Datatype, "Expected int datatype")
 	assert.Equal(t, 100, rule1.SampleRate, "Expected sample rate of 100")
+	// Check the rule has the correct Name field
+	assert.Equal(t, "Deterministic_Sampler_1", rule1.Name, "Expected rule name to be the sampler component name")
 
 	// Rule 2: error exists AND duration_ms >= 1000, SampleRate: 1
 	rule2 := defaultSampler.RulesBasedSampler.Rules[1]
@@ -63,4 +65,6 @@ func TestTwoSamplingPipes(t *testing.T) {
 	assert.Equal(t, 1000, cond2b.Value, "Expected value 1000")
 	assert.Equal(t, "int", cond2b.Datatype, "Expected int datatype")
 	assert.Equal(t, 1, rule2.SampleRate, "Expected sample rate of 1")
+	// Check the rule has the correct Name field
+	assert.Equal(t, "Keep_All_1", rule2.Name, "Expected rule name to be the sampler component name")
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- When generating HPSF rules for Refinery, it wasn't generating the Name field for the rules. This uses the sampler name as the rule name so that the rules can be documented. Since the names must be unique, this is safe and helpful.

## Short description of the changes

- Pass the component name into the metadata
- When conditions are right, use the component name to extend the data for the rules
- Fix all the tests to look for rule names
- The keep and drop samplers had a RuleName field that wasn't being used or tested for. Remove it.

