### PR TITLE
chore: remove unused function LoadEmbeddedDefaultTemplate

### DIFF
--- a/pkg/data/loadEmbedded.go
+++ b/pkg/data/loadEmbedded.go
@@ -87,21 +87,6 @@ func LoadEmbeddedTemplates() (map[string]hpsf.HPSF, error) {
 	return templates, nil
 }
 
-// LoadEmbeddedDefaultTemplate loads the default template from the embedded filesystem.
-func LoadEmbeddedDefaultTemplate() (hpsf.HPSF, error) {
-	templates, err := LoadEmbeddedTemplates()
-	if err != nil {
-		return hpsf.HPSF{}, err
-	}
-
-	template, ok := templates[DefaultConfigurationKind]
-	if !ok {
-		return hpsf.HPSF{}, fmt.Errorf("no default template found")
-	}
-
-	return template, nil
-}
-
 // CalculateChecksums reads the components and templates in the non-test
 // subdirectories in the embedded filesystem and returns all the checksums in a
 // map.

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -178,8 +178,11 @@ func TestDefaultHPSF(t *testing.T) {
 			require.NoError(t, err)
 			var expectedConfig = string(b)
 
-			h, err := data.LoadEmbeddedDefaultTemplate()
+			templates, err := data.LoadEmbeddedTemplates()
 			require.NoError(t, err)
+
+			h, ok := templates[data.DefaultConfigurationKind]
+			require.True(t, ok)
 
 			tlater := NewEmptyTranslator()
 			comps, err := data.LoadEmbeddedComponents()


### PR DESCRIPTION
## Which problem is this PR solving?

- Continuing to reduce the API surface, this change removes a function that was only used in a test file, and replaced its usage by calling LoadEmbeddedTemplates directly.

## Short description of the changes

- Removes `LoadEmbeddedDefaultTemplate`
- Update tests using it

