### PR TITLE
feat: Reorganize category tags for updated UI.

### DIFF
--- a/pkg/data/components/AttributeJSONParsingProcessor.yaml
+++ b/pkg/data/components/AttributeJSONParsingProcessor.yaml
@@ -9,7 +9,6 @@ description: Takes any attribute from a log or span and parses it as JSON into i
 tags:
   - category:processor
   - service:collector
-  - category:filter
   - signal:OTelTraces
   - signal:OTelLogs
 ports:

--- a/pkg/data/components/CompareDecimalFieldCondition.yaml
+++ b/pkg/data/components/CompareDecimalFieldCondition.yaml
@@ -9,7 +9,7 @@ description: |-
   This checks if any span in a trace has a specific numeric field that compares appropriately to the
   specified value.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/CompareIntegerFieldCondition.yaml
+++ b/pkg/data/components/CompareIntegerFieldCondition.yaml
@@ -9,7 +9,7 @@ description: |-
   This checks if any span in a trace has a specific integer field that compares appropriately to the
   specified value.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/CompareStringFieldCondition.yaml
+++ b/pkg/data/components/CompareStringFieldCondition.yaml
@@ -9,7 +9,7 @@ description: |-
   This checks if any span in a trace has a specific string field that compares appropriately to the
   specified value.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/CustomFilterProcessor.yaml
+++ b/pkg/data/components/CustomFilterProcessor.yaml
@@ -9,7 +9,6 @@ description: Filters traces, metrics, and logs based on rules defined in the con
 tags:
   - category:processor
   - service:collector
-  - category:filter
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs

--- a/pkg/data/components/DebugExporter.yaml
+++ b/pkg/data/components/DebugExporter.yaml
@@ -10,8 +10,7 @@ description: |-
   Exports signal data from a pipeline to stdout. This is useful for debugging, but only if you have
   access to the stdout stream in your environment. This component is not intended for production use.
 tags:
-  - category:exporter
-  - category:debug
+  - category:output
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Deterministically samples a fixed fraction of traces based on trace ID.
 description: A sampler that deterministically samples a fixed fraction of traces based on trace ID.
 tags:
-  - category:sampling
+  - category:sampler
   - service:refinery
   - signal:HoneycombEvents
   - sampler:deterministic

--- a/pkg/data/components/Dropper.yaml
+++ b/pkg/data/components/Dropper.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Drops all traces
 description: This sampler drops all traces.
 tags:
-  - category:refinery_sampler
+  - category:sampler
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/EMADynamicSampler.yaml
+++ b/pkg/data/components/EMADynamicSampler.yaml
@@ -10,7 +10,7 @@ description: |-
   on trying to achieve representative quantities of the specified sampling keys. The keys should be
   chosen from fields with relatively low cardinality, such as HTTP method, status code, etc.
 tags:
-  - category:sampling
+  - category:sampler
   - service:refinery
   - signal:HoneycombEvents
   - sampler:ema

--- a/pkg/data/components/EMAThroughputSampler.yaml
+++ b/pkg/data/components/EMAThroughputSampler.yaml
@@ -13,7 +13,7 @@ description: |-
   keys. The keys should be chosen from fields with relatively low cardinality, such as HTTP method,
   status code, etc.
 tags:
-  - category:sampling
+  - category:sampler
   - service:refinery
   - signal:HoneycombEvents
   - sampler:ema

--- a/pkg/data/components/ErrorExistsCondition.yaml
+++ b/pkg/data/components/ErrorExistsCondition.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Checks if an error exists in any span of a trace
 description: This checks if any span in a trace has an error.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/FieldContainsCondition.yaml
+++ b/pkg/data/components/FieldContainsCondition.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Checks if a field contains a specific substring
 description: This checks if any span in a trace has a specific field that contains a given substring.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/FieldExistsCondition.yaml
+++ b/pkg/data/components/FieldExistsCondition.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Checks if a field exists or does not exist in a trace
 description: This checks if any span in a trace has a specific field that exists or does not exist.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:field

--- a/pkg/data/components/FieldStartsWithCondition.yaml
+++ b/pkg/data/components/FieldStartsWithCondition.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Checks if a field starts with a specific prefix
 description: This checks if any span in a trace has a specific field that starts with a given prefix.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/ForceSpanScope.yaml
+++ b/pkg/data/components/ForceSpanScope.yaml
@@ -12,7 +12,7 @@ description: |-
   "span" rather than "trace", so that the rule will only match when all conditions are true for the
   same span.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -10,7 +10,7 @@ description: |-
   This component sends traces, logs, metrics, and Honeycomb-formatted events to the Honeycomb's data
   store for real-time analysis.
 tags:
-  - category:exporter
+  - category:output
   - service:refinery
   - signal:HoneycombEvents
   - vendor:Honeycomb

