### PR TITLE
chore: remove deprecated consts

### DIFF
--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -6,18 +6,6 @@ import (
 	"github.com/honeycombio/hpsf/pkg/hpsftypes"
 )
 
-// Deprecated: use hpsftypes.Type
-type Type hpsftypes.Type
-
-const (
-	// Deprecated: use hpsftypes.RefineryConfig
-	RefineryConfigType = hpsftypes.RefineryConfig
-	// Deprecated: use hpsftypes.RefineryRules
-	RefineryRulesType = hpsftypes.RefineryRules
-	// Deprecated: use hpsftypes.CollectorConfig
-	CollectorConfigType = hpsftypes.CollectorConfig
-)
-
 // The Component interface is implemented by all components.
 // If one of these functions returns nil, nil, it means
 // that the component has no impact on that particular system.
@@ -58,15 +46,15 @@ var _ Component = (*GenericBaseComponent)(nil)
 
 func (c GenericBaseComponent) GenerateConfig(ct hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	switch ct {
-	case RefineryConfigType:
+	case hpsftypes.RefineryConfig:
 		// DottedConfig is already a map, so we don't need a pointer
 		return tmpl.DottedConfig{
 			"General.ConfigurationVersion": 2,
 			"General.MinRefineryVersion":   "v2.0",
 		}, nil
-	case RefineryRulesType:
+	case hpsftypes.RefineryRules:
 		return tmpl.NewRulesConfig(tmpl.Output, nil, nil), nil
-	case CollectorConfigType:
+	case hpsftypes.CollectorConfig:
 		return tmpl.NewCollectorConfig(), nil
 	default:
 		return nil, nil

--- a/pkg/config/refinery.go
+++ b/pkg/config/refinery.go
@@ -18,7 +18,7 @@ type RefineryInputComponent struct {
 var _ Component = (*RefineryInputComponent)(nil)
 
 func (c *RefineryInputComponent) GenerateConfig(ct hpsftypes.Type, pipeline hpsf.PathWithConnections, userdata map[string]any) (tmpl.TemplateConfig, error) {
-	if ct != RefineryConfigType {
+	if ct != hpsftypes.RefineryConfig {
 		return nil, nil
 	}
 	if c.Component.Properties == nil {

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -219,7 +219,7 @@ func TestHPSFWithoutSamplerComponentGeneratesValidRefineryRules(t *testing.T) {
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	cfg, err := tlater.GenerateConfig(&hpsf, config.RefineryRulesType, nil)
+	cfg, err := tlater.GenerateConfig(&hpsf, hpsftypes.RefineryRules, nil)
 	require.NoError(t, err)
 
 	got, err := cfg.RenderYAML()
@@ -568,7 +568,7 @@ layout:
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	x, err := tlater.GenerateConfig(h, config.RefineryRulesType, nil)
+	x, err := tlater.GenerateConfig(h, hpsftypes.RefineryRules, nil)
 	require.NoError(t, err)
 	require.NotNil(t, x)
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/honeycombio/hpsf v0.6.1
+	github.com/honeycombio/hpsf/pkg/hpsftypes v0.0.0-20250729165849-4881e28cb2c5
 	github.com/honeycombio/opentelemetry-collector-configs/honeycombextension v0.0.0-20250529172854-29e92f8bd7cb
 	github.com/honeycombio/opentelemetry-collector-configs/usageprocessor v0.1.0
 	github.com/honeycombio/refinery v1.21.1-0.20250604165426-312ddc7c2c94
@@ -56,7 +57,6 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/go-tpm v0.9.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
-	github.com/honeycombio/hpsf/pkg/hpsftypes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jessevdk/go-flags v1.6.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -148,6 +148,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
 github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
+github.com/honeycombio/hpsf/pkg/hpsftypes v0.0.0-20250729165849-4881e28cb2c5 h1:i9F4nOrImOz7wWtGzkcERygpoGXXPLHl3P44R1Yl3xE=
+github.com/honeycombio/hpsf/pkg/hpsftypes v0.0.0-20250729165849-4881e28cb2c5/go.mod h1:AyIo3V8Ci5sO1UUdwuPhpawZh956nSkKVRFjnVVUpNo=
 github.com/honeycombio/husky v0.36.0 h1:IxVSFE4p+AHm/ip3qPNbTV1ZGf/0VQxUab8ah+nWVlw=
 github.com/honeycombio/husky v0.36.0/go.mod h1:glSzr4Mq5tMkcUZRRg9s+YUshPy8kRO+2F17cKazI98=
 github.com/honeycombio/libhoney-go v1.25.0 h1:r33tlX90HtafK0bgRcjfNnsrJ9ZMTKuI/1DYaOFCc1o=


### PR DESCRIPTION
These have been updated in all downstream dependencies
