### PR TITLE
refactor: remove EnsureYAML public func

### DIFF
--- a/pkg/hpsf/hpsfTypes.go
+++ b/pkg/hpsf/hpsfTypes.go
@@ -792,9 +792,22 @@ func getValidKeys(p any) []string {
 	return keys
 }
 
+// unmarshalYAML is a brain-dead validator that just tries to unmarshal the input into a map
+// to validate the input is parseable YAML
+func unmarshalYAML(input []byte) (map[string]any, error) {
+	// try unmarshaling into map
+	var h map[string]any
+	err := y.Unmarshal(input, &h)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
 // EnsureHPSFYAML returns an error if the input is not HPSF yaml or invalid HPSF
 func EnsureHPSFYAML(input string) error {
-	m, err := validator.EnsureYAML([]byte(input))
+	m, err := unmarshalYAML([]byte(input))
 	if err != nil {
 		return err
 	}

--- a/pkg/hpsf/hpsfTypes_test.go
+++ b/pkg/hpsf/hpsfTypes_test.go
@@ -67,7 +67,7 @@ connections:
       port: Traces
       type: OTelTraces`)
 
-	_, err := validator.EnsureYAML(inputData)
+	_, err := unmarshalYAML(inputData)
 	require.NoError(t, err)
 
 	var h HPSF
@@ -108,7 +108,7 @@ connections:
       port: Traces
       type: OTelTraces`)
 
-	_, err := validator.EnsureYAML(inputData)
+	_, err := unmarshalYAML(inputData)
 	require.NoError(t, err)
 
 	var h HPSF

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -397,8 +397,7 @@ func (t *Translator) ValidateConfig(h *hpsf.HPSF) error {
 	}
 
 	// if we don't pass basic validation, we can't continue
-	err := h.Validate()
-	if err != nil {
+	if err := h.Validate(); err != nil {
 		return err
 	}
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -2,8 +2,6 @@ package validator
 
 import (
 	"errors"
-
-	y "gopkg.in/yaml.v3"
 )
 
 // Result is the value returned by the Validate method; it conforms to the error interface
@@ -83,18 +81,4 @@ func (e Result) ErrOrNil() error {
 // errors.
 type Validator interface {
 	Validate() error
-}
-
-// EnsureYAML is a brain-dead validator that just tries to unmarshal the input into appropriate forms
-func EnsureYAML(input []byte) (map[string]any, error) {
-	// validate the input is parseable YAML (parses into a map)
-
-	// try unmarshaling into map
-	var h map[string]any
-	err := y.Unmarshal(input, &h)
-	if err != nil {
-		return nil, err
-	}
-
-	return h, nil
 }


### PR DESCRIPTION
This function is only ever used internally within the hpsf package, no need for a public function.
