### PR TITLE
feat: add input/output tags

### DIFF
--- a/pkg/data/components/AttributeJSONParsingProcessor.yaml
+++ b/pkg/data/components/AttributeJSONParsingProcessor.yaml
@@ -11,6 +11,10 @@ tags:
   - service:collector
   - signal:OTelTraces
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - output:Traces
+  - output:Logs
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/CompareDecimalFieldCondition.yaml
+++ b/pkg/data/components/CompareDecimalFieldCondition.yaml
@@ -13,6 +13,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/CompareIntegerFieldCondition.yaml
+++ b/pkg/data/components/CompareIntegerFieldCondition.yaml
@@ -13,6 +13,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/CompareStringFieldCondition.yaml
+++ b/pkg/data/components/CompareStringFieldCondition.yaml
@@ -13,6 +13,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/CustomFilterProcessor.yaml
+++ b/pkg/data/components/CustomFilterProcessor.yaml
@@ -12,6 +12,12 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
+  - output:Traces
+  - output:Logs
+  - output:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/DebugExporter.yaml
+++ b/pkg/data/components/DebugExporter.yaml
@@ -15,6 +15,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/DeterministicSampler.yaml
+++ b/pkg/data/components/DeterministicSampler.yaml
@@ -12,6 +12,8 @@ tags:
   - signal:HoneycombEvents
   - sampler:deterministic
   - sampler:rate
+  - input:SampleData
+  - output:Events
 ports:
   # inputs
   - name: Sample

--- a/pkg/data/components/Dropper.yaml
+++ b/pkg/data/components/Dropper.yaml
@@ -11,6 +11,7 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
 ports:
   # inputs
   - name: Sample

--- a/pkg/data/components/EMADynamicSampler.yaml
+++ b/pkg/data/components/EMADynamicSampler.yaml
@@ -15,6 +15,8 @@ tags:
   - signal:HoneycombEvents
   - sampler:ema
   - sampler:dynamic
+  - input:SampleData
+  - output:Events
 ports:
   # inputs
   - name: Sample

--- a/pkg/data/components/EMAThroughputSampler.yaml
+++ b/pkg/data/components/EMAThroughputSampler.yaml
@@ -18,6 +18,8 @@ tags:
   - signal:HoneycombEvents
   - sampler:ema
   - sampler:throughput
+  - input:SampleData
+  - output:Events
 ports:
   # inputs
   - name: Sample

--- a/pkg/data/components/ErrorExistsCondition.yaml
+++ b/pkg/data/components/ErrorExistsCondition.yaml
@@ -11,6 +11,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/FieldContainsCondition.yaml
+++ b/pkg/data/components/FieldContainsCondition.yaml
@@ -11,6 +11,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/FieldExistsCondition.yaml
+++ b/pkg/data/components/FieldExistsCondition.yaml
@@ -11,6 +11,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:field
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/FieldStartsWithCondition.yaml
+++ b/pkg/data/components/FieldStartsWithCondition.yaml
@@ -11,6 +11,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/ForceSpanScope.yaml
+++ b/pkg/data/components/ForceSpanScope.yaml
@@ -16,6 +16,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/HTTPStatusCondition.yaml
+++ b/pkg/data/components/HTTPStatusCondition.yaml
@@ -15,6 +15,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/HoneycombExporter.yaml
+++ b/pkg/data/components/HoneycombExporter.yaml
@@ -14,6 +14,10 @@ tags:
   - service:refinery
   - signal:HoneycombEvents
   - vendor:Honeycomb
+  - input:Events
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Events

--- a/pkg/data/components/KeepAllSampler.yaml
+++ b/pkg/data/components/KeepAllSampler.yaml
@@ -11,6 +11,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:Events
 ports:
   # inputs
   - name: Sample

--- a/pkg/data/components/LogBodyJSONParsingProcessor.yaml
+++ b/pkg/data/components/LogBodyJSONParsingProcessor.yaml
@@ -12,6 +12,8 @@ tags:
   - category:processor
   - service:collector
   - signal:OTelLogs
