### PR TITLE
feat: add library_version field, add FromYAML func

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -115,12 +115,12 @@ func main() {
 
 	switch cmds[0] {
 	case "format":
-		hpsf, err := unmarshalHPSF(inputRdr)
+		h, err := hpsf.FromYAML(inputRdr)
 		if err != nil {
 			log.Fatalf("error unmarshaling input file: %v", err)
 		}
 		// write it to the output file as yaml
-		data, err := y.Marshal(hpsf)
+		data, err := y.Marshal(&h)
 		if err != nil {
 			log.Fatalf("error marshaling output file: %v", err)
 		}
@@ -178,7 +178,7 @@ func main() {
 		os.Exit(0)
 
 	case "rConfig", "rRules", "cConfig":
-		hpsf, err := unmarshalHPSF(inputRdr)
+		hpsf, err := hpsf.FromYAML(inputRdr)
 		if err != nil {
 			log.Fatalf("error unmarshaling input file: %v", err)
 		}
@@ -191,7 +191,7 @@ func main() {
 		case "cConfig":
 			ct = hpsftypes.CollectorConfig
 		}
-		cfg, err := tr.GenerateConfig(hpsf, ct, userdata)
+		cfg, err := tr.GenerateConfig(&hpsf, ct, userdata)
 		if err != nil {
 			log.Fatalf("error translating config: %v", err)
 		}
@@ -228,14 +228,4 @@ func readInput(filename string) ([]byte, error) {
 		return nil, fmt.Errorf("error reading file %s: %w", filename, err)
 	}
 	return data, nil
-}
-
-func unmarshalHPSF(data io.Reader) (*hpsf.HPSF, error) {
-	var h hpsf.HPSF
-	dec := y.NewDecoder(data)
-	err := dec.Decode(&h)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling to yaml: %w", err)
-	}
-	return &h, nil
 }

--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -83,7 +83,6 @@ func main() {
 	subst.SetPriority("installation", 2)
 	subst.SetPriority("cluster", 1)
 	input := subst.DoSubstitutions(string(inputData))
-	inputRdr := strings.NewReader(input)
 
 	// Create the output file
 	var outf io.Writer
@@ -115,7 +114,7 @@ func main() {
 
 	switch cmds[0] {
 	case "format":
-		h, err := hpsf.FromYAML(inputRdr)
+		h, err := hpsf.FromYAML(input)
 		if err != nil {
 			log.Fatalf("error unmarshaling input file: %v", err)
 		}
@@ -178,7 +177,7 @@ func main() {
 		os.Exit(0)
 
 	case "rConfig", "rRules", "cConfig":
-		hpsf, err := hpsf.FromYAML(inputRdr)
+		hpsf, err := hpsf.FromYAML(input)
 		if err != nil {
 			log.Fatalf("error unmarshaling input file: %v", err)
 		}

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -549,15 +549,16 @@ func (c *Container) Validate() error {
 type Layout map[string]any
 
 type HPSF struct {
-	Kind        string        `yaml:"kind"`
-	Version     string        `yaml:"version"`
-	Name        string        `yaml:"name"`
-	Summary     string        `yaml:"summary"`
-	Description string        `yaml:"description"`
-	Components  []*Component  `yaml:"components,omitempty"`
-	Connections []*Connection `yaml:"connections,omitempty"`
-	Containers  []Container   `yaml:"containers,omitempty"`
-	Layout      Layout        `yaml:"layout,omitempty"`
+	Kind           string        `yaml:"kind"`
+	Version        string        `yaml:"version"`
+	Name           string        `yaml:"name"`
+	Summary        string        `yaml:"summary"`
+	Description    string        `yaml:"description"`
+	LibraryVersion string        `yaml:"library_version"`
+	Components     []*Component  `yaml:"components,omitempty"`
+	Connections    []*Connection `yaml:"connections,omitempty"`
+	Containers     []Container   `yaml:"containers,omitempty"`
+	Layout         Layout        `yaml:"layout,omitempty"`
 }
 
 // GetStartComponents generates a list of components that are not named as the destination of a connection
@@ -815,9 +816,7 @@ func EnsureHPSFYAML(input string) error {
 		return errors.New("HPSF yaml contains unexpected keys: " + strings.Join(badkeys, ", "))
 	}
 
-	var h HPSF
-	dec := y.NewDecoder(strings.NewReader(input))
-	err = dec.Decode(&h)
+	h, err := FromYAML(strings.NewReader(input))
 	if err != nil {
 		return err
 	}
@@ -831,4 +830,11 @@ func (h *HPSF) AsYAML() (string, error) {
 		return "", fmt.Errorf("error marshaling hpsf to YAML: %w", err)
 	}
 	return string(data), nil
+}
+
+func FromYAML(in *strings.Reader) (HPSF, error) {
+	var h HPSF
+	dec := y.NewDecoder(in)
+	err := dec.Decode(&h)
+	return h, err
 }

--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -816,7 +816,7 @@ func EnsureHPSFYAML(input string) error {
 		return errors.New("HPSF yaml contains unexpected keys: " + strings.Join(badkeys, ", "))
 	}
 
-	h, err := FromYAML(strings.NewReader(input))
+	h, err := FromYAML(input)
 	if err != nil {
 		return err
 	}
@@ -832,9 +832,9 @@ func (h *HPSF) AsYAML() (string, error) {
 	return string(data), nil
 }
 
-func FromYAML(in *strings.Reader) (HPSF, error) {
+func FromYAML(in string) (HPSF, error) {
 	var h HPSF
-	dec := y.NewDecoder(in)
+	dec := y.NewDecoder(strings.NewReader(in))
 	err := dec.Decode(&h)
 	return h, err
 }

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -99,7 +99,7 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 
 				for _, template := range component.Templates {
 					configType := template.Kind
-					h, err := hpsf.FromYAML(strings.NewReader(inputData))
+					h, err := hpsf.FromYAML(inputData)
 					require.NoError(t, err)
 
 					cfg, err := tlater.GenerateConfig(&h, configType, nil)
@@ -255,7 +255,7 @@ func TestTranslatorValidation(t *testing.T) {
 			require.NoError(t, err)
 			var inputData = string(b)
 
-			h, err := hpsf.FromYAML(strings.NewReader(inputData))
+			h, err := hpsf.FromYAML(inputData)
 			require.NoError(t, err)
 
 			err = tlater.ValidateConfig(&h)
@@ -404,7 +404,7 @@ func TestTranslator_ValidateBadConfigs(t *testing.T) {
 			require.NoError(t, err)
 			var inputData = string(b)
 
-			h, err := hpsf.FromYAML(strings.NewReader(inputData))
+			h, err := hpsf.FromYAML(inputData)
 			require.NoError(t, err)
 
 			trans := NewEmptyTranslator()
@@ -452,7 +452,7 @@ func TestTranslator_ValidateValidConfigs(t *testing.T) {
 			require.NoError(t, err)
 			var inputData = string(b)
 
-			h, err := hpsf.FromYAML(strings.NewReader(inputData))
+			h, err := hpsf.FromYAML(inputData)
 			require.NoError(t, err)
 
 			trans := NewEmptyTranslator()
@@ -552,7 +552,7 @@ layout:
         y: 160
 `
 
-	h, err := hpsf.FromYAML(strings.NewReader(c))
+	h, err := hpsf.FromYAML(c)
 	require.NoError(t, err)
 
 	tlater := NewEmptyTranslator()

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/honeycombio/hpsf/pkg/validator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yamlv3 "gopkg.in/yaml.v3"
 )
 
 func TestThatEachTestFileHasAMatchingComponent(t *testing.T) {
@@ -100,12 +99,10 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 
 				for _, template := range component.Templates {
 					configType := template.Kind
-					var h *hpsf.HPSF
-					dec := yamlv3.NewDecoder(strings.NewReader(inputData))
-					err = dec.Decode(&h)
+					h, err := hpsf.FromYAML(strings.NewReader(inputData))
 					require.NoError(t, err)
 
-					cfg, err := tlater.GenerateConfig(h, configType, nil)
+					cfg, err := tlater.GenerateConfig(&h, configType, nil)
 					require.NoError(t, err)
 					if cfg == nil {
 						continue // skip if no config is generated for this component
@@ -258,12 +255,10 @@ func TestTranslatorValidation(t *testing.T) {
 			require.NoError(t, err)
 			var inputData = string(b)
 
-			var h *hpsf.HPSF
-			dec := yamlv3.NewDecoder(strings.NewReader(inputData))
-			err = dec.Decode(&h)
+			h, err := hpsf.FromYAML(strings.NewReader(inputData))
 			require.NoError(t, err)
 
-			err = tlater.ValidateConfig(h)
+			err = tlater.ValidateConfig(&h)
 			require.NoError(t, errors.Unwrap(err))
 		})
 	}
@@ -409,9 +404,7 @@ func TestTranslator_ValidateBadConfigs(t *testing.T) {
 			require.NoError(t, err)
 			var inputData = string(b)
 
-			var h *hpsf.HPSF
-			dec := yamlv3.NewDecoder(strings.NewReader(inputData))
-			err = dec.Decode(&h)
+			h, err := hpsf.FromYAML(strings.NewReader(inputData))
 			require.NoError(t, err)
 
 			trans := NewEmptyTranslator()
@@ -419,7 +412,7 @@ func TestTranslator_ValidateBadConfigs(t *testing.T) {
 			require.NoError(t, err)
 			trans.InstallComponents(comps)
 
-			err = trans.ValidateConfig(h)
+			err = trans.ValidateConfig(&h)
 			if err == nil {
 				t.Errorf("Translator.ValidateConfig() did not error when it should have")
 			}
@@ -459,9 +452,7 @@ func TestTranslator_ValidateValidConfigs(t *testing.T) {
 			require.NoError(t, err)
 			var inputData = string(b)
 
-			var h *hpsf.HPSF
-			dec := yamlv3.NewDecoder(strings.NewReader(inputData))
-			err = dec.Decode(&h)
+			h, err := hpsf.FromYAML(strings.NewReader(inputData))
 			require.NoError(t, err)
 
 			trans := NewEmptyTranslator()
@@ -469,7 +460,7 @@ func TestTranslator_ValidateValidConfigs(t *testing.T) {
 			require.NoError(t, err)
 			trans.InstallComponents(comps)
 
-			err = trans.ValidateConfig(h)
+			err = trans.ValidateConfig(&h)
 			if err != nil {
 				t.Errorf("Translator.ValidateConfig() should not error for valid config, got: %v", err)
 			}
@@ -561,9 +552,7 @@ layout:
         y: 160
 `
 
-	var h *hpsf.HPSF
-	dec := yamlv3.NewDecoder(strings.NewReader(c))
-	err := dec.Decode(&h)
+	h, err := hpsf.FromYAML(strings.NewReader(c))
 	require.NoError(t, err)
 
 	tlater := NewEmptyTranslator()
@@ -571,7 +560,7 @@ layout:
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	x, err := tlater.GenerateConfig(h, hpsftypes.RefineryRules, nil)
+	x, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, nil)
 	require.NoError(t, err)
 	require.NotNil(t, x)
 }

--- a/tests/providers/hpsf/hpsf_provider.go
+++ b/tests/providers/hpsf/hpsf_provider.go
@@ -1,8 +1,6 @@
 package hpsf
 
 import (
-	"fmt"
-	"io"
 	"log"
 	"os"
 	"strings"
@@ -18,7 +16,6 @@ import (
 	refineryConfig "github.com/honeycombio/refinery/config"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/otelcol"
-	y "gopkg.in/yaml.v3"
 )
 
 type ErrorDetails struct {
@@ -48,7 +45,7 @@ func GetParsedConfigsFromFile(t *testing.T, filename string) (refineryRules *ref
 }
 
 func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryConfig.V2SamplerConfig, collectorConfig *otelcol.Config, groupedErrors ParserError) {
-	hpsf, err := unmarshalHPSF(strings.NewReader(hpsfConfig))
+	h, err := hpsf.FromYAML(strings.NewReader(hpsfConfig))
 	if err != nil {
 		log.Fatalf("error unmarshaling HPSF: %v", err)
 	}
@@ -62,14 +59,14 @@ func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryC
 
 	errors := make(map[hpsftypes.Type]ErrorDetails)
 
-	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(hpsf, hpsftypes.RefineryRules, nil)
+	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.RefineryRules, nil)
 	if err != nil {
 		errors[hpsftypes.RefineryConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {
 		refineryRules = refineryConfigProvider.GetParsedRulesConfig(t, refineryRulesTmpl.(*tmpl.RulesConfig))
 	}
 
-	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(hpsf, hpsftypes.CollectorConfig, nil)
+	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.CollectorConfig, nil)
 	if err != nil {
 		errors[hpsftypes.CollectorConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {
@@ -86,14 +83,4 @@ func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryC
 	groupedErrors.FailIfError(t)
 	return
 
-}
-
-func unmarshalHPSF(data io.Reader) (*hpsf.HPSF, error) {
-	var h hpsf.HPSF
-	dec := y.NewDecoder(data)
-	err := dec.Decode(&h)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling to yaml: %v", err)
-	}
-	return &h, nil
 }

--- a/tests/providers/hpsf/hpsf_provider.go
+++ b/tests/providers/hpsf/hpsf_provider.go
@@ -3,7 +3,6 @@ package hpsf
 import (
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/honeycombio/hpsf/pkg/config/tmpl"
@@ -45,7 +44,7 @@ func GetParsedConfigsFromFile(t *testing.T, filename string) (refineryRules *ref
 }
 
 func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryConfig.V2SamplerConfig, collectorConfig *otelcol.Config, groupedErrors ParserError) {
-	h, err := hpsf.FromYAML(strings.NewReader(hpsfConfig))
+	h, err := hpsf.FromYAML(hpsfConfig)
 	if err != nil {
 		log.Fatalf("error unmarshaling HPSF: %v", err)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- Adding `library_version` field to store the version of the library that was used when generating HPSF. This version will be used later on when using different versions of the library to translate HPSF into various configurations.
- Introduce a `FromYAML` func to use downstream

## Short description of the changes

- add LibraryVersion struct field 
- add FromYAML func and clean up various areas where decoding was done

