### PR TITLE
feat: Add FieldStartsWith and FieldContains conditions

### DIFF
--- a/pkg/data/components/FieldContainsCondition.yaml
+++ b/pkg/data/components/FieldContainsCondition.yaml
@@ -1,0 +1,58 @@
+kind: FieldContainsCondition
+name: Check That Field Contains a Substring
+style: condition
+type: base
+status: alpha
+version: v0.1.0
+summary: Checks if a field contains a specific substring
+description: |
+  This checks if any span in a trace has a specific field that contains a given substring.
+tags:
+  - category:refinery_rule_condition
+  - service:refinery
+  - vendor:Honeycomb
+  - type:error
+ports:
+  # inputs
+  - name: Match
+    direction: input
+    type: SampleData
+  # outputs
+  - name: And
+    direction: output
+    type: SampleData
+properties:
+  - name: Field
+    summary:
+      The name of the field to check. If this field exists in any span of a trace,
+      and its value contains the specified substring, the condition will match.
+    description: |
+      The field name to check for the substring.
+    type: string
+    validations:
+      - nonempty
+    default: SomeField
+  - name: Substring
+    summary:
+      The substring to check against the field value.
+    description: |
+      The substring that the field value should contain.
+    type: string
+    validations:
+      - nonempty
+    default: SomeSubstring
+templates:
+  - kind: refinery_rules
+    name: FieldContainsCondition
+    format: rules
+    meta:
+      condition: true
+    data:
+      - key: Field
+        value: "{{ .Values.Field }}"
+      - key: Operator
+        value: contains
+      - key: Value
+        value: "{{ .Values.Substring }}"
+      - key: Datatype
+        value: string

--- a/pkg/data/components/FieldContainsCondition.yaml
+++ b/pkg/data/components/FieldContainsCondition.yaml
@@ -30,8 +30,7 @@ properties:
       The field name to check for the substring.
     type: string
     validations:
-      - nonempty
-    default: SomeField
+      - noblanks
   - name: Substring
     summary:
       The substring to check against the field value.
@@ -39,8 +38,7 @@ properties:
       The substring that the field value should contain.
     type: string
     validations:
-      - nonempty
-    default: SomeSubstring
+      - noblanks
 templates:
   - kind: refinery_rules
     name: FieldContainsCondition

--- a/pkg/data/components/FieldStartsWithCondition.yaml
+++ b/pkg/data/components/FieldStartsWithCondition.yaml
@@ -30,8 +30,7 @@ properties:
       The field name to check for the prefix.
     type: string
     validations:
-      - nonempty
-    default: SomeField
+      - noblanks
   - name: Prefix
     summary:
       The prefix to check against the field value.
@@ -39,8 +38,7 @@ properties:
       The prefix that the field value should start with.
     type: string
     validations:
-      - nonempty
-    default: SomePrefix
+      - noblanks
 templates:
   - kind: refinery_rules
     name: FieldStartsWithCondition

--- a/pkg/data/components/FieldStartsWithCondition.yaml
+++ b/pkg/data/components/FieldStartsWithCondition.yaml
@@ -1,0 +1,58 @@
+kind: FieldStartsWithCondition
+name: Check That Field Starts With
+style: condition
+type: base
+status: alpha
+version: v0.1.0
+summary: Checks if a field starts with a specific prefix
+description: |
+  This checks if any span in a trace has a specific field that starts with a given prefix.
+tags:
+  - category:refinery_rule_condition
+  - service:refinery
+  - vendor:Honeycomb
+  - type:error
+ports:
+  # inputs
+  - name: Match
+    direction: input
+    type: SampleData
+  # outputs
+  - name: And
+    direction: output
+    type: SampleData
+properties:
+  - name: Field
+    summary:
+      The name of the field to check. If this field exists in any span of a trace,
+      and its value starts with the specified prefix, the condition will match.
+    description: |
+      The field name to check for the prefix.
+    type: string
+    validations:
+      - nonempty
+    default: SomeField
+  - name: Prefix
+    summary:
+      The prefix to check against the field value.
+    description: |
+      The prefix that the field value should start with.
+    type: string
+    validations:
+      - nonempty
+    default: SomePrefix
+templates:
+  - kind: refinery_rules
+    name: FieldStartsWithCondition
+    format: rules
+    meta:
+      condition: true
+    data:
+      - key: Field
+        value: "{{ .Values.Field }}"
+      - key: Operator
+        value: startsWith
+      - key: Value
+        value: "{{ .Values.Prefix }}"
+      - key: Datatype
+        value: string

--- a/pkg/translator/testdata/hpsf/fieldcontainscondition_all.yaml
+++ b/pkg/translator/testdata/hpsf/fieldcontainscondition_all.yaml
@@ -1,0 +1,49 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Field Contains_1
+    kind: FieldContainsCondition
+    properties:
+      - name: Field
+        value: "error.message"
+      - name: Substring
+        value: "timeout"
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Field Contains_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Field Contains_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/hpsf/fieldcontainscondition_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/fieldcontainscondition_defaults.yaml
@@ -1,0 +1,44 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Field Contains_1
+    kind: FieldContainsCondition
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Field Contains_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Field Contains_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/hpsf/fieldcontainscondition_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/fieldcontainscondition_defaults.yaml
@@ -5,6 +5,11 @@ components:
     kind: SamplingSequencer
   - name: Field Contains_1
     kind: FieldContainsCondition
