### PR TITLE
chore: remove unnecessary call to func

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -128,12 +128,6 @@ func main() {
 			log.Fatalf("error writing output file: %v", err)
 		}
 	case "validate":
-		// validate the input file
-		_, err := validator.EnsureYAML(inputData)
-		if err != nil {
-			log.Fatalf("error validating input file: %v", err)
-		}
-
 		err = hpsf.EnsureHPSFYAML(string(inputData))
 		if err != nil {
 			log.Fatalf("input file is not hpsf: %v", err)


### PR DESCRIPTION
EnsureHPSFYAML already calls EnsureYAML. no need for a separate call.
