### PR TITLE
feat: add validation for component version

### DIFF
--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -262,6 +262,7 @@ type Property struct {
 type Component struct {
 	Name       string     `yaml:"name"`
 	Kind       string     `yaml:"kind"`
+	Version    string     `yaml:"version"`
 	Ports      []Port     `yaml:"ports,omitempty"`
 	Properties []Property `yaml:"properties,omitempty"`
 	Style      string     `yaml:"style,omitempty"`

--- a/pkg/translator/testdata/bad_hpsf/invalid_component_version.yaml
+++ b/pkg/translator/testdata/bad_hpsf/invalid_component_version.yaml
@@ -1,0 +1,42 @@
+version: 0.14.0
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+    version: v0.1.0
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+    version: v0.1.0
+  - name: Deterministic Sampler_1
+    kind: DeterministicSampler
+    properties:
+      - name: SampleRate
+        value: 120
+    version: v0.1.0
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+    version: v999999.1.0
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Deterministic Sampler_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Deterministic Sampler_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -74,14 +74,14 @@ func (t *Translator) LoadEmbeddedComponents() error {
 func (t *Translator) MakeConfigComponent(component *hpsf.Component) (config.Component, error) {
 	// first look in the template components
 	tc, ok := t.components[component.Kind]
-	if ok {
+	if ok && (len(component.Version) <= 0 || tc.Version == component.Version) {
 		// found it, manufacture a new instance of the component
 		tc.SetHPSF(component)
 		return &tc, nil
 	}
 
 	// nothing found so we're done
-	return nil, fmt.Errorf("unknown component kind: %s", component.Kind)
+	return nil, fmt.Errorf("unknown component kind: %s@%s", component.Kind, component.Version)
 }
 
 // getMatchingTemplateComponents returns the template components that match the components in the HPSF document.
@@ -95,10 +95,10 @@ func (t *Translator) getMatchingTemplateComponents(h *hpsf.HPSF) (map[string]con
 			result.Add(fmt.Errorf("failed to validate component %s: %w", c.Name, err))
 			continue
 		}
-		if comp, ok := t.components[c.Kind]; ok {
+		if comp, ok := t.components[c.Kind]; ok && (len(c.Version) <= 0 || c.Version == comp.Version) {
 			templateComps[c.GetSafeName()] = comp
 		} else {
-			result.Add(fmt.Errorf("failed to locate corresponding template component for %s: %w", c.Name, err))
+			result.Add(fmt.Errorf("failed to locate corresponding template component for %s@%s: %w", c.Kind, c.Version, err))
 		}
 	}
 	return templateComps, result

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -398,6 +398,7 @@ func TestTranslator_ValidateBadConfigs(t *testing.T) {
 		{"missing property", "testdata/bad_hpsf/missing_property.yaml", "property not found"},
 		{"missing port", "testdata/bad_hpsf/missing_port.yaml", "source component does not have a port,destination component does not have a port"},
 		{"missing condition on lower index", "testdata/bad_hpsf/missing_condition_on_lower_index.yaml", "Every path on a startsampler except the one with the highest index must connect to a condition"},
+		{"missing component for specified version", "testdata/bad_hpsf/invalid_component_version.yaml", "failed to locate corresponding template component for HoneycombExporter@v999999.1.0"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- Ensure that components loaded match the HPSF configuration

## Short description of the changes

- This updates the validation path to check that any component version specified in the HPSF will be taken into consideration when looking up the component. The component map should probably be a map of maps to include multiple versions of the same component in the near future, but this is ok for now.

