### PR TITLE
fix: handle paths with just a complex sampler

### DIFF
--- a/tests/scenario_tests/sampling_direct_downstream_test.go
+++ b/tests/scenario_tests/sampling_direct_downstream_test.go
@@ -1,0 +1,62 @@
+package hpsftests
+
+import (
+	"testing"
+	"time"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSamplingDirectDownstream(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/sampling_direct_downstream.yaml")
+
+	// Verify the traces pipeline exists and has the correct components
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
+	require.True(t, getResult.Found, "Expected traces pipeline to be found")
+
+	// Check pipeline components
+	assert.Len(t, receivers, 1, "Expected 1 receiver")
+	assert.Contains(t, receivers, "otlp/Receive_OTel_1", "Expected OTel receiver")
+
+	// Sampling components are translated to Refinery rules, not collector processors
+	assert.Len(t, processors, 1, "Expected 1 processor (usage)")
+	assert.Contains(t, processors, "usage", "Expected usage processor")
+
+	assert.Len(t, exporters, 1, "Expected 1 exporter")
+	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected SamplingSequencer exporter")
+
+	// Verify Refinery rules configuration
+	assert.Len(t, rulesConfig.Samplers, 1, "Expected 1 sampler in refinery config")
+
+	// Check that the __default__ environment has a sampler
+	defaultSampler, exists := rulesConfig.Samplers["__default__"]
+	require.True(t, exists, "Expected __default__ sampler to exist")
+
+	// Verify the sampler is a RulesBasedSampler with two rules
+	require.NotNil(t, defaultSampler.RulesBasedSampler, "Expected RulesBasedSampler configuration")
+	assert.Len(t, defaultSampler.RulesBasedSampler.Rules, 2, "Expected 2 rules in the sampler")
+
+	// Check the first rule is a DeterministicSampler with a condition
+	rule1 := defaultSampler.RulesBasedSampler.Rules[0]
+	assert.Equal(t, "Sample_at_a_Fixed_Rate_1", rule1.Name, "Expected rule 1 name to match component name")
+	assert.Len(t, rule1.Conditions, 1, "Expected 1 condition in rule 1")
+	assert.Equal(t, "duration_ms", rule1.Conditions[0].Field, "Expected duration_ms field in rule 1")
+	assert.Equal(t, ">=", rule1.Conditions[0].Operator, "Expected >= operator in rule 1")
+	assert.Equal(t, 1000, rule1.Conditions[0].Value, "Expected value 1000 in rule 1")
+	assert.Equal(t, "int", rule1.Conditions[0].Datatype, "Expected int datatype in rule 1")
+
+	// Check the second rule is an EMAThroughputSampler
+	rule2 := defaultSampler.RulesBasedSampler.Rules[1]
+	assert.Nil(t, rule2.Conditions, "Expected no conditions in rule 2")
+	assert.NotNil(t, rule2.Sampler, "Expected sampler configuration in rule 2")
+	assert.NotNil(t, rule2.Sampler.EMAThroughputSampler, "Expected EMAThroughputSampler in rule 2")
+	assert.Equal(t, 200, rule2.Sampler.EMAThroughputSampler.GoalThroughputPerSec, "Expected GoalThroughputPerSec in rule 2")
+	assert.Equal(t, time.Duration(60)*time.Second, time.Duration(rule2.Sampler.EMAThroughputSampler.AdjustmentInterval), "Expected AdjustmentInterval in rule 2")
+	assert.ElementsMatch(t, []string{"http.method", "http.status_code"}, rule2.Sampler.EMAThroughputSampler.FieldList, "Expected FieldList in rule 2")
+}

--- a/tests/scenario_tests/testdata/sampling_direct_downstream.yaml
+++ b/tests/scenario_tests/testdata/sampling_direct_downstream.yaml
@@ -1,0 +1,95 @@
+components:
+  - name: Receive OTel_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Check Duration_1
+    kind: LongDurationCondition
+  - name: Sample at a Fixed Rate_1
+    kind: DeterministicSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+  - name: Sample by Events per Second_1
+    kind: EMAThroughputSampler
+    properties:
+      - name: GoalThroughputPerSec
+        value: 200
+      - name: AdjustmentInterval
+        value: 60
+      - name: FieldList
+        value: ["http.method", "http.status_code"]
+connections:
+  - source:
+      component: Receive OTel_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Check Duration_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Check Duration_1
+      port: And
+      type: SampleData
+    destination:
+      component: Sample at a Fixed Rate_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Sample at a Fixed Rate_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Sample by Events per Second_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Start Sampling_1
+      port: Rule 2
+      type: SampleData
+    destination:
+      component: Sample by Events per Second_1
+      port: Sample
+      type: SampleData
+layout:
+  components:
+    - name: Receive OTel_1
+      position:
+        x: -40
+        y: -40
+    - name: Start Sampling_1
+      position:
+        x: 220
+        y: -80
+    - name: Check Duration_1
+      position:
+        x: 400
+        y: -80
+    - name: Sample at a Fixed Rate_1
+      position:
+        x: 611
+        y: -80
+    - name: Send to Honeycomb_1
+      position:
+        x: 836
+        y: -80
+    - name: Sample by Events per Second_1
+      position:
+        x: 480
+        y: 80


### PR DESCRIPTION
## Which problem is this PR solving?

- A path that contained a complex sampler but no conditions didn't render properly

## Short description of the changes

- Write a good test (thanks for the assist, Cursor)
- Propagate the index to the right place
- Clean up the output so it renders idiomatically (curse you, Refinery rules config!)

