### PR TITLE
fix: Set the name field properly with downstream samplers

### DIFF
--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -128,9 +128,8 @@ func isDownstreamSamplerType(samplerType string) bool {
 }
 
 // Add the Name field if we're creating a rule (keyPrefix starts with
-// "RulesBasedSampler.Rules." but doesn't contain "Conditions")
+// "RulesBasedSampler.Rules." but doesn't contain "Conditions" or ".Sampler.").
 func shouldAddNameField(keyPrefix string) bool {
-	// Only add Name if we're at the rule level, not inside Sampler or Conditions
 	return strings.HasPrefix(keyPrefix, "RulesBasedSampler.Rules.") &&
 		!strings.Contains(keyPrefix, "Conditions") &&
 		!strings.Contains(keyPrefix, ".Sampler.")

--- a/pkg/config/tmpl/rulesconfig.go
+++ b/pkg/config/tmpl/rulesconfig.go
@@ -127,9 +127,13 @@ func isDownstreamSamplerType(samplerType string) bool {
 	}
 }
 
-// Add the Name field if we're creating a rule (keyPrefix starts with "RulesBasedSampler.Rules." but doesn't contain "Conditions")
+// Add the Name field if we're creating a rule (keyPrefix starts with
+// "RulesBasedSampler.Rules." but doesn't contain "Conditions")
 func shouldAddNameField(keyPrefix string) bool {
-	return strings.HasPrefix(keyPrefix, "RulesBasedSampler.Rules.") && !strings.Contains(keyPrefix, "Conditions")
+	// Only add Name if we're at the rule level, not inside Sampler or Conditions
+	return strings.HasPrefix(keyPrefix, "RulesBasedSampler.Rules.") &&
+		!strings.Contains(keyPrefix, "Conditions") &&
+		!strings.Contains(keyPrefix, ".Sampler.")
 }
 
 func (rc *RulesConfig) Merge(other TemplateConfig) error {
@@ -233,9 +237,25 @@ func (rc *RulesConfig) Merge(other TemplateConfig) error {
 					return err
 				}
 			}
+			// Only set Name if keyPrefix is at the rule level (not inside .Sampler.)
 			if shouldAddNameField(keyPrefix) {
-				if componentName, exists := otherRC.meta[MetaComponentName]; exists {
-					if err := setMemberValue(keyPrefix+"Name", sampler, componentName); err != nil {
+				componentName, exists := otherRC.meta[MetaComponentName]
+				if !exists {
+					// Fallback: try to get component name from current RC's meta
+					componentName, exists = rc.meta[MetaComponentName]
+				}
+				if exists {
+					if err := setMemberValue(fmt.Sprintf("RulesBasedSampler.Rules.%d.Name", ruleIndex), sampler, componentName); err != nil {
+						return err
+					}
+				}
+			}
+
+			// For downstream samplers, always set the rule's Name field to the sampler's component name
+			if isDownstreamSamplerType(samplerType) {
+				componentName, exists := otherRC.meta[MetaComponentName]
+				if exists {
+					if err := setMemberValue(fmt.Sprintf("RulesBasedSampler.Rules.%d.Name", ruleIndex), sampler, componentName); err != nil {
 						return err
 					}
 				}

--- a/tests/scenario_tests/sampling_first_pipe_test.go
+++ b/tests/scenario_tests/sampling_first_pipe_test.go
@@ -52,9 +52,10 @@ func TestFirstSamplingPipe(t *testing.T) {
 	assert.Equal(t, 1000, condition.Value, "Expected duration value of 1000")
 	assert.Equal(t, "int", condition.Datatype, "Expected int datatype")
 
-	// Check the rule has SampleRate: 1 (KeepAllSampler is translated to SampleRate: 1)
-	assert.Equal(t, 1, rule.SampleRate, "Expected sample rate of 1")
-
 	// Check the rule has the correct Name field
-	assert.Equal(t, "Keep_All_1", rule.Name, "Expected rule name to be the sampler component name")
+	assert.Equal(t, "EMA1", rule.Name, "Expected rule name to be the sampler component name")
+
+	// Check that the rule has an EMADynamicSampler configuration
+	require.NotNil(t, rule.Sampler, "Expected sampler configuration")
+	require.NotNil(t, rule.Sampler.EMADynamicSampler, "Expected EMADynamicSampler configuration")
 }

--- a/tests/scenario_tests/testdata/firstSamplingPipe.yaml
+++ b/tests/scenario_tests/testdata/firstSamplingPipe.yaml
@@ -5,8 +5,11 @@ components:
     kind: SamplingSequencer
   - name: Long Duration_1
     kind: LongDurationCondition
-  - name: Keep All_1
-    kind: KeepAllSampler
+  - name: EMA1
+    kind: EMADynamicSampler
+    properties:
+      - name: FieldList
+        value: [http.method, http.status_code]
   - name: Send to Honeycomb_1
     kind: HoneycombExporter
 connections:
@@ -31,11 +34,11 @@ connections:
       port: And
       type: SampleData
     destination:
-      component: Keep All_1
+      component: EMA1
       port: Sample
       type: SampleData
   - source:
-      component: Keep All_1
+      component: EMA1
       port: Events
       type: HoneycombEvents
     destination:
@@ -56,7 +59,7 @@ layout:
       position:
         x: 478
         y: 0
-    - name: Keep All_1
+    - name: EMA1
       position:
         x: 669
         y: 0


### PR DESCRIPTION
## Which problem is this PR solving?

- #170 had added using the sampler name for the rule name, but I forgot to properly account for downstream samplers (the refinery configuration for samplers is complex!). This fixes that problem.

## Short description of the changes

- make shouldAddNameField() more restrictive
- handle downstream samplers specifically
- tweak the firstSamplingPipe scenario test to use a downstream EMA instead of KeepAll to test for this case

Had quite a bit of help from Cursor AI on this one.