### PR TITLE
feat: Add missing advanced properties to EMA dynamic sampler

### DIFF
--- a/pkg/data/components/EMADynamicSampler.yaml
+++ b/pkg/data/components/EMADynamicSampler.yaml
@@ -67,6 +67,69 @@ properties:
       - noblanks
       - nonempty
     default: []
+  - name: MaxKeys
+    summary: The maximum number of distinct keys the sampler tracks
+    description: |
+      The maximum number of distinct keys the sampler tracks. This is used to limit
+      the number of keys that are retained in the sampler's state that is used to
+      compute the sampling rate.
+      The default value is 500.
+    type: int
+    validations:
+      - positive
+    default: 500
+    advanced: true
+  - name: Weight
+    summary: The weight to apply to the sampling rate adjustment
+    description: |
+      The weight to apply to the sampling rate adjustment. This controls how
+      aggressively the sampler adjusts the sampling rate in response to
+      changes in traffic patterns. A higher weight will result in more
+      aggressive adjustments, while a lower weight will result in more
+      conservative adjustments.
+      The default value is 0.5.
+    type: float
+    validations:
+      - inrange(0.0, 1.0)
+    default: 0.5
+    advanced: true
+  - name: AgeOutValue
+    summary: The value to use for aging out old keys
+    description: |
+      The value to use for aging out old keys. This controls how aggressively
+      the sampler will remove old keys from its state. A higher value will
+      result in more aggressive aging out, while a lower value will result in
+      more conservative aging out.
+      The default value is 0.5.
+    type: float
+    validations:
+      - inrange(0.0, 1.0)
+    default: 0.5
+    advanced: true
+  - name: BurstMultiple
+    summary: The burst multiple to use for sampling
+    description: |
+      The burst multiple to use for sampling. This controls how much the
+      sampler is allowed to "burst" above the target sample rate in order
+      to capture short-lived spikes in traffic. A higher burst multiple
+      will allow for more aggressive bursting, while a lower burst multiple
+      will result in more conservative bursting.
+      The default value is 1.0.
+    type: float
+    validations:
+      - positive
+    default: 2.0
+    advanced: true
+  - name: BurstDetectionDelay
+    summary: the number of `AdjustmentIntervals` to wait before detecting bursts.
+    description: |
+      Indicates the number of intervals to run before burst detection kicks in.
+      Defaults value is `3`.
+    type: int
+    validations:
+      - positive
+    default: 3
+    advanced: true
 templates:
   - kind: refinery_rules
     name: EMA_Dynamic_Rules
@@ -81,3 +144,14 @@ templates:
         value: "{{ .Values.AdjustmentInterval }}s"
       - key: FieldList
         value: "{{ .Values.FieldList | encodeAsArray }}"
+      - key: MaxKeys
+        value: "{{ .Values.MaxKeys | encodeAsInt }}"
+      - key: Weight
+        value: "{{ .Values.Weight | encodeAsFloat }}"
+      - key: AgeOutValue
+        value: "{{ .Values.AgeOutValue | encodeAsFloat }}"
+      - key: BurstMultiple
+        value: "{{ .Values.BurstMultiple | encodeAsFloat }}"
+        suppress_if: "{{ eq .Values.BurstMultiple 0.0 }}"
+      - key: BurstDetectionDelay
+        value: "{{ .Values.BurstDetectionDelay | encodeAsInt }}"

--- a/pkg/data/components/EMADynamicSampler.yaml
+++ b/pkg/data/components/EMADynamicSampler.yaml
@@ -140,18 +140,24 @@ templates:
     data:
       - key: GoalSampleRate
         value: "{{ .Values.GoalSampleRate | encodeAsInt }}"
-      - key: AdjustmentInterval
-        value: "{{ .Values.AdjustmentInterval }}s"
       - key: FieldList
         value: "{{ .Values.FieldList | encodeAsArray }}"
+      # properties are suppressed if defaults are used
+      - key: AdjustmentInterval
+        value: "{{ .Values.AdjustmentInterval }}s"
+        suppress_if: "{{ eq .Values.AdjustmentInterval 60 }}"
       - key: MaxKeys
         value: "{{ .Values.MaxKeys | encodeAsInt }}"
+        suppress_if: "{{ eq .Values.MaxKeys 500 }}"
       - key: Weight
         value: "{{ .Values.Weight | encodeAsFloat }}"
+        suppress_if: "{{ eq .Values.Weight 0.5 }}"
       - key: AgeOutValue
         value: "{{ .Values.AgeOutValue | encodeAsFloat }}"
+        suppress_if: "{{ eq .Values.AgeOutValue 0.5 }}"
       - key: BurstMultiple
         value: "{{ .Values.BurstMultiple | encodeAsFloat }}"
-        suppress_if: "{{ eq .Values.BurstMultiple 0.0 }}"
+        suppress_if: "{{ or (eq .Values.BurstMultiple 0.0) (eq .Values.BurstMultiple 2.0) }}"
       - key: BurstDetectionDelay
         value: "{{ .Values.BurstDetectionDelay | encodeAsInt }}"
+        suppress_if: "{{ eq .Values.BurstDetectionDelay 3 }}"

--- a/pkg/translator/testdata/hpsf/emadynamicsampler_all.yaml
+++ b/pkg/translator/testdata/hpsf/emadynamicsampler_all.yaml
@@ -12,6 +12,16 @@ components:
         value: 99
       - name: FieldList
         value: [http.status_code]
+      - name: MaxKeys
+        value: 1000
+      - name: Weight
+        value: 0.1
+      - name: AgeOutValue
+        value: 0.2
+      - name: BurstMultiple
+        value: 2.5
+      - name: BurstDetectionDelay
+        value: 5
   - name: Send to Honeycomb_1
     kind: HoneycombExporter
 connections:

--- a/pkg/translator/testdata/refinery_rules/emadynamicsampler_all.yaml
+++ b/pkg/translator/testdata/refinery_rules/emadynamicsampler_all.yaml
@@ -4,5 +4,10 @@ Samplers:
         EMADynamicSampler:
             GoalSampleRate: 120
             AdjustmentInterval: 1m39s
+            Weight: 0.1
+            AgeOutValue: 0.2
+            BurstMultiple: 2.5
+            BurstDetectionDelay: 5
             FieldList:
                 - http.status_code
+            MaxKeys: 1000

--- a/pkg/translator/testdata/refinery_rules/emadynamicsampler_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/emadynamicsampler_defaults.yaml
@@ -4,6 +4,11 @@ Samplers:
         EMADynamicSampler:
             GoalSampleRate: 100
             AdjustmentInterval: 1m0s
+            Weight: 0.5
+            AgeOutValue: 0.5
+            BurstMultiple: 2
+            BurstDetectionDelay: 3
             FieldList:
                 - http.method
                 - http.status_code
+            MaxKeys: 500

--- a/pkg/translator/testdata/refinery_rules/emadynamicsampler_defaults.yaml
+++ b/pkg/translator/testdata/refinery_rules/emadynamicsampler_defaults.yaml
@@ -3,12 +3,6 @@ Samplers:
     __default__:
         EMADynamicSampler:
             GoalSampleRate: 100
-            AdjustmentInterval: 1m0s
-            Weight: 0.5
-            AgeOutValue: 0.5
-            BurstMultiple: 2
-            BurstDetectionDelay: 3
             FieldList:
                 - http.method
                 - http.status_code
-            MaxKeys: 500


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the EMA dynamic sampler to add missing properties that are useful.

Builder view:

<img width="363" height="774" alt="image" src="https://github.com/user-attachments/assets/e74ea0ad-ca38-4a58-9c1b-511dd939648c" />

Generated config:

```yaml
RulesVersion: 2
Samplers:
    __default__:
        EMADynamicSampler:
            GoalSampleRate: 100
            AdjustmentInterval: 1m0s
            Weight: 0.5
            AgeOutValue: 0.5
            BurstMultiple: 2
            BurstDetectionDelay: 3
            FieldList:
                - http.status_code
            MaxKeys: 500
```

## Short description of the changes

- Add new properties to the sampler
- Update tests to verify expected behaviour