### PR TITLE
feat: support versions not prefixed with 'v'

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -184,7 +184,7 @@ func main() {
 		case "cConfig":
 			ct = hpsftypes.CollectorConfig
 		}
-		cfg, err := tr.GenerateConfig(&hpsf, ct, "latest", userdata)
+		cfg, err := tr.GenerateConfig(&hpsf, ct, translator.LatestVersion, userdata)
 		if err != nil {
 			log.Fatalf("error translating config: %v", err)
 		}

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const LatestVersion = "latest"
+
 // A Translator is responsible for translating an HPSF document into a
 // collection of components, and then further rendering those into configuration
 // files.
@@ -75,8 +77,14 @@ func (t *Translator) LoadEmbeddedComponents() error {
 
 // artifactVersionSupported checks if the component supports the artifact version requested
 func artifactVersionSupported(component config.TemplateComponent, v string) bool {
-	if v == "" || v == "latest" {
+	if v == "" || v == LatestVersion {
 		return true
+	}
+
+	// ensure the version string is prefixed with v otherwise semver.Compare fails
+	// to parse the version
+	if v[0] != 'v' {
+		v = "v" + v
 	}
 
 	if component.Minimum != "" && semver.Compare(v, component.Minimum) < 0 {

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -105,7 +105,7 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 					h, err := hpsf.FromYAML(inputData)
 					require.NoError(t, err)
 
-					cfg, err := tlater.GenerateConfig(&h, configType, "latest", nil)
+					cfg, err := tlater.GenerateConfig(&h, configType, LatestVersion, nil)
 					require.NoError(t, err)
 					if cfg == nil {
 						continue // skip if no config is generated for this component
@@ -189,7 +189,7 @@ func TestDefaultHPSF(t *testing.T) {
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, tC.ct, "latest", nil)
+			cfg, err := tlater.GenerateConfig(&h, tC.ct, LatestVersion, nil)
 			require.NoError(t, err)
 
 			got, err := cfg.RenderYAML()
@@ -222,7 +222,7 @@ func TestHPSFWithoutSamplerComponentGeneratesValidRefineryRules(t *testing.T) {
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	cfg, err := tlater.GenerateConfig(&hpsf, hpsftypes.RefineryRules, "latest", nil)
+	cfg, err := tlater.GenerateConfig(&hpsf, hpsftypes.RefineryRules, LatestVersion, nil)
 	require.NoError(t, err)
 
 	got, err := cfg.RenderYAML()
@@ -563,7 +563,7 @@ layout:
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	x, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, "latest", nil)
+	x, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
 	require.NoError(t, err)
 	require.NotNil(t, x)
 }
@@ -738,7 +738,7 @@ connections:
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, "latest", nil)
+			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 		})
@@ -838,7 +838,7 @@ connections:
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, "latest", nil)
+			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 
@@ -1138,7 +1138,7 @@ connections:
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, "latest", nil)
+			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 
@@ -1197,7 +1197,7 @@ func TestArtifactVersionSupported(t *testing.T) {
 		{
 			name:            "latest artifact version",
 			wantSupported:   true,
-			artifactVersion: "latest",
+			artifactVersion: LatestVersion,
 			component: config.TemplateComponent{
 				Minimum: "v0.100.0",
 				Maximum: "v0.200.0",

--- a/tests/providers/hpsf/hpsf_provider.go
+++ b/tests/providers/hpsf/hpsf_provider.go
@@ -58,14 +58,14 @@ func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryC
 
 	errors := make(map[hpsftypes.Type]ErrorDetails)
 
-	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.RefineryRules, "latest", nil)
+	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.RefineryRules, translator.LatestVersion, nil)
 	if err != nil {
 		errors[hpsftypes.RefineryConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {
 		refineryRules = refineryConfigProvider.GetParsedRulesConfig(t, refineryRulesTmpl.(*tmpl.RulesConfig))
 	}
 
-	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.CollectorConfig, "latest", nil)
+	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.CollectorConfig, translator.LatestVersion, nil)
 	if err != nil {
 		errors[hpsftypes.CollectorConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {


### PR DESCRIPTION
This change ensures that version parsing supports versions that are not prefixed with a 'v'.