+  - input:Logs
+  - output:Logs
 ports:
   # inputs
   - name: Logs

--- a/pkg/data/components/LogDeduplicationProcessor.yaml
+++ b/pkg/data/components/LogDeduplicationProcessor.yaml
@@ -12,6 +12,8 @@ tags:
   - category:processor
   - service:collector
   - signal:OTelLogs
+  - input:Logs
+  - output:Logs
 ports:
   # inputs
   - name: Logs

--- a/pkg/data/components/LogSeverityFilterProcessor.yaml
+++ b/pkg/data/components/LogSeverityFilterProcessor.yaml
@@ -10,6 +10,8 @@ tags:
   - category:processor
   - service:collector
   - signal:OTelLogs
+  - input:Logs
+  - output:Logs
 ports:
   # inputs
   - name: Logs

--- a/pkg/data/components/LongDurationCondition.yaml
+++ b/pkg/data/components/LongDurationCondition.yaml
@@ -13,6 +13,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:error
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/MatchRegularExpression.yaml
+++ b/pkg/data/components/MatchRegularExpression.yaml
@@ -12,6 +12,8 @@ tags:
   - vendor:Honeycomb
   - type:regex
   - type:string
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/NopExporter.yaml
+++ b/pkg/data/components/NopExporter.yaml
@@ -13,6 +13,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/NopReceiver.yaml
+++ b/pkg/data/components/NopReceiver.yaml
@@ -13,6 +13,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/OTelGRPCExporter.yaml
+++ b/pkg/data/components/OTelGRPCExporter.yaml
@@ -13,6 +13,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/OTelHTTPExporter.yaml
+++ b/pkg/data/components/OTelHTTPExporter.yaml
@@ -13,6 +13,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/OTelReceiver.yaml
+++ b/pkg/data/components/OTelReceiver.yaml
@@ -15,6 +15,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - output:Traces
+  - output:Logs
+  - output:Metrics
 ports:
   # outputs
   - name: Traces

--- a/pkg/data/components/RedactionProcessor.yaml
+++ b/pkg/data/components/RedactionProcessor.yaml
@@ -14,6 +14,12 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
+  - output:Traces
+  - output:Logs
+  - output:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/RootSpanCondition.yaml
+++ b/pkg/data/components/RootSpanCondition.yaml
@@ -14,6 +14,8 @@ tags:
   - service:refinery
   - vendor:Honeycomb
   - type:root_span
+  - input:SampleData
+  - output:SampleData
 ports:
   # inputs
   - name: Match

--- a/pkg/data/components/S3ArchiveExporter.yaml
+++ b/pkg/data/components/S3ArchiveExporter.yaml
@@ -13,6 +13,9 @@ tags:
   - signal:OTelTraces
   - signal:OTelMetrics
   - signal:OTelLogs
+  - input:Traces
+  - input:Logs
+  - input:Metrics
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/SamplingSequencer.yaml
+++ b/pkg/data/components/SamplingSequencer.yaml
@@ -16,6 +16,9 @@ tags:
   - signal:OTelLogs
   - signal:HoneycombEvents
   - vendor:Honeycomb
+  - input:Traces
+  - input:Logs
+  - output:SampleData
 ports:
   # inputs
   - name: Traces

--- a/pkg/data/components/SymbolicatorProcessor.yaml
+++ b/pkg/data/components/SymbolicatorProcessor.yaml
@@ -10,6 +10,8 @@ tags:
   - category:processor
   - service:collector
   - signal:OtelTraces
+  - input:Traces
+  - output:Traces
 ports:
   # inputs
   - name: Traces


### PR DESCRIPTION

## Which problem is this PR solving?

- The frontend expects input and output tags to be set on individual components. This somehow got lost in PR management.

## Short description of the changes

- Add input/output tags based on ports.

