### PR TITLE
chore: accidentally bumped up go version in previous commit

### DIFF
--- a/.github/tools.mod
+++ b/.github/tools.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/hpsf/tools
 
-go 1.24.4
+go 1.24.0
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/hpsf
 
-go 1.24.4
+go 1.24.0
 
 require (
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33

--- a/pkg/hpsftypes/go.mod
+++ b/pkg/hpsftypes/go.mod
@@ -1,3 +1,3 @@
 module github.com/honeycombio/hpsf/pkg/hpsftypes
 
-go 1.24.4
+go 1.24.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/hpsf/tests
 
-go 1.24.4
+go 1.24.0
 
 require (
 	github.com/honeycombio/hpsf v0.6.1


### PR DESCRIPTION
This brings back down the requirement of the go version