--- a/pkg/data/components/KeepAllSampler.yaml
+++ b/pkg/data/components/KeepAllSampler.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Keeps all traces that reach this sampler.
 description: This sampler keeps (samples) all traces, setting SampleRate to 1.
 tags:
-  - category:refinery_sampler
+  - category:sampler
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/LogBodyJSONParsingProcessor.yaml
+++ b/pkg/data/components/LogBodyJSONParsingProcessor.yaml
@@ -11,7 +11,6 @@ description: |-
 tags:
   - category:processor
   - service:collector
-  - category:filter
   - signal:OTelLogs
 ports:
   # inputs

--- a/pkg/data/components/LogSeverityFilterProcessor.yaml
+++ b/pkg/data/components/LogSeverityFilterProcessor.yaml
@@ -9,7 +9,6 @@ description: Filters logs using the `severity_number` attribute supplied on the 
 tags:
   - category:processor
   - service:collector
-  - category:filter
   - signal:OTelLogs
 ports:
   # inputs

--- a/pkg/data/components/LongDurationCondition.yaml
+++ b/pkg/data/components/LongDurationCondition.yaml
@@ -9,7 +9,7 @@ description: |-
   This checks the duration of the root span in a trace. If the root span exceeds the specified
   duration, the trace will be sampled at the specified rate (default 1).
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:error

--- a/pkg/data/components/MatchRegularExpression.yaml
+++ b/pkg/data/components/MatchRegularExpression.yaml
@@ -7,7 +7,7 @@ version: v0.1.0
 summary: Checks if a field matches a regular expression
 description: This checks if any span in a trace has a specific field that matches a given regular expression.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:regex

--- a/pkg/data/components/NopExporter.yaml
+++ b/pkg/data/components/NopExporter.yaml
@@ -8,9 +8,7 @@ status: development
 summary: An "exporter" that does nothing, but might be useful for testing.
 description: A simple no-op exporter. This exporter does nothing. It is required for the minimal collector.
 tags:
-  - category:exporter
-  - category:nop
-  - category:debug
+  - category:output
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -8,9 +8,7 @@ status: development
 summary: A no-op "receiver" that does nothing, but might be useful for testing.
 description: A simple no-op receiver. This receiver does nothing. It is required for the minimal configuration.
 tags:
-  - category:receiver
-  - category:nop
-  - category:debug
+  - category:input
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -8,7 +8,7 @@ version: v0.1.0
 summary: Sends telemetry in OpenTelemetry (OTLP) format via gRPC.
 description: Exports OpenTelemetry signals using OTLP via gRPC.
 tags:
-  - category:exporter
+  - category:output
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -8,7 +8,7 @@ version: v0.1.0
 summary: Sends telemetry in OpenTelemetry (OTLP) format via HTTP.
 description: Exports OpenTelemetry signals using OTLP via HTTP.
 tags:
-  - category:exporter
+  - category:output
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -10,7 +10,7 @@ description: |-
   Imports OTLP signals from OpenTelemetry via gRPC or HTTP. This receiver can be configured to listen
   on both gRPC and HTTP, or just one.
 tags:
-  - category:receiver
+  - category:input
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/RedactionProcessor.yaml
+++ b/pkg/data/components/RedactionProcessor.yaml
@@ -11,7 +11,6 @@ description: |-
 tags:
   - category:processor
   - service:collector
-  - category:filter
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs

--- a/pkg/data/components/RootSpanCondition.yaml
+++ b/pkg/data/components/RootSpanCondition.yaml
@@ -10,7 +10,7 @@ description: |-
   typically used to ensure that the trace has been fully received before being sent for a sampling
   decision.
 tags:
-  - category:refinery_rule_condition
+  - category:condition
   - service:refinery
   - vendor:Honeycomb
   - type:root_span

--- a/pkg/data/components/S3ArchiveExporter.yaml
+++ b/pkg/data/components/S3ArchiveExporter.yaml
@@ -8,7 +8,7 @@ version: v0.1.0
 summary: Sends the telemetry to AWS S3
 description: Sends the telemetry S3 for long-term storage to the location you choose.
 tags:
-  - category:exporter
+  - category:output
   - service:collector
   - signal:OTelTraces
   - signal:OTelMetrics

--- a/pkg/data/components/SamplingSequencer.yaml
+++ b/pkg/data/components/SamplingSequencer.yaml
@@ -10,7 +10,7 @@ description: |-
   some advanced configuration options for sending data to Refinery; most installations will not need
   to change these.
 tags:
-  - category:converter
+  - category:startsampling
   - service:refinery
   - signal:OTelTraces
   - signal:OTelLogs


### PR DESCRIPTION
## Which problem is this PR solving?

- The revised UI needs category tags to drive the organization of the sidebar. This sets those up.

## Short description of the changes

- Rename category tags, leave only one category per component.

Once this merges, we'll release a new HPSF.