+    properties:
+      - name: Field
+        value: "error.message"
+      - name: Substring
+        value: "timeout"
   - name: Keep All_1
     kind: KeepAllSampler
   - name: Send to Honeycomb_1

--- a/pkg/translator/testdata/hpsf/fieldstartswithcondition_all.yaml
+++ b/pkg/translator/testdata/hpsf/fieldstartswithcondition_all.yaml
@@ -1,0 +1,49 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Field Starts With_1
+    kind: FieldStartsWithCondition
+    properties:
+      - name: Field
+        value: "http.url"
+      - name: Prefix
+        value: "https://"
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Field Starts With_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Field Starts With_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/hpsf/fieldstartswithcondition_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/fieldstartswithcondition_defaults.yaml
@@ -5,6 +5,11 @@ components:
     kind: SamplingSequencer
   - name: Field Starts With_1
     kind: FieldStartsWithCondition
+    properties:
+      - name: Field
+        value: "http.url"
+      - name: Prefix
+        value: "https://"
   - name: Keep All_1
     kind: KeepAllSampler
   - name: Send to Honeycomb_1

--- a/pkg/translator/testdata/hpsf/fieldstartswithcondition_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/fieldstartswithcondition_defaults.yaml
@@ -1,0 +1,44 @@
+components:
+  - name: OTel Receiver_1
+    kind: OTelReceiver
+  - name: Start Sampling_1
+    kind: SamplingSequencer
+  - name: Field Starts With_1
+    kind: FieldStartsWithCondition
+  - name: Keep All_1
+    kind: KeepAllSampler
+  - name: Send to Honeycomb_1
+    kind: HoneycombExporter
+connections:
+  - source:
+      component: OTel Receiver_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Start Sampling_1
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Field Starts With_1
+      port: Match
+      type: SampleData
+  - source:
+      component: Field Starts With_1
+      port: And
+      type: SampleData
+    destination:
+      component: Keep All_1
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All_1
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Send to Honeycomb_1
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/refinery_rules/fieldcontainscondition_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/fieldcontainscondition_all.yaml
@@ -1,0 +1,12 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Name: Keep_All_1
+                  SampleRate: 1
+                  Conditions:
+                    - Field: error.message
+                      Operator: contains
+                      Value: timeout
+                      Datatype: string

--- a/pkg/translator/testdata/refinery_rules/fieldcontainscondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/fieldcontainscondition_defaults.yaml
@@ -6,7 +6,7 @@ Samplers:
                 - Name: Keep_All_1
                   SampleRate: 1
                   Conditions:
-                    - Field: SomeField
+                    - Field: error.message
                       Operator: contains
-                      Value: SomeSubstring
+                      Value: timeout
                       Datatype: string

--- a/pkg/translator/testdata/refinery_rules/fieldcontainscondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/fieldcontainscondition_defaults.yaml
@@ -1,0 +1,12 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Name: Keep_All_1
+                  SampleRate: 1
+                  Conditions:
+                    - Field: SomeField
+                      Operator: contains
+                      Value: SomeSubstring
+                      Datatype: string

--- a/pkg/translator/testdata/refinery_rules/fieldstartswithcondition_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/fieldstartswithcondition_all.yaml
@@ -1,0 +1,12 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Name: Keep_All_1
+                  SampleRate: 1
+                  Conditions:
+                    - Field: http.url
+                      Operator: startsWith
+                      Value: https://
+                      Datatype: string

--- a/pkg/translator/testdata/refinery_rules/fieldstartswithcondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/fieldstartswithcondition_defaults.yaml
@@ -6,7 +6,7 @@ Samplers:
                 - Name: Keep_All_1
                   SampleRate: 1
                   Conditions:
-                    - Field: SomeField
+                    - Field: http.url
                       Operator: startsWith
-                      Value: SomePrefix
+                      Value: https://
                       Datatype: string

--- a/pkg/translator/testdata/refinery_rules/fieldstartswithcondition_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/fieldstartswithcondition_defaults.yaml
@@ -1,0 +1,12 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        RulesBasedSampler:
+            Rules:
+                - Name: Keep_All_1
+                  SampleRate: 1
+                  Conditions:
+                    - Field: SomeField
+                      Operator: startsWith
+                      Value: SomePrefix
+                      Datatype: string

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -646,6 +646,10 @@ connections:
 			conditionName: "LongDurationCondition_1",
 			conditionKind: "LongDurationCondition",
 		},
+		{
+			conditionName: "FieldContainsCondition_1",
+			conditionKind: "FieldContainsCondition",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.conditionName, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds two new conditions to Refinery rules components:
  - `FieldStartsWithCondition` checks a string field for a prefix
  - `FieldContainsCondition` checks a string field for a prefix

## Short description of the changes

- Create components
- Create a new condition test function that can quickly test all condition objects
- Add test files where needed

