### PR TITLE
maint: update smoke tests to test components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		echo "+++ container not running"; \
 		docker logs 'smoke-refinery'; \
 		docker rm 'smoke-refinery'; \
+		echo "+++ refinery failed to started up for $(FILE)"; \
 		exit 1; \
 	else \
 		echo "+++ container is running"; \
@@ -152,6 +153,7 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		echo "+++ container not running"; \
 		docker logs 'smoke-collector'; \
 		docker rm 'smoke-collector'; \
+		echo "+++ collector failed to start up for $(FILE)"; \
 		exit 1; \
 	else \
 		echo "+++ container is running"; \
@@ -160,13 +162,17 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		echo "+++ collector successfully started up for $(FILE)"; \
 	fi
 
-.PHONY: smoke
+.PHONY: smoke_templates
 #: run smoke tests for HPSF templates
-smoke: pkg/data/templates/*.yaml
+smoke_templates: pkg/data/templates/*.yaml
 	for file in $^ ; do \
 		$(MAKE) .smoke_refinery FILE=$${file} || exit 1; \
 		$(MAKE) .smoke_collector FILE=$${file} || exit 1; \
 	done
+
+.PHONY: smoke
+#: run smoke tests for HPSF templates
+smoke: smoke_templates
 
 .PHONY: unsmoke
 unsmoke:

--- a/Makefile
+++ b/Makefile
@@ -170,9 +170,17 @@ smoke_templates: pkg/data/templates/*.yaml
 		$(MAKE) .smoke_collector FILE=$${file} || exit 1; \
 	done
 
+.PHONY: smoke_components
+#: run smoke tests for components
+smoke_components: tests/smoke/*.yaml
+	for file in $^ ; do \
+		$(MAKE) .smoke_refinery FILE=$${file} || exit 1; \
+		$(MAKE) .smoke_collector FILE=$${file} || exit 1; \
+	done
+
 .PHONY: smoke
-#: run smoke tests for HPSF templates
-smoke: smoke_templates
+#: run smoke tests for HPSF
+smoke: smoke_templates smoke_components
 
 .PHONY: unsmoke
 unsmoke:

--- a/Makefile
+++ b/Makefile
@@ -132,19 +132,19 @@ validate_all: examples/hpsf* pkg/data/templates/*
 		'del(.processors.usage) | \
 		 del(.extensions.honeycomb) | \
 		 del(.service.extensions[] | select(. == "honeycomb")) | \
-		 del(.service.pipelines.traces.processors[] | select(. == "usage")) | \
-		 del(.service.pipelines.metrics.processors[] | select(. == "usage")) | \
-		 del(.service.pipelines.logs.processors[] | select(. == "usage"))' \
+		 del(.service.pipelines.traces*.processors[] | select(. == "usage")) | \
+		 del(.service.pipelines.metrics*.processors[] | select(. == "usage")) | \
+		 del(.service.pipelines.logs*.processors[] | select(. == "usage"))' \
 		tmp/collector-config.yaml || exit 1
 
 	# run collector with the generated config
 	docker run -d --name smoke-collector \
-		--entrypoint /otelcol-contrib \
-		-v ./tmp/collector-config.yaml:/etc/otelcol-contrib/config.yaml \
+		--entrypoint /honeycomb-otelcol \
+		-v ./tmp/collector-config.yaml:/config.yaml \
 		-e HTP_COLLECTOR_POD_IP=localhost \
 		-e HTP_REFINERY_POD_IP=localhost \
 		honeycombio/supervised-collector:latest \
-		--config /etc/otelcol-contrib/config.yaml || exit 1
+		--config /config.yaml || exit 1
 	sleep 1
 
 	# check if the container is running

--- a/pkg/data/templates/emathroughput.yaml
+++ b/pkg/data/templates/emathroughput.yaml
@@ -33,12 +33,12 @@ connections:
       type: OTelTraces
   - source:
       component: Start Sampling 1
-      port: Events
-      type: HoneycombEvents
+      port: Rule 1
+      type: SampleData
     destination:
       component: EMA Throughput 1
-      port: Events
-      type: HoneycombEvents
+      port: Sample
+      type: SampleData
   - source:
       component: EMA Throughput 1
       port: Events

--- a/tests/smoke/everything_alpha.yaml
+++ b/tests/smoke/everything_alpha.yaml
@@ -1,0 +1,310 @@
+# Technically it's everything alpha except `DropSampler` since there wasn't room on SamplingSequencer to add it
+components:
+  - name: Receive OTel_1
+    kind: OTelReceiver
+  - name: Send OTel via gRPC_1
+    kind: OTelGRPCExporter
+    properties:
+      - name: Headers
+        value:
+          test: header
+      - name: Insecure
+        value: true
+  - name: Send OTel via HTTP_1
+    kind: OTelHTTPExporter
+    properties:
+      - name: Headers
+        value:
+          test: header
+      - name: Insecure
+        value: true
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+    properties:
+      - name: Insecure
+        value: true
+  - name: Send to S3 Archive_1
+    kind: S3ArchiveExporter
+    properties:
+      - name: Bucket
+        value: test
+      - name: Prefix
+        value: test
+  - name: Send to stdout_1
+    kind: DebugExporter
+  - name: Check Duration_1
+    kind: LongDurationCondition
+  - name: Check for Errors_1
+    kind: ErrorExistsCondition
+    properties:
+      - name: ErrorFields
+        value:
+          - error
+  - name: Filter Logs by Severity_1
+    kind: LogSeverityFilterProcessor
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Parse Log Body As JSON_1
+    kind: LogBodyJSONParsingProcessor
+  - name: Sample at a Fixed Rate_1
+    kind: DeterministicSampler
+  - name: Sample by Events per Second_1
+    kind: EMAThroughputSampler
+    properties:
+      - name: FieldList
+        value:
+          - test
+  - name: Sample Proportionally by Key_1
+    kind: EMADynamicSampler
+    properties:
+      - name: FieldList
+        value:
+          - test
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+    properties:
+      - name: Headers
+        value:
+          test: header
+      - name: UseTLS
+        value: true
+  - name: Parse Attribute As JSON_1
+    kind: AttributeJSONParsingProcessor
+    properties:
+      - name: Attribute
+        value: test
+      - name: Signal
+        value: span
+  - name: Check HTTP Status_1
+    kind: HTTPStatusCondition
+connections:
+  - source:
+      component: Receive OTel_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Parse Attribute As JSON_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Parse Attribute As JSON_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Check Duration_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Check Duration_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Start Sampling_1
+      port: Rule 2
+      type: SampleData
+    destination:
+      component: Check for Errors_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Check for Errors_1
+      port: And
+      type: SampleData
+    destination:
+      component: Sample at a Fixed Rate_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Sample at a Fixed Rate_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Start Sampling_1
+      port: Rule 4
+      type: SampleData
+    destination:
+      component: Sample Proportionally by Key_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Sample Proportionally by Key_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Start Sampling_1
+      port: Rule 3
+      type: SampleData
+    destination:
+      component: Check HTTP Status_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Check HTTP Status_1
+      port: And
+      type: SampleData
+    destination:
+      component: Sample by Events per Second_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Sample by Events per Second_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents
+  - source:
+      component: Receive OTel_1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: Send to stdout_1
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: Parse Log Body As JSON_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Receive OTel_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Parse Log Body As JSON_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to Honeycomb_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send OTel via gRPC_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send OTel via HTTP_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Filter Logs by Severity_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Send to S3 Archive_1
+      port: Logs
+      type: OTelLogs
+layout:
+  components:
+    - name: Receive OTel_1
+      position:
+        x: -1360
+        y: -100
+    - name: Send OTel via gRPC_1
+      position:
+        x: 560
+        y: 500
+    - name: Send OTel via HTTP_1
+      position:
+        x: 560
+        y: 640
+    - name: Send to Honeycomb_1
+      position:
+        x: 580
+        y: 160
+    - name: Send to S3 Archive_1
+      position:
+        x: 560
+        y: 780
+    - name: Send to stdout_1
+      position:
+        x: -760
+        y: 500
+    - name: Check Duration_1
+      position:
+        x: -140
+        y: -420
+    - name: Check for Errors_1
+      position:
+        x: -140
+        y: -300
+    - name: Filter Logs by Severity_1
+      position:
+        x: -480
+        y: -60
+    - name: Keep All_1
+      position:
+        x: 280
+        y: -440
+    - name: Parse Log Body As JSON_1
+      position:
+        x: -780
+        y: -100
+    - name: Sample at a Fixed Rate_1
+      position:
+        x: 160
+        y: -280
+    - name: Sample by Events per Second_1
+      position:
+        x: 160
+        y: -160
+    - name: Sample Proportionally by Key_1
+      position:
+        x: 180
+        y: -20
+    - name: Start Sampling_1
+      position:
+        x: -600
+        y: -380
+    - name: Parse Attribute As JSON_1
+      position:
+        x: -1080
+        y: -180
+    - name: Check HTTP Status_1
+      position:
+        x: -60
+        y: -160


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/pipeline-team/issues/306

## Short description of the changes

- Update smoke tests to uses the supervised-collector image.
- Update smoke tests to handle new unique pipeline names
- Update EMAThroughput sampler to latest sampler API
- add test that smokes all alpha components and their properties.


I tried adding `make smoke` to CI but passing the config files to docker is proving challenging. I'll follow that up in another PR.

