### PR TITLE
chore: clean up following linter suggestions

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -87,10 +87,11 @@ func main() {
 
 	// Create the output file
 	var outf io.Writer
+	var f *os.File
 	if cmdopts.Output == "-" {
 		outf = os.Stdout
 	} else {
-		f, err := os.Create(cmdopts.Output)
+		f, err = os.Create(cmdopts.Output)
 		if err != nil {
 			log.Fatalf("error creating output file: %v", err)
 		}
@@ -104,6 +105,9 @@ func main() {
 	// a real app should load them from a database
 	components, err := data.LoadEmbeddedComponents()
 	if err != nil {
+		if f != nil {
+			f.Close()
+		}
 		log.Fatalf("error loading embedded components: %v", err)
 	}
 	// install the components
@@ -150,10 +154,10 @@ func main() {
 					log.Printf("  error: %v", e)
 				}
 				os.Exit(1)
-			} else {
-				log.Printf("unexpected validation error: %v", verrors)
-				os.Exit(1)
 			}
+
+			log.Printf("unexpected validation error: %v", verrors)
+			os.Exit(1)
 		}
 
 		log.Printf("HPSF is valid")
@@ -212,7 +216,7 @@ func readInput(filename string) ([]byte, error) {
 	} else {
 		f, err := os.Open(filename)
 		if err != nil {
-			return nil, fmt.Errorf("error opening file %s: %v", filename, err)
+			return nil, fmt.Errorf("error opening file %s: %w", filename, err)
 		}
 		fIn = f
 		defer f.Close()
@@ -221,7 +225,7 @@ func readInput(filename string) ([]byte, error) {
 	// read it into a buffer
 	data, err := io.ReadAll(fIn)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file %s: %v", filename, err)
+		return nil, fmt.Errorf("error reading file %s: %w", filename, err)
 	}
 	return data, nil
 }
@@ -231,7 +235,7 @@ func unmarshalHPSF(data io.Reader) (*hpsf.HPSF, error) {
 	dec := y.NewDecoder(data)
 	err := dec.Decode(&hpsf)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling to yaml: %v", err)
+		return nil, fmt.Errorf("error unmarshaling to yaml: %w", err)
 	}
 	return &hpsf, nil
 }

--- a/cmd/hpsf2db/main.go
+++ b/cmd/hpsf2db/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"log"
 	"maps"
@@ -26,7 +26,7 @@ type Options struct {
 
 func (o *Options) validate() error {
 	if o.VerifyCheckums && o.CalculateChecksums || !o.VerifyCheckums && !o.CalculateChecksums {
-		return fmt.Errorf("you must specify one of -v (--calculate-checksum) or -x (--verify-checksums). See --help for more information")
+		return errors.New("you must specify one of -v (--calculate-checksum) or -x (--verify-checksums). See --help for more information")
 	}
 	return nil
 }
@@ -134,9 +134,8 @@ func main() {
 			log.Println("no changes")
 			// we return 0 to indicate that the checksums match
 			os.Exit(0)
-		} else {
-			// we return 1 to indicate that the checksums do not match
-			os.Exit(1)
 		}
+		// we return 1 to indicate that the checksums do not match
+		os.Exit(1)
 	}
 }

