### PR TITLE
maint: add smoke tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Install Go 1.24.4"
+          name: "Install Go"
+          environment:
+            GO_VERSION: "1.24.4"
           command: |
-            wget https://go.dev/dl/go1.24.4.linux-amd64.tar.gz
+            wget https://go.dev/dl/go$(GO_VERSION).linux-amd64.tar.gz
             sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go$(GO_VERSION).linux-amd64.tar.gz
             echo 'export PATH=/usr/local/go/bin:$PATH' >> $BASH_ENV
             go version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
+      - run: make smoke
       - run: make test
       - run: make validate_all
-      - run: make smoke
       - store_test_results:
           path: test_results/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
           command: |
             sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
             sudo chmod +x /usr/local/bin/yq
-            echo 'export PATH=/usr/local/bin:$PATH' >> $BASH_ENV
             yq --version
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
-      - run: make smoke
       - run: make test
       - run: make validate_all
+      - run: make smoke
       - store_test_results:
           path: test_results/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,24 @@ version: 2.1
 
 jobs:
   test:
-    docker:
-      - image: cimg/go:1.24
+    machine:
+      - image: ubuntu-2004:current
     steps:
       - checkout
+      - run:
+          name: "Install Go 1.24.4"
+          command: |
+            wget https://go.dev/dl/go1.24.4.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
+            echo 'export PATH=/usr/local/go/bin:$PATH' >> $BASH_ENV
+            go version
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
       - run: make test
       - run: make validate_all
+      - run: make smoke
       - store_test_results:
           path: test_results/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@ version: 2.1
 
 jobs:
   test:
-    machine:
-      - image: ubuntu-2004:current
+    machine: true
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           command: |
             sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
             sudo chmod +x /usr/local/bin/yq
+            echo 'export PATH=/usr/local/bin:$PATH' >> $BASH_ENV
             yq --version
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ jobs:
             sudo tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
             echo 'export PATH=/usr/local/go/bin:$PATH' >> $BASH_ENV
             go version
+      - run:
+          name: "Install yq"
+          command: |
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
       - restore_cache:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ jobs:
           environment:
             GO_VERSION: "1.24.4"
           command: |
-            wget https://go.dev/dl/go$(GO_VERSION).linux-amd64.tar.gz
+            wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go$(GO_VERSION).linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
             echo 'export PATH=/usr/local/go/bin:$PATH' >> $BASH_ENV
             go version
       - run:

--- a/Makefile
+++ b/Makefile
@@ -118,20 +118,9 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	# generate the configs from the provided file
 	go run ./cmd/hpsf -i ${FILE} -o tmp/collector-config.yaml cConfig || exit 1
 
-	# check yq is installed and at least version 4.0.0
-	if [ "$$(yq --version | cut -d' ' -f2 | cut -d'.' -f1)" -lt 4 ]; then \
-		echo "+++ yq could not be found or its version is less than 4.0.0, please update it"; \
-		exit 1; \
-	fi
-
 	# use yq to remove the usage processor and honeycomb extension from collector config
 	yq -i e \
-		'del(.processors.usage) | \
-		 del(.extensions.honeycomb) | \
-		 del(.service.extensions[] | select(. == "honeycomb")) | \
-		 del(.service.pipelines.traces*.processors[] | select(. == "usage")) | \
-		 del(.service.pipelines.metrics*.processors[] | select(. == "usage")) | \
-		 del(.service.pipelines.logs*.processors[] | select(. == "usage"))' \
+		'del(.processors.usage) | del(.extensions.honeycomb) | del(.service.extensions[] | select(. == "honeycomb")) | del(.service.pipelines.traces*.processors[] | select(. == "usage")) | del(.service.pipelines.metrics*.processors[] | select(. == "usage")) | del(.service.pipelines.logs*.processors[] | select(. == "usage"))' \
 		tmp/collector-config.yaml || exit 1
 
 	# run collector with the generated config

--- a/Makefile
+++ b/Makefile
@@ -119,12 +119,8 @@ validate_all: examples/hpsf* pkg/data/templates/*
 	go run ./cmd/hpsf -i ${FILE} -o tmp/collector-config.yaml cConfig || exit 1
 
 	# check yq is installed and at least version 4.0.0
-	if ! command -v yq &> /dev/null; then \
-		echo "+++ yq could not be found, please install it"; \
-		exit 1; \
-	fi
 	if [ "$$(yq --version | cut -d' ' -f2 | cut -d'.' -f1)" -lt 4 ]; then \
-		echo "+++ yq version is less than 4.0.0, please update it"; \
+		echo "+++ yq could not be found or its version is less than 4.0.0, please update it"; \
 		exit 1; \
 	fi
 

--- a/pkg/data/components/S3ArchiveExporter.yaml
+++ b/pkg/data/components/S3ArchiveExporter.yaml
@@ -110,7 +110,7 @@ templates:
       signalTypes: [traces, metrics, logs]
       collectorComponentName: awss3
     data:
-      - key: "{{ .ComponentName }}.s3uploader.s3_bucketssssss"
+      - key: "{{ .ComponentName }}.s3uploader.s3_bucket"
         value: "{{ .Values.Bucket }}"
       - key: "{{ .ComponentName }}.s3uploader.region"
         value: "{{ .Values.Region }}"

--- a/pkg/data/components/S3ArchiveExporter.yaml
+++ b/pkg/data/components/S3ArchiveExporter.yaml
@@ -110,7 +110,7 @@ templates:
       signalTypes: [traces, metrics, logs]
       collectorComponentName: awss3
     data:
-      - key: "{{ .ComponentName }}.s3uploader.s3_bucket"
+      - key: "{{ .ComponentName }}.s3uploader.s3_bucketssssss"
         value: "{{ .Values.Bucket }}"
       - key: "{{ .ComponentName }}.s3uploader.region"
         value: "{{ .Values.Region }}"


### PR DESCRIPTION
## Which problem is this PR solving?

- add smoke tests to CI

## Short description of the changes

- update ci config to use machine executor so volume mounting works
- add steps to install Go and yq
- update smoke target in makefile to not check for yq (this step wasn't working in ci)
- update smoke target in makefile to pass in the ya string in 1 line (ci didn't like splitting the string into separate lines).

