### PR TITLE
fix: allow dropper after condition

### DIFF
--- a/tests/scenario_tests/dropper_after_condition_test.go
+++ b/tests/scenario_tests/dropper_after_condition_test.go
@@ -1,0 +1,62 @@
+package hpsftests
+
+import (
+	"testing"
+	"time"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropperAfterCondition(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/dropper_after_condition.yaml")
+
+	// Verify the traces pipeline exists and has the correct components
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
+	require.True(t, getResult.Found, "Expected traces pipeline to be found")
+
+	// Check pipeline components
+	assert.Len(t, receivers, 1, "Expected 1 receiver")
+	assert.Contains(t, receivers, "otlp/Receive_OTel_1", "Expected OTel receiver")
+
+	// Sampling components are translated to Refinery rules, not collector processors
+	assert.Len(t, processors, 1, "Expected 1 processor (usage)")
+	assert.Contains(t, processors, "usage", "Expected usage processor")
+
+	assert.Len(t, exporters, 1, "Expected 1 exporter")
+	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected SamplingSequencer exporter")
+
+	// Verify Refinery rules configuration
+	assert.Len(t, rulesConfig.Samplers, 1, "Expected 1 sampler in refinery config")
+
+	// Check that the __default__ environment has a sampler
+	defaultSampler, exists := rulesConfig.Samplers["__default__"]
+	require.True(t, exists, "Expected __default__ sampler to exist")
+
+	// Verify the sampler is a RulesBasedSampler with two rules
+	require.NotNil(t, defaultSampler.RulesBasedSampler, "Expected RulesBasedSampler configuration")
+	assert.Len(t, defaultSampler.RulesBasedSampler.Rules, 2, "Expected 2 rules in the sampler")
+
+	// Check the first rule is a DeterministicSampler with a condition
+	rule1 := defaultSampler.RulesBasedSampler.Rules[0]
+	assert.Equal(t, "Drop_1", rule1.Name, "Expected rule 1 name to match component name")
+	assert.Len(t, rule1.Conditions, 1, "Expected 1 condition in rule 1")
+	assert.Len(t, rule1.Conditions[0].Fields, 1, "Expected 1 Fields in condition 1")
+	assert.Equal(t, "error", rule1.Conditions[0].Fields[0], "Expected error field in rule 1")
+	assert.Equal(t, "exists", rule1.Conditions[0].Operator, "Expected exists operator in rule 1")
+	assert.True(t, rule1.Drop, "Expected this rule to drop")
+
+	// Check the second rule is an EMAThroughputSampler
+	rule2 := defaultSampler.RulesBasedSampler.Rules[1]
+	assert.Nil(t, rule2.Conditions, "Expected no conditions in rule 2")
+	assert.NotNil(t, rule2.Sampler, "Expected sampler configuration in rule 2")
+	assert.NotNil(t, rule2.Sampler.EMAThroughputSampler, "Expected EMAThroughputSampler in rule 2")
+	assert.Equal(t, 200, rule2.Sampler.EMAThroughputSampler.GoalThroughputPerSec, "Expected GoalThroughputPerSec in rule 2")
+	assert.Equal(t, time.Duration(60)*time.Second, time.Duration(rule2.Sampler.EMAThroughputSampler.AdjustmentInterval), "Expected AdjustmentInterval in rule 2")
+	assert.ElementsMatch(t, []string{"http.method", "http.status_code"}, rule2.Sampler.EMAThroughputSampler.FieldList, "Expected FieldList in rule 2")
+}

--- a/tests/scenario_tests/dropper_after_sampler_test.go
+++ b/tests/scenario_tests/dropper_after_sampler_test.go
@@ -1,0 +1,49 @@
+package hpsftests
+
+import (
+	"testing"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropperAfterSampler(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/dropper_after_sampler.yaml")
+
+	// Verify the traces pipeline exists and has the correct components
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	receivers, processors, exporters, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
+	require.True(t, getResult.Found, "Expected traces pipeline to be found")
+
+	// Check pipeline components
+	assert.Len(t, receivers, 1, "Expected 1 receiver")
+	assert.Contains(t, receivers, "otlp/Receive_OTel_1", "Expected OTel receiver")
+
+	// Sampling components are translated to Refinery rules, not collector processors
+	assert.Len(t, processors, 1, "Expected 1 processor (usage)")
+	assert.Contains(t, processors, "usage", "Expected usage processor")
+
+	assert.Len(t, exporters, 1, "Expected 1 exporter")
+	assert.Contains(t, exporters, "otlphttp/Start_Sampling_1", "Expected SamplingSequencer exporter")
+
+	// Verify Refinery rules configuration
+	assert.Len(t, rulesConfig.Samplers, 1, "Expected 1 sampler in refinery config")
+
+	// Check that the __default__ environment has a sampler
+	defaultSampler, exists := rulesConfig.Samplers["__default__"]
+	require.True(t, exists, "Expected __default__ sampler to exist")
+
+	// Verify the sampler is a RulesBasedSampler with two rules
+	require.NotNil(t, defaultSampler.RulesBasedSampler, "Expected RulesBasedSampler configuration")
+	assert.Len(t, defaultSampler.RulesBasedSampler.Rules, 1, "Expected 1 rules in the sampler")
+
+	// Check the first rule is a DeterministicSampler with a condition
+	rule1 := defaultSampler.RulesBasedSampler.Rules[0]
+	assert.Equal(t, "Drop_1", rule1.Name, "Expected rule 1 name to match component name")
+	assert.Len(t, rule1.Conditions, 0, "Expected 0 conditions in rule 1")
+	assert.True(t, rule1.Drop, "Expected this rule to drop")
+}

--- a/tests/scenario_tests/testdata/dropper_after_condition.yaml
+++ b/tests/scenario_tests/testdata/dropper_after_condition.yaml
@@ -1,0 +1,87 @@
+components:
+  - name: Receive OTel_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Check for Errors_1
+    kind: ErrorExistsCondition
+  - name: Drop_1
+    kind: Dropper
+  - name: Sample by Events per Second_1
+    kind: EMAThroughputSampler
+    properties:
+      - name: GoalThroughputPerSec
+        value: 200
+      - name: AdjustmentInterval
+        value: 60
+      - name: FieldList
+        value: ["http.method", "http.status_code"]
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: Receive OTel_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Check for Errors_1
+      port: And
+      type: SampleData
+    destination:
+      component: Drop_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Check for Errors_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Start Sampling_1
+      port: Rule 2
+      type: SampleData
+    destination:
+      component: Sample by Events per Second_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Sample by Events per Second_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+layout:
+  components:
+    - name: Receive OTel_1
+      position:
+        x: 50
+        y: 0
+    - name: Start Sampling_1
+      position:
+        x: 277
+        y: 0
+    - name: Check for Errors_1
+      position:
+        x: 680
+        y: 0
+    - name: Drop_1
+      position:
+        x: 875
+        y: 0
+    - name: Sample by Events per Second_1
+      position:
+        x: 660
+        y: 160
+    - name: Send to Honeycomb_1
+      position:
+        x: 1060
+        y: 160

--- a/tests/scenario_tests/testdata/dropper_after_sampler.yaml
+++ b/tests/scenario_tests/testdata/dropper_after_sampler.yaml
@@ -1,0 +1,38 @@
+components:
+  - name: Receive OTel_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Drop_1
+    kind: Dropper
+connections:
+  - source:
+      component: Receive OTel_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Drop_1
+      port: Sample
+      type: SampleData
+layout:
+  components:
+    - name: Receive OTel_1
+      position:
+        x: 50
+        y: 0
+    - name: Start Sampling_1
+      position:
+        x: 277
+        y: 0
+    - name: Drop_1
+      position:
+        x: 875
+        y: 0


### PR DESCRIPTION
## Which problem is this PR solving?

- allows Droppers to be used after Conditions in refinery rules setup.

## Short description of the changes

- update switch to allow dropper after a condition
- add test for dropper after condition
- add test for dropper after startsampling

