### PR TITLE
fix: RootSpanCondition property type

### DIFF
--- a/pkg/data/components/RootSpanCondition.yaml
+++ b/pkg/data/components/RootSpanCondition.yaml
@@ -25,7 +25,7 @@ ports:
     type: SampleData
 properties:
   - name: HasRootSpan
-    type: boolean
+    type: bool
     default: false
     description: |
       When true, checks that the trace has a root span.


### PR DESCRIPTION
## Which problem is this PR solving?

- fix a bug where `RootSpanCondition` had a field property with `boolean` instead of `bool`.

## Short description of the changes

- change field type to `bool`.