--- a/pkg/config/collectorTemplate.go
+++ b/pkg/config/collectorTemplate.go
@@ -37,39 +37,38 @@ func getKV(d any) (*dottedConfigTemplateKV, bool) {
 	// values can be strings, ints, bools, []string, map[string]string, []any, or map[string]any
 	if _, ok := m["value"]; !ok {
 		return kv, false
-	} else {
-		switch val := m["value"].(type) {
-		case string:
-			kv.value = val
-		case int:
-			kv.value = val
-		case bool:
-			kv.value = val
-		case []string:
-			kv.value = val
-		case map[string]string:
-			kv.value = val
-		case []any:
-			sl := make([]string, 0, len(val))
-			for _, v := range val {
-				if _, ok := v.(string); !ok {
-					return kv, false
-				}
-				sl = append(sl, v.(string))
+	}
+	switch val := m["value"].(type) {
+	case string:
+		kv.value = val
+	case int:
+		kv.value = val
+	case bool:
+		kv.value = val
+	case []string:
+		kv.value = val
+	case map[string]string:
+		kv.value = val
+	case []any:
+		sl := make([]string, 0, len(val))
+		for _, v := range val {
+			if _, ok := v.(string); !ok {
+				return kv, false
 			}
-			kv.value = sl
-		case map[string]any:
-			mp := make(map[string]string)
-			for k, v := range val {
-				if _, ok := v.(string); !ok {
-					return kv, false
-				}
-				mp[k] = v.(string)
-			}
-			kv.value = mp
-		default:
-			return kv, false
+			sl = append(sl, v.(string))
 		}
+		kv.value = sl
+	case map[string]any:
+		mp := make(map[string]string)
+		for k, v := range val {
+			if _, ok := v.(string); !ok {
+				return kv, false
+			}
+			mp[k] = v.(string)
+		}
+		kv.value = mp
+	default:
+		return kv, false
 	}
 
 	// suppress_if specifies a condition under which the key-value pair should be suppressed
@@ -78,7 +77,7 @@ func getKV(d any) (*dottedConfigTemplateKV, bool) {
 		if _, ok := m["suppress_if"].(string); !ok {
 			return kv, false
 		}
-		kv.suppress_if = m["suppress_if"].(string)
+		kv.suppressIf = m["suppress_if"].(string)
 	}
 	return kv, true
 }

--- a/pkg/config/dotTemplate.go
+++ b/pkg/config/dotTemplate.go
@@ -1,15 +1,16 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 )
 
 type dottedConfigTemplateKV struct {
-	key         string
-	value       any
-	suppress_if string
+	key        string
+	value      any
+	suppressIf string
 }
 
 // dottedConfigTemplate is the type we use for templates that properly modeled by
@@ -26,7 +27,7 @@ func buildDottedConfigTemplate(data []any) (dottedConfigTemplate, error) {
 		}
 		var sk, sv, suppr string
 		if mk, ok := m["key"]; !ok {
-			return nil, fmt.Errorf("missing key in template data")
+			return nil, errors.New("missing key in template data")
 		} else {
 			if _, ok := mk.(string); !ok {
 				return nil, fmt.Errorf("expected string for key, got %T", mk)
@@ -34,7 +35,7 @@ func buildDottedConfigTemplate(data []any) (dottedConfigTemplate, error) {
 			sk = mk.(string)
 		}
 		if _, ok := m["value"]; !ok {
-			return nil, fmt.Errorf("missing value in template data")
+			return nil, errors.New("missing value in template data")
 		} else {
 			if _, ok := m["value"].(string); !ok {
 				return nil, fmt.Errorf("expected string for v, got %T", m["value"])
@@ -47,7 +48,7 @@ func buildDottedConfigTemplate(data []any) (dottedConfigTemplate, error) {
 			}
 			suppr = m["suppress_if"].(string)
 		}
-		d = append(d, dottedConfigTemplateKV{key: sk, value: sv, suppress_if: suppr})
+		d = append(d, dottedConfigTemplateKV{key: sk, value: sv, suppressIf: suppr})
 	}
 	return d, nil
 }
@@ -62,9 +63,9 @@ func (t *TemplateComponent) generateDottedConfig(dct dottedConfigTemplate, userd
 		if err != nil {
 			return nil, err
 		}
-		if kv.suppress_if != "" {
+		if kv.suppressIf != "" {
 			// if the suppress_if condition is met, we skip this key
-			condition, err := t.applyTemplate(kv.suppress_if, userdata)
+			condition, err := t.applyTemplate(kv.suppressIf, userdata)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -62,13 +62,15 @@ func buildurl(args ...any) string {
 	var insecure bool
 	var port int
 	var host, path string
-	if len(args) == 4 {
+	switch len(args) {
+	case 4:
 		path = args[3].(string)
-	} else if len(args) == 3 {
+	case 3:
 		path = ""
-	} else {
+	default:
 		return ""
 	}
+
 	insecure = args[0].(bool)
 	host = args[1].(string)
 	port = _asInt(args[2])
@@ -138,7 +140,7 @@ func encodeAsFloat(a any) string {
 	value := "0"
 	switch v := a.(type) {
 	case int:
-		value = fmt.Sprintf("%d", v)
+		value = strconv.Itoa(v)
 	case float64:
 		value = fmt.Sprintf("%f", v)
 	case string:
@@ -157,7 +159,7 @@ func encodeAsInt(a any) string {
 	value := "0"
 	switch v := a.(type) {
 	case int:
-		value = fmt.Sprintf("%d", v)
+		value = strconv.Itoa(v)
 	case float64:
 		value = fmt.Sprintf("%f", v)
 	case string:
@@ -245,19 +247,11 @@ func yamlf(a any) string {
 }
 
 // The functions below are internal to this file hence the leading underscore.
-// Some of these are currently unused but will likely be used in the future.
-
-// internal function to compare two "any" values for equivalence
-func _equivalent(a, b any) bool {
-	va := fmt.Sprintf("%v", a)
-	vb := fmt.Sprintf("%v", b)
-	return va == vb
-}
 
 // this formats an integer with underscores for readability.
 // e.g. 1000000 becomes 1_000_000
 func _formatIntWithUnderscores(i int) string {
-	s := fmt.Sprintf("%d", i)
+	s := strconv.Itoa(i)
 	var output []string
 	for len(s) > 3 {
 		output = append([]string{s[len(s)-3:]}, output...)
@@ -298,27 +292,6 @@ func _isZeroValue(value any) bool {
 	default:
 		return false
 	}
-}
-
-// Takes a key that may or may not be in the incoming data,
-// and returns the value found, possibly doing a recursive call
-// separated by dots in the key.
-func _fetch(data map[string]any, key string) (any, bool) {
-	if value, ok := data[key]; ok {
-		return value, true
-	}
-	if strings.Contains(key, ".") {
-		parts := strings.SplitN(key, ".", 2)
-		groups := strings.Split(parts[0], "/")
-		for _, g := range groups {
-			if value, ok := data[g]; ok {
-				if submap, ok := value.(map[string]any); ok {
-					return _fetch(submap, parts[1])
-				}
-			}
-		}
-	}
-	return nil, false
 }
 
 // Takes a value that is a slice of strings or a slice of any and returns a

--- a/pkg/config/rulestemplate.go
+++ b/pkg/config/rulestemplate.go
@@ -73,9 +73,9 @@ func (t *TemplateComponent) generateRulesConfig(rt *rulesTemplate, compType tmpl
 		if err != nil {
 			return nil, err
 		}
-		if kv.suppress_if != "" {
+		if kv.suppressIf != "" {
 			// if the suppress_if condition is met, we skip this key
-			condition, err := t.applyTemplate(kv.suppress_if, userdata)
+			condition, err := t.applyTemplate(kv.suppressIf, userdata)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/config/templateProperty.go
+++ b/pkg/config/templateProperty.go
@@ -129,7 +129,7 @@ func (tp *TemplateProperty) Validate(prop hpsf.Property) error {
 }
 
 // always returns false
-func alwaysFail(val any) bool {
+func alwaysFail(_ any) bool {
 	return false
 }
 

--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -88,7 +88,6 @@ func dedup[T comparable](slice []T) []T {
 // it's not a slice.
 // It will create the section if it doesn't exist.
 func (cc *CollectorConfig) Set(section string, key string, value any) {
-
 	if _, ok := cc.Sections[section]; !ok {
 		cc.Sections[section] = make(DottedConfig)
 	}

--- a/pkg/config/tmpl/dottedconfig.go
+++ b/pkg/config/tmpl/dottedconfig.go
@@ -241,7 +241,6 @@ func (dc DottedConfig) Merge(other TemplateConfig) error {
 		default:
 			dc[k] = v
 		}
-
 	}
 	return nil
 }

--- a/pkg/config/tmpl/refineryrules.go
+++ b/pkg/config/tmpl/refineryrules.go
@@ -227,34 +227,33 @@ func setMemberValue(key string, member any, value any) error {
 			nextMember = field.Addr().Interface()
 		}
 		return setMemberValue(parts[1], nextMember, value)
-	} else {
-		field := memberValue.FieldByName(parts[0])
-		if !field.IsValid() {
-			return fmt.Errorf("field %s not found in type %T", parts[0], memberValue.Interface())
-		}
-		if field.Kind() == reflect.Ptr {
-			if field.IsNil() {
-				field.Set(reflect.New(field.Type().Elem()))
-			}
-			field = field.Elem()
-		}
-		// At the end of the path, set the value with type conversion if needed
-		v := reflect.ValueOf(value)
-		if v.Type() != field.Type() {
-			// Special handling for Duration type
-			if field.Type() == reflect.TypeOf(Duration(0)) && v.Kind() == reflect.String {
-				dur, err := time.ParseDuration(v.String())
-				if err != nil {
-					return fmt.Errorf("invalid duration format: %s", v.String())
-				}
-				v = reflect.ValueOf(Duration(dur))
-			} else if v.Type().ConvertibleTo(field.Type()) {
-				v = v.Convert(field.Type())
-			} else {
-				return fmt.Errorf("cannot assign value of type %s to field of type %s", v.Type(), field.Type())
-			}
-		}
-		field.Set(v)
 	}
+	field := memberValue.FieldByName(parts[0])
+	if !field.IsValid() {
+		return fmt.Errorf("field %s not found in type %T", parts[0], memberValue.Interface())
+	}
+	if field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		field = field.Elem()
+	}
+	// At the end of the path, set the value with type conversion if needed
+	v := reflect.ValueOf(value)
+	if v.Type() != field.Type() {
+		// Special handling for Duration type
+		if field.Type() == reflect.TypeOf(Duration(0)) && v.Kind() == reflect.String {
+			dur, err := time.ParseDuration(v.String())
+			if err != nil {
+				return fmt.Errorf("invalid duration format: %s", v.String())
+			}
+			v = reflect.ValueOf(Duration(dur))
+		} else if v.Type().ConvertibleTo(field.Type()) {
+			v = v.Convert(field.Type())
+		} else {
+			return fmt.Errorf("cannot assign value of type %s to field of type %s", v.Type(), field.Type())
+		}
+	}
+	field.Set(v)
 	return nil
 }

--- a/pkg/config/tmpl/refineryrules_test.go
+++ b/pkg/config/tmpl/refineryrules_test.go
@@ -5,50 +5,51 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetMemberValue(t *testing.T) {
 	vsc := &V2SamplerChoice{}
 	err := setMemberValue("DeterministicSampler.SampleRate", vsc, 100)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 100, vsc.DeterministicSampler.SampleRate)
 
 	err = setMemberValue("RulesBasedSampler.Rules.0.SampleRate", vsc, 200)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 200, vsc.RulesBasedSampler.Rules[0].SampleRate)
 
 	err = setMemberValue("RulesBasedSampler.Rules.1.SampleRate", vsc, 300)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 300, vsc.RulesBasedSampler.Rules[1].SampleRate)
 
 	err = setMemberValue("RulesBasedSampler.Rules.0.Sampler.DynamicSampler.SampleRate", vsc, int64(400))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(400), vsc.RulesBasedSampler.Rules[0].Sampler.DynamicSampler.SampleRate)
 
 	err = setMemberValue("WindowedThroughputSampler.UseClusterSize", vsc, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, vsc.WindowedThroughputSampler.UseClusterSize)
 
 	err = setMemberValue("WindowedThroughputSampler.UpdateFrequency", vsc, "10s")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, Duration(10*time.Second), vsc.WindowedThroughputSampler.UpdateFrequency)
 }
 
 func TestSetMemberValueFields(t *testing.T) {
 	vsc := &V2SamplerChoice{}
 	err := setMemberValue("RulesBasedSampler.Rules.0.Conditions.0.Fields", vsc, []string{"field1", "field2"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"field1", "field2"}, vsc.RulesBasedSampler.Rules[0].Conditions[0].Fields)
 
 	err = setMemberValue("RulesBasedSampler.Rules.0.Conditions.0.Field", vsc, "field3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "field3", vsc.RulesBasedSampler.Rules[0].Conditions[0].Field)
 }
 
 func TestSetMemberValueZeroValue(t *testing.T) {
 	vsc := &V2SamplerChoice{}
 	err := setMemberValue("RulesBasedSampler.Rules.0.SampleRate", vsc, 1000)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1000, vsc.RulesBasedSampler.Rules[0].SampleRate)
 	// Verify that unrelated fields remain nil/uninitialized
 	assert.Nil(t, vsc.RulesBasedSampler.Rules[0].Conditions)

--- a/pkg/data/loadEmbedded.go
+++ b/pkg/data/loadEmbedded.go
@@ -13,7 +13,7 @@ import (
 
 const DefaultConfigurationKind = "TemplateDefault"
 
-// Reads a set of components from the local embedded filesystem (in the source, this is the
+// LoadEmbeddedComponents reads a set of components from the local embedded filesystem (in the source, this is the
 // data/components directory) and loads them into a map of TemplateComponent by name.
 func LoadEmbeddedComponents() (map[string]config.TemplateComponent, error) {
 	// Read the components from the filesystem
@@ -50,7 +50,7 @@ func LoadEmbeddedComponents() (map[string]config.TemplateComponent, error) {
 	return components, nil
 }
 
-// Reads a set of templates from the local embedded filesystem (in the source, this is the
+// LoadEmbeddedTemplates reads a set of templates from the local embedded filesystem (in the source, this is the
 // data/templates directory) and loads them into a map of TemplateComponent by name.
 func LoadEmbeddedTemplates() (map[string]hpsf.HPSF, error) {
 	// Read the components from the filesystem

--- a/pkg/data/loadEmbedded_test.go
+++ b/pkg/data/loadEmbedded_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/honeycombio/hpsf/pkg/config"
@@ -48,7 +47,7 @@ func TestLoadEmbeddedComponents(t *testing.T) {
 		mustHave := []string{"name", "kind", "type", "status", "style", "version"}
 		for _, mh := range mustHave {
 			v, ok := dc[mh]
-			require.True(t, ok, fmt.Sprintf("missing %s in %s", mh, k))
+			require.True(t, ok, "missing %s in %s", mh, k)
 			require.NotEmpty(t, v)
 		}
 	}
@@ -84,7 +83,7 @@ func TestLoadTemplates(t *testing.T) {
 			require.NotEmpty(t, tmpl.Version)
 			require.NotEmpty(t, tmpl.Summary)
 			require.NotEmpty(t, tmpl.Description)
-			require.Empty(t, tmpl.Validate())
+			require.NoError(t, tmpl.Validate())
 		})
 	}
 }

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -407,7 +407,7 @@ func safeName(s string) string {
 	return re.ReplaceAllString(s, "_")
 }
 
-// Returns the safe name of the component (no spaces or special characters)
+// GetSafeName returns the safe name of the component (no spaces or special characters)
 // This has potential to cause a problem if the resulting name is not unique -- so uniqueness
 // should be tested with this name, not the original name.
 // we replace any runs of characters not in [a-zA-Z0-9] with an underscore
@@ -415,7 +415,7 @@ func (c *Component) GetSafeName() string {
 	return safeName(c.Name)
 }
 
-// returns the port with the given name, or nil if not found
+// GetPort returns the port with the given name, or nil if not found
 func (c *Component) GetPort(name string) *Port {
 	for _, p := range c.Ports {
 		if p.Name == name {
@@ -425,7 +425,7 @@ func (c *Component) GetPort(name string) *Port {
 	return nil
 }
 
-// returns the property with the given name, or nil if not found
+// GetProperty returns the property with the given name, or nil if not found
 func (c *Component) GetProperty(name string) *Property {
 	for _, p := range c.Properties {
 		if p.Name == name {
@@ -435,7 +435,7 @@ func (c *Component) GetProperty(name string) *Property {
 	return nil
 }
 
-// returns all specified property names as a slice of strings
+// GetPropertyNames returns all specified property names as a slice of strings
 func (c *Component) GetPropertyNames() []string {
 	props := make([]string, len(c.Properties))
 	for i, p := range c.Properties {
@@ -560,7 +560,7 @@ type HPSF struct {
 	Layout      Layout        `yaml:"layout,omitempty"`
 }
 
-// generate a list of components that are not named as the destination of a connection
+// GetStartComponents generates a list of components that are not named as the destination of a connection
 // This is used in visiting all the components in graph order, regardless of connection type.
 func (h *HPSF) GetStartComponents() []*Component {
 	startComps := make([]*Component, 0)
@@ -579,8 +579,8 @@ func (h *HPSF) GetStartComponents() []*Component {
 	return startComps
 }
 
-// for a given signal type, generate a list of components that are sources of connections but not destinations
-// of connections. This is used to find the start components of a pipeline.
+// GetSourceComponentsFor generates a list of components that are sources of connections but not destinations
+// of connections for a given signal type. This is used to find the start components of a pipeline.
 func (h *HPSF) GetSourceComponentsFor(connType ConnectionType) []*Component {
 	sourceComps := make([]*Component, 0)
 	// make a map of all components that are destinations of connections for the given signal type
@@ -663,7 +663,7 @@ func (p PathWithConnections) GetID() string {
 // returns a slice of slices of components, where each inner slice is a path
 // from a start component to an end component. If there are no start components,
 // it returns nil.
-func (h *HPSF) FindAllPaths(receivers map[string]bool) []PathWithConnections {
+func (h *HPSF) FindAllPaths(_ map[string]bool) []PathWithConnections {
 	var paths []PathWithConnections
 	var path []*Component
 	var connections []*Connection
@@ -711,7 +711,7 @@ func (h *HPSF) FindAllPaths(receivers map[string]bool) []PathWithConnections {
 	return paths
 }
 
-// visit all components in the HPSF in order of connections, starting from the components
+// VisitComponents visits all components in the HPSF in order of connections, starting from the components
 // that are not destinations of any connections. This is a depth-first search
 // that will visit all components that are reachable from the start components.
 func (h *HPSF) VisitComponents(fn func(*Component) error) error {
@@ -828,7 +828,7 @@ func (h *HPSF) AsYAML() (string, error) {
 	// this is a mechanism to marshal the template to YAML
 	data, err := y.Marshal(h)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling hpsf to YAML: %w", err)
+		return "", fmt.Errorf("error marshaling hpsf to YAML: %w", err)
 	}
 	return string(data), nil
 }

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/validator"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -67,14 +68,14 @@ connections:
       type: OTelTraces`)
 
 	_, err := validator.EnsureYAML(inputData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var hpsf HPSF
 	err = yaml.Unmarshal(inputData, &hpsf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	errors := hpsf.Validate()
-	assert.Empty(t, errors)
+	require.NoError(t, errors)
 }
 
 func TestHPSF_ValidateFailures(t *testing.T) {
@@ -108,11 +109,11 @@ connections:
       type: OTelTraces`)
 
 	_, err := validator.EnsureYAML(inputData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var hpsf HPSF
 	err = yaml.Unmarshal(inputData, &hpsf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = hpsf.Validate()
 	result, ok := err.(validator.Result)
@@ -384,14 +385,14 @@ func TestHPSF_VisitComponents(t *testing.T) {
 			})
 
 			if tt.errorOn != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), "test error")
 			} else {
 				if tt.expectedError != "" {
-					assert.Error(t, err)
+					require.Error(t, err)
 					assert.Contains(t, err.Error(), tt.expectedError)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, tt.expectedOrder, visited)
 				}
 			}

--- a/pkg/translator/substitutor_test.go
+++ b/pkg/translator/substitutor_test.go
@@ -3,7 +3,6 @@ package translator
 import "testing"
 
 func TestSubstitutor_DoSubstitutions(t *testing.T) {
-
 	// use the default priorities
 	tr := NewSubstitutor()
 	tr.AddSubstitution("team", "apikey", "abc123")
@@ -39,7 +38,6 @@ func TestSubstitutor_DoSubstitutions(t *testing.T) {
 }
 
 func TestSubstitutor_SubsWithPriorities(t *testing.T) {
-
 	// set up priorities in reverse
 	tr := NewSubstitutor()
 	tr.AddSubstitution("cluster", "apikey", "ghi789")

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -1,11 +1,11 @@
 package translator
 
 import (
+	"errors"
 	"fmt"
 	"iter"
-	"sort"
-
 	"maps"
+	"sort"
 
 	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
@@ -30,7 +30,7 @@ func NewTranslator() (*Translator, error) {
 	return tr, err
 }
 
-// Creates a translator with no components loaded.
+// NewEmptyTranslator creates a translator with no components loaded.
 func NewEmptyTranslator() *Translator {
 	tr := &Translator{
 		components: make(map[string]config.TemplateComponent),
@@ -59,7 +59,7 @@ func (t *Translator) GetTemplates() map[string]hpsf.HPSF {
 	return t.templates
 }
 
-// Loads the embedded components into the translator.
+// LoadEmbeddedComponents loads the embedded components into the translator.
 // Deprecated: use InstallComponents instead
 func (t *Translator) LoadEmbeddedComponents() error {
 	// load the embedded components
@@ -392,7 +392,7 @@ func (t *Translator) validateStartSampling(h *hpsf.HPSF, templateComps map[strin
 // in their configuration.
 func (t *Translator) ValidateConfig(h *hpsf.HPSF) error {
 	if h == nil {
-		return fmt.Errorf("nil HPSF document provided for validation")
+		return errors.New("nil HPSF document provided for validation")
 	}
 
 	// if we don't pass basic validation, we can't continue

--- a/pkg/translator/translator_property_validation_test.go
+++ b/pkg/translator/translator_property_validation_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestPropertyValidation(t *testing.T) {
-
 	t.Run("Validate should error if a noblanks string is not supplied and there is no default", func(t *testing.T) {
-
 		testComponent := config.TemplateComponent{
 			Kind: "NoBlanksComponent",
 			Properties: []config.TemplateProperty{
@@ -75,7 +73,6 @@ func TestPropertyValidation(t *testing.T) {
 	})
 
 	t.Run("Validate should fail when one property passes and another does not", func(t *testing.T) {
-
 		translator := NewEmptyTranslator()
 
 		testComponent := config.TemplateComponent{
@@ -107,6 +104,5 @@ func TestPropertyValidation(t *testing.T) {
 		require.IsType(t, validator.Result{}, err)
 		validationError := err.(validator.Result)
 		assert.Equal(t, 1, validationError.Len())
-
 	})
 }

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -69,7 +69,7 @@ func TestThatEachTestFileHasAMatchingComponent(t *testing.T) {
 func TestGenerateConfigForAllComponents(t *testing.T) {
 	// set this to true to overwrite the testdata files with the generated
 	// config files if they are different
-	var overwrite bool = false
+	var overwrite bool
 
 	// this allows for the make target regenerate_translator_testdata to work instead of editing
 	if os.Getenv("OVERWRITE_TESTDATA") == "1" {
@@ -98,7 +98,7 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 				var inputData = string(b)
 
 				for _, template := range component.Templates {
-					configType := config.Type(template.Kind)
+					configType := template.Kind
 					var hpsf *hpsf.HPSF
 					dec := yamlv3.NewDecoder(strings.NewReader(inputData))
 					err = dec.Decode(&hpsf)
@@ -164,7 +164,7 @@ func TestDefaultHPSF(t *testing.T) {
 
 	// set this to true to overwrite the testdata files with the generated
 	// config files if they are different
-	var overwrite bool = false
+	var overwrite bool
 
 	// this allows for the make target regenerate_translator_testdata to work instead of editing
 	if os.Getenv("OVERWRITE_TESTDATA") == "1" {
@@ -173,7 +173,6 @@ func TestDefaultHPSF(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-
 			b, err := os.ReadFile(tC.expectedConfigTestData)
 			require.NoError(t, err)
 			var expectedConfig = string(b)

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -85,7 +85,7 @@ type Validator interface {
 	Validate() error
 }
 
-// this is a brain-dead validator that just tries to unmarshal the input into appropriate forms
+// EnsureYAML is a brain-dead validator that just tries to unmarshal the input into appropriate forms
 func EnsureYAML(input []byte) (map[string]any, error) {
 	// validate the input is parseable YAML (parses into a map)
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Ran a linter locally against the repo and am following some of the suggestions to clean up the code a bit. No functional changes in this PR, though it did find a potential bug in main.go where a file handle could be left dangling, and simplified some of the indented cases that were not necessary.

## Short description of the changes

- updated comments
- added a call to close a file handle when loading embedded components could return early
- removed a few unnecessary indentation blocks
- updated assert.Error to use require.Error
- use strconv where possible instead of Sprintf
- 

