### PR TITLE
feat: add tool to help with bulk-editing components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ CLAUDE.md
 .claude/
 
 # executables
-/cmd/propdump/propdump
+/cmd/component2csv/component2csv
 /cmd/hpsf/hpsf

--- a/Makefile
+++ b/Makefile
@@ -190,21 +190,21 @@ bulk_export_components:
 	@echo
 	@echo "+++ exporting components"
 	@echo
-	go run ./cmd/propdump --export=export.csv pkg/data/components/*.yaml
+	go run ./cmd/component2csv --export=export.csv pkg/data/components/*.yaml
 
 .PHONY: bulk_import_components
 bulk_import_components:
 	@echo
 	@echo "+++ importing components"
 	@echo
-	go run ./cmd/propdump --import=export.csv pkg/data/components/*.yaml
+	go run ./cmd/component2csv --import=export.csv pkg/data/components/*.yaml
 
 .PHONY: rewrite_components
 rewrite_components:
 	@echo
 	@echo "+++ rewriting components"
 	@echo
-	go run ./cmd/propdump --export=rewrite.csv pkg/data/components/*.yaml
-	go run ./cmd/propdump --import=rewrite.csv pkg/data/components/*.yaml
+	go run ./cmd/component2csv --export=rewrite.csv pkg/data/components/*.yaml
+	go run ./cmd/component2csv --import=rewrite.csv pkg/data/components/*.yaml
 	rm -f rewrite.csv
 

--- a/cmd/component2csv/main.go
+++ b/cmd/component2csv/main.go
@@ -50,9 +50,9 @@ If no fields are specified, defaults to: name, style, status, version, summary, 
 If no files are specified, processes all *.yaml files in the current directory.
 
 Examples:
-  propdump --export components.csv --style condition
-  propdump --import components.csv
-  propdump --export - --field name --field status | head -10`
+  component2csv --export components.csv --style condition
+  component2csv --import components.csv
+  component2csv --export - --field name --field status | head -10`
 
 	args, err := parser.Parse()
 	if err != nil {


### PR DESCRIPTION
## Which problem is this PR solving?

- When working on component files, it's useful sometimes to look at them together so that they have the same general format and conventions. This implements a tool that exports a subset of component data to a CSV file so that it can be edited in a spreadsheet, and then applies that CSV file back to the components.

Multiline strings are unwrapped to a single cell in the CSV, and rewrapped to 100 characters on output if needed. You don't need to worry about wordwrapping when editing the CSV.

The tags array (and any other string array we may use) is unwrapped to a single string that looks like `[]key1:value,key2:value`, and rewrapped on output.

The tool works pretty hard to keep the input file as intact as possible. The only reformatting it does is to normalize the way single and multiline text fields are treated. Otherwise, fields are written in the same order as the input file, and the indentation should be the same. 

Once this is merged, there will be a separate PR to rewrite all the files with whatever minor changes are needed for consistent formatting. That's what one of the makefile targets does. 

## Short description of the changes

- Create component2csv tool
- Add makefile targets for it
- Prevent git from tracking executables

## Help text from the tool

```txt
Usage:
  component2csv [OPTIONS]

This tool allows you to extract key fields from component YAML files to a CSV file for editing in a spreadsheet, then apply changes back to the YAML files.

The tool performs two main operations:
• Export: Extract component fields to CSV (one row per component)
• Import: Read CSV and modify components based on values

Multi-line fields are unwrapped (newlines replaced with spaces) when exported to CSV.
On import, text longer than 100 characters is word-wrapped before being written to YAML.
The tags array is unwrapped to a single string that looks like '[]key1:value,key2:value',
and rewrapped on output.

The 'style' field can be used to filter components by their style (e.g., 'sampler', 'processor').
When importing, only components that match the kind specified in the CSV will be modified.

The 'kind' field is always included as the first column for matching components.
If no fields are specified, defaults to: name, style, status, version, summary, description.
If no files are specified, processes all *.yaml files in the current directory.

Examples:
component2csv --export components.csv --style condition
component2csv --import components.csv
component2csv --export - --field name --field status | head -10

Application Options:
  -e, --export= Export components to CSV file (use - for stdout)
  -i, --import= Import CSV file and apply changes to components (use - for stdin)
  -s, --style=  Component style to include (can be repeated)
  -f, --field=  Top-level field to include (can be repeated)

Help Options:
  -h, --help    Show this help message
```

