### PR TITLE
fix: add default signal to AttributeJSONParsingProcessor

### DIFF
--- a/pkg/data/components/AttributeJSONParsingProcessor.yaml
+++ b/pkg/data/components/AttributeJSONParsingProcessor.yaml
@@ -36,6 +36,7 @@ properties:
   - name: Signal
     type: string
     subtype: oneof(span, log)
+    default: log
     validations:
       - oneof(span, log)
 templates:

--- a/pkg/data/components/DebugExporter.yaml
+++ b/pkg/data/components/DebugExporter.yaml
@@ -35,7 +35,6 @@ properties:
     type: string
     subtype: oneof(basic, normal, detailed)
     validations:
-      - noblanks
       - oneof(basic, normal, detailed)
     default: basic
 templates:

--- a/pkg/translator/testdata/hpsf/attributejsonparsingprocessor_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/attributejsonparsingprocessor_defaults.yaml
@@ -8,8 +8,6 @@ components:
     properties:
       - name: Attribute
         value: "json_data"
-      - name: Signal
-        value: "log"
 connections:
   - source:
       component: otlp_in


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes an issue where the AttributeJSONParsingProcessor validations were failing on a defalt component because no default signal was set

## Short description of the changes

- add default signal to AttributeJSONParsingProcessor
- remove unnecessary validation from DebugExporter

