### PR TITLE
feat: split up hpsftypes into separate package

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/data"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 	"github.com/honeycombio/hpsf/pkg/translator"
 	"github.com/honeycombio/hpsf/pkg/validator"
 	"github.com/jessevdk/go-flags"
@@ -182,14 +182,14 @@ func main() {
 		if err != nil {
 			log.Fatalf("error unmarshaling input file: %v", err)
 		}
-		var ct config.Type
+		var ct hpsftypes.Type
 		switch cmds[0] {
 		case "rConfig":
-			ct = config.RefineryConfigType
+			ct = hpsftypes.RefineryConfig
 		case "rRules":
-			ct = config.RefineryRulesType
+			ct = hpsftypes.RefineryRules
 		case "cConfig":
-			ct = config.CollectorConfigType
+			ct = hpsftypes.CollectorConfig
 		}
 		cfg, err := tr.GenerateConfig(hpsf, ct, userdata)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/honeycombio/hpsf
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.24.4
 
 require (
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33
+	github.com/honeycombio/hpsf/pkg/hpsftypes v0.0.0-00010101000000-000000000000
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -18,3 +17,5 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
+
+replace github.com/honeycombio/hpsf/pkg/hpsftypes => ./pkg/hpsftypes

--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -3,14 +3,19 @@ package config
 import (
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 )
 
-type Type string
+// Deprecated: use hpsftypes.Type
+type Type hpsftypes.Type
 
 const (
-	RefineryConfigType  Type = "refinery_config"
-	RefineryRulesType   Type = "refinery_rules"
-	CollectorConfigType Type = "collector_config"
+	// Deprecated: use hpsftypes.RefineryConfig
+	RefineryConfigType = hpsftypes.RefineryConfig
+	// Deprecated: use hpsftypes.RefineryRules
+	RefineryRulesType = hpsftypes.RefineryRules
+	// Deprecated: use hpsftypes.CollectorConfig
+	CollectorConfigType = hpsftypes.CollectorConfig
 )
 
 // The Component interface is implemented by all components.
@@ -21,7 +26,7 @@ const (
 // We will need to convert the dotted paths into real ones later.
 // The pipeline identifies which pipeline is being generated.
 type Component interface {
-	GenerateConfig(cfgType Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error)
+	GenerateConfig(cfgType hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error)
 	AddConnection(*hpsf.Connection)
 }
 
@@ -34,7 +39,7 @@ func NewNullComponent() *NullComponent {
 // ensure that NullComponent implements Component
 var _ Component = (*NullComponent)(nil)
 
-func (c *NullComponent) GenerateConfig(Type, hpsf.PathWithConnections, map[string]any) (tmpl.TemplateConfig, error) {
+func (c *NullComponent) GenerateConfig(hpsftypes.Type, hpsf.PathWithConnections, map[string]any) (tmpl.TemplateConfig, error) {
 	return nil, nil
 }
 
@@ -51,7 +56,7 @@ type GenericBaseComponent struct {
 // ensure that GenericBaseComponent implements Component
 var _ Component = (*GenericBaseComponent)(nil)
 
-func (c GenericBaseComponent) GenerateConfig(ct Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
+func (c GenericBaseComponent) GenerateConfig(ct hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	switch ct {
 	case RefineryConfigType:
 		// DottedConfig is already a map, so we don't need a pointer
@@ -83,15 +88,15 @@ type UnconfiguredComponent struct {
 // ensure that UnconfiguredRefineryComponent implements Component
 var _ Component = (*UnconfiguredComponent)(nil)
 
-func (c UnconfiguredComponent) GenerateConfig(ct Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
+func (c UnconfiguredComponent) GenerateConfig(ct hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	switch ct {
-	case RefineryConfigType:
+	case hpsftypes.RefineryConfig:
 		// DottedConfig is already a map, so we don't need a pointer
 		return tmpl.DottedConfig{
 			"General.ConfigurationVersion": 2,
 			"General.MinRefineryVersion":   "v2.0",
 		}, nil
-	case RefineryRulesType:
+	case hpsftypes.RefineryRules:
 		rules := tmpl.NewRulesConfig(tmpl.Output, nil, nil)
 		rules.Samplers["__default__"] = &tmpl.V2SamplerChoice{
 			DeterministicSampler: &tmpl.DeterministicSamplerConfig{
@@ -99,7 +104,7 @@ func (c UnconfiguredComponent) GenerateConfig(ct Type, pipeline hpsf.PathWithCon
 			},
 		}
 		return rules, nil
-	case CollectorConfigType:
+	case hpsftypes.CollectorConfig:
 		return tmpl.NewCollectorConfig(), nil
 	default:
 		return nil, nil

--- a/pkg/config/refinery.go
+++ b/pkg/config/refinery.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 	"github.com/honeycombio/hpsf/pkg/yaml"
 )
 
@@ -16,7 +17,7 @@ type RefineryInputComponent struct {
 // ensure RefineryInputComponent implements Component
 var _ Component = (*RefineryInputComponent)(nil)
 
-func (c *RefineryInputComponent) GenerateConfig(ct Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
+func (c *RefineryInputComponent) GenerateConfig(ct hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	if ct != RefineryConfigType {
 		return nil, nil
 	}

--- a/pkg/config/templateComponent.go
+++ b/pkg/config/templateComponent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 	y "gopkg.in/yaml.v3"
 )
 
@@ -45,7 +46,7 @@ type TemplatePort struct {
 // template), a format (which is the format of the data), meta (a map of extra
 // component-level info) and the data itself.
 type TemplateData struct {
-	Kind   Type
+	Kind   hpsftypes.Type
 	Name   string
 	Format string
 	Meta   map[string]any
@@ -263,7 +264,7 @@ func (t *TemplateComponent) GetPortIndex(name string) int {
 // // ensure that TemplateComponent implements Component
 var _ Component = (*TemplateComponent)(nil)
 
-func (t *TemplateComponent) GenerateConfig(cfgType Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
+func (t *TemplateComponent) GenerateConfig(cfgType hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	// we have to find a template with the kind of the config; if it
 	// doesn't exist, we return an error
 

--- a/pkg/hpsftypes/go.mod
+++ b/pkg/hpsftypes/go.mod
@@ -1,0 +1,3 @@
+module github.com/honeycombio/hpsf/pkg/hpsftypes
+
+go 1.24.4

--- a/pkg/hpsftypes/types.go
+++ b/pkg/hpsftypes/types.go
@@ -1,0 +1,9 @@
+package hpsftypes
+
+type Type string
+
+const (
+	RefineryConfig  Type = "refinery_config"
+	RefineryRules   Type = "refinery_rules"
+	CollectorConfig Type = "collector_config"
+)

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/data"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 	"github.com/honeycombio/hpsf/pkg/validator"
 )
 
@@ -467,7 +468,7 @@ func (om *OrderedComponentMap) Items() iter.Seq[config.Component] {
 	}
 }
 
-func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct config.Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
+func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct hpsftypes.Type, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	comps := NewOrderedComponentMap()
 	receiverNames := make(map[string]bool)
 	// make all the components

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/data"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 	"github.com/honeycombio/hpsf/pkg/validator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,23 +142,23 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 func TestDefaultHPSF(t *testing.T) {
 	testCases := []struct {
 		desc                   string
-		ct                     config.Type
+		ct                     hpsftypes.Type
 		inputHPSFTestData      string
 		expectedConfigTestData string
 	}{
 		{
 			desc:                   "Refinery Config",
-			ct:                     config.RefineryConfigType,
+			ct:                     hpsftypes.RefineryConfig,
 			expectedConfigTestData: "testdata/refinery_config/default.yaml",
 		},
 		{
 			desc:                   "Refinery Rules",
-			ct:                     config.RefineryRulesType,
+			ct:                     hpsftypes.RefineryRules,
 			expectedConfigTestData: "testdata/refinery_rules/default.yaml",
 		},
 		{
 			desc:                   "Collector Config",
-			ct:                     config.CollectorConfigType,
+			ct:                     hpsftypes.CollectorConfig,
 			expectedConfigTestData: "testdata/collector_config/default.yaml",
 		},
 	}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/hpsf/tests
 
-go 1.24.1
+go 1.24.4
 
 require (
 	github.com/honeycombio/hpsf v0.6.1
@@ -56,6 +56,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/go-tpm v0.9.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
+	github.com/honeycombio/hpsf/pkg/hpsftypes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect
@@ -218,3 +219,5 @@ require (
 )
 
 replace github.com/honeycombio/hpsf => ../
+
+replace github.com/honeycombio/hpsf/pkg/hpsftypes => ../pkg/hpsftypes

--- a/tests/providers/hpsf/hpsf_provider.go
+++ b/tests/providers/hpsf/hpsf_provider.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
 	"github.com/honeycombio/hpsf/pkg/data"
 	"github.com/honeycombio/hpsf/pkg/hpsf"
+	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 	"github.com/honeycombio/hpsf/pkg/translator"
 	collectorConfigProvider "github.com/honeycombio/hpsf/tests/providers/collector"
 	refineryConfigProvider "github.com/honeycombio/hpsf/tests/providers/refinery"
@@ -27,7 +27,7 @@ type ErrorDetails struct {
 }
 
 type ParserError struct {
-	GenerateErrors map[config.Type]ErrorDetails
+	GenerateErrors map[hpsftypes.Type]ErrorDetails
 
 	error
 }
@@ -60,23 +60,23 @@ func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryC
 	}
 	hpsfTranslator.InstallComponents(allHpsfComponents)
 
-	errors := make(map[config.Type]ErrorDetails)
+	errors := make(map[hpsftypes.Type]ErrorDetails)
 
-	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(hpsf, config.RefineryRulesType, nil)
+	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(hpsf, hpsftypes.RefineryRules, nil)
 	if err != nil {
-		errors[config.RefineryConfigType] = ErrorDetails{Config: hpsfConfig, Error: err}
+		errors[hpsftypes.RefineryConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {
 		refineryRules = refineryConfigProvider.GetParsedRulesConfig(t, refineryRulesTmpl.(*tmpl.RulesConfig))
 	}
 
-	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(hpsf, config.CollectorConfigType, nil)
+	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(hpsf, hpsftypes.CollectorConfig, nil)
 	if err != nil {
-		errors[config.CollectorConfigType] = ErrorDetails{Config: hpsfConfig, Error: err}
+		errors[hpsftypes.CollectorConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {
 		var parsingErrors collectorConfigProvider.CollectorConfigParseError
 		collectorConfig, parsingErrors = collectorConfigProvider.GetParsedConfig(t, collectorConfigTmpl.(*tmpl.CollectorConfig))
 		if parsingErrors.HasError {
-			errors[config.CollectorConfigType] = ErrorDetails{Config: parsingErrors.Config, Error: parsingErrors.Error}
+			errors[hpsftypes.CollectorConfig] = ErrorDetails{Config: parsingErrors.Config, Error: parsingErrors.Error}
 		}
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

- This reduces the dependency on the config package, as currently the usage of `hpsf/pkg/config` is limited to the types of artifacts defined within that package. This will allow us to scope down the public api in the near future, reducing the surface 
of changes that will need to be tested to support multiple versions.

## Short description of the changes

- added `hpsftypes` package
- deprecate types in the config package in favour of the types defined in hpsftypes

