### PR TITLE
feat: Add TransformProcessor component

### DIFF
--- a/pkg/data/components/TransformProcessor.yaml
+++ b/pkg/data/components/TransformProcessor.yaml
@@ -1,0 +1,116 @@
+kind: TransformProcessor
+name: Transform Processor
+style: processor
+type: base
+status: alpha
+version: v0.1.0
+summary: Apply custom transform statements to traces, metrics, and logs
+description: |
+  A flexible processor that allows you to apply custom OpenTelemetry transform statements 
+  to traces, metrics, and logs. You can provide arrays of trace statements, metric statements, 
+  and log statements to perform complex data transformations, filtering, and enrichment operations.
+tags:
+  - category:processor
+  - service:collector
+  - signal:OTelTraces
+  - signal:OTelMetrics
+  - signal:OTelLogs
+  - input:Traces
+  - input:Metrics
+  - input:Logs
+  - output:Traces
+  - output:Metrics
+  - output:Logs
+ports:
+  # inputs
+  - name: Traces
+    direction: input
+    type: OTelTraces
+  - name: Metrics
+    direction: input
+    type: OTelMetrics
+  - name: Logs
+    direction: input
+    type: OTelLogs
+  # outputs
+  - name: Traces
+    direction: output
+    type: OTelTraces
+  - name: Metrics
+    direction: output
+    type: OTelMetrics
+  - name: Logs
+    direction: output
+    type: OTelLogs
+properties:
+  - name: ErrorMode
+    type: string
+    subtype: oneof(ignore, silent, propagate)
+    default: ignore
+    summary: How to handle errors during transformation
+    description: |
+      Controls how the processor handles errors during transformation:
+      - ignore: Log errors but continue processing
+      - silent: Ignore errors silently
+      - propagate: Stop processing and return the error
+    validations:
+      - oneof(ignore, silent, propagate)
+  - name: TraceStatements
+    type: stringarray
+    summary: Array of OTTL trace transform statements
+    description: |
+      Array of OpenTelemetry Transformation Language (OTTL) statements to apply to traces.
+      Each statement can modify span attributes, perform filtering, or apply other transformations.
+      Examples:
+      - set(span.attributes["custom.field"], "value")
+      - delete_key(span.attributes, "unwanted_field")
+      - set(span.name, Concat([span.name, " - processed"], ""))
+    default: []
+    advanced: false
+  - name: LogStatements
+    type: stringarray
+    summary: Array of OTTL log transform statements
+    description: |
+      Array of OpenTelemetry Transformation Language (OTTL) statements to apply to logs.
+      Each statement can modify log attributes, body, or perform other transformations.
+      Examples:
+      - set(log.attributes["processed"], "true")
+      - set(log.body, Concat([log.body, " [processed]"], ""))
+      - delete_key(log.attributes, "sensitive_field")
+    default: []
+    advanced: false
+  - name: MetricStatements
+    type: stringarray
+    summary: Array of OTTL metric transform statements
+    description: |
+      Array of OpenTelemetry Transformation Language (OTTL) statements to apply to metrics.
+      Each statement can modify metric attributes, name, description, or perform other transformations.
+      Examples:
+      - set(metric.attributes["custom.field"], "value")
+      - set(metric.description, Concat([metric.description, " (processed)"], ""))
+      - delete_key(metric.attributes, "unwanted_field")
+    default: []
+    advanced: false
+templates:
+  - kind: collector_config
+    name: transform_processor
+    format: collector
+    meta:
+      componentSection: processors
+      signalTypes: [logs, traces, metrics]
+      collectorComponentName: transform
+    data:
+      - key: "{{ .ComponentName }}.error_mode"
+        value: "{{ .Values.ErrorMode }}"
+      # Trace statements - each statement becomes an element in trace_statements array
+      - key: "{{ .ComponentName }}.trace_statements"
+        value: "{{ .Values.TraceStatements | encodeAsArray }}"
+        suppress_if: "{{ not .Values.TraceStatements }}"
+      # Log statements - each statement becomes an element in log_statements array  
+      - key: "{{ .ComponentName }}.log_statements"
+        value: "{{ .Values.LogStatements | encodeAsArray }}"
+        suppress_if: "{{ not .Values.LogStatements }}"
+      # Metric statements - each statement becomes an element in metric_statements array
+      - key: "{{ .ComponentName }}.metric_statements"
+        value: "{{ .Values.MetricStatements | encodeAsArray }}"
+        suppress_if: "{{ not .Values.MetricStatements }}"

--- a/tests/scenario_tests/testdata/transformprocessor_defaults.yaml
+++ b/tests/scenario_tests/testdata/transformprocessor_defaults.yaml
@@ -1,0 +1,67 @@
+name: transformprocessor_defaults_test
+version: v0.1.0
+summary: Test for TransformProcessor with default configuration
+description: |
+  Test configuration with an OTel receiver, TransformProcessor with empty arrays (defaults),
+  and OTel HTTP exporter.
+
+components:
+  - name: OTel Receiver 1
+    kind: OTelReceiver
+  - name: transform_1
+    kind: TransformProcessor
+    properties:
+      - name: ErrorMode
+        value: ignore
+  - name: OTel HTTP Exporter 1
+    kind: OTelHTTPExporter
+
+connections:
+  - source:
+      component: OTel Receiver 1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: OTel Receiver 1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: transform_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: transform_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: OTel Receiver 1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: transform_1
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: transform_1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Metrics
+      type: OTelMetrics

--- a/tests/scenario_tests/testdata/transformprocessor_single_signal.yaml
+++ b/tests/scenario_tests/testdata/transformprocessor_single_signal.yaml
@@ -1,0 +1,39 @@
+name: transformprocessor_single_signal_test
+version: v0.1.0
+summary: Test for TransformProcessor with only trace statements
+description: |
+  Test configuration with an OTel receiver, TransformProcessor with only trace statements,
+  and OTel HTTP exporter. Tests that other signal types are not affected.
+
+components:
+  - name: OTel Receiver 1
+    kind: OTelReceiver
+  - name: transform_1
+    kind: TransformProcessor
+    properties:
+      - name: ErrorMode
+        value: propagate
+      - name: TraceStatements
+        value:
+          - 'set(span.attributes["trace_only"], "true")'
+          - 'set(span.name, Concat([span.name, " [transformed]"], ""))'
+  - name: OTel HTTP Exporter 1
+    kind: OTelHTTPExporter
+
+connections:
+  - source:
+      component: OTel Receiver 1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Traces
+      type: OTelTraces

--- a/tests/scenario_tests/testdata/transformprocessor_with_statements.yaml
+++ b/tests/scenario_tests/testdata/transformprocessor_with_statements.yaml
@@ -1,0 +1,80 @@
+name: transformprocessor_statements_test
+version: v0.1.0
+summary: Test for TransformProcessor with custom statements
+description: |
+  Test configuration with an OTel receiver, TransformProcessor with custom trace, log, and metric statements,
+  and OTel HTTP exporter.
+
+components:
+  - name: OTel Receiver 1
+    kind: OTelReceiver
+  - name: transform_1
+    kind: TransformProcessor
+    properties:
+      - name: ErrorMode
+        value: ignore
+      - name: TraceStatements
+        value:
+          - 'set(span.attributes["processed"], "true")'
+          - 'set(span.attributes["processor"], "transform")'
+          - 'delete_key(span.attributes, "temp_field")'
+      - name: LogStatements
+        value:
+          - 'set(log.attributes["processed"], "true")'
+          - 'set(log.severity_text, "INFO")'
+      - name: MetricStatements
+        value:
+          - 'set(metric.attributes["processed"], "true")'
+          - 'set(metric.description, Concat([metric.description, " (processed)"], ""))'
+  - name: OTel HTTP Exporter 1
+    kind: OTelHTTPExporter
+
+connections:
+  - source:
+      component: OTel Receiver 1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: OTel Receiver 1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: transform_1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: transform_1
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: OTel Receiver 1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: transform_1
+      port: Metrics
+      type: OTelMetrics
+  - source:
+      component: transform_1
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Metrics
+      type: OTelMetrics

--- a/tests/scenario_tests/transform_processor_test.go
+++ b/tests/scenario_tests/transform_processor_test.go
@@ -1,0 +1,175 @@
+package hpsftests
+
+import (
+	"testing"
+
+	collectorprovider "github.com/honeycombio/hpsf/tests/providers/collector"
+	hpsfprovider "github.com/honeycombio/hpsf/tests/providers/hpsf"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformProcessorDefaults(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/transformprocessor_defaults.yaml")
+
+	assert.Len(t, rulesConfig.Samplers, 1)
+
+	// Check that all three pipeline types are created
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 1, "Expected 1 logs pipeline, got %v", logsPipelineNames)
+
+	metricsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "metrics")
+	assert.Len(t, metricsPipelineNames, 1, "Expected 1 metrics pipeline, got %v", metricsPipelineNames)
+
+	// Check that transform processor is in all pipelines
+	_, processors, _, getResult := collectorprovider.GetPipelineConfig(collectorConfig, tracesPipelineNames[0].String())
+	require.True(t, getResult.Found)
+	assert.Contains(t, processors, "transform/transform_1")
+
+	_, processors, _, getResult = collectorprovider.GetPipelineConfig(collectorConfig, logsPipelineNames[0].String())
+	require.True(t, getResult.Found)
+	assert.Contains(t, processors, "transform/transform_1")
+
+	_, processors, _, getResult = collectorprovider.GetPipelineConfig(collectorConfig, metricsPipelineNames[0].String())
+	require.True(t, getResult.Found)
+	assert.Contains(t, processors, "transform/transform_1")
+
+	// Check transform processor configuration
+	transformConfig, findResult := collectorprovider.GetProcessorConfig[transformprocessor.Config](collectorConfig, "transform/transform_1")
+	require.True(t, findResult.Found, "Expected transform processor to be found, found (%v)", findResult.Components)
+
+	// With default/empty arrays, should have no statements
+	assert.Len(t, transformConfig.TraceStatements, 0)
+	assert.Len(t, transformConfig.LogStatements, 0)
+	assert.Len(t, transformConfig.MetricStatements, 0)
+
+	// Check error mode
+	assert.Equal(t, "ignore", string(transformConfig.ErrorMode))
+}
+
+func TestTransformProcessorWithStatements(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/transformprocessor_with_statements.yaml")
+
+	assert.Len(t, rulesConfig.Samplers, 1)
+
+	transformConfig, findResult := collectorprovider.GetProcessorConfig[transformprocessor.Config](collectorConfig, "transform/transform_1")
+	require.True(t, findResult.Found, "Expected transform processor to be found, found (%v)", findResult.Components)
+
+	// Check trace statements - they are wrapped in statement objects
+	require.Len(t, transformConfig.TraceStatements, 1)
+	traceStatement := transformConfig.TraceStatements[0]
+	require.Len(t, traceStatement.Statements, 3)
+	assert.Equal(t, `set(span.attributes["processed"], "true")`, traceStatement.Statements[0])
+	assert.Equal(t, `set(span.attributes["processor"], "transform")`, traceStatement.Statements[1])
+	assert.Equal(t, `delete_key(span.attributes, "temp_field")`, traceStatement.Statements[2])
+
+	// Check log statements - they are wrapped in statement objects
+	require.Len(t, transformConfig.LogStatements, 1)
+	logStatement := transformConfig.LogStatements[0]
+	require.Len(t, logStatement.Statements, 2)
+	assert.Equal(t, `set(log.attributes["processed"], "true")`, logStatement.Statements[0])
+	assert.Equal(t, `set(log.severity_text, "INFO")`, logStatement.Statements[1])
+
+	// Check metric statements - they are wrapped in statement objects
+	require.Len(t, transformConfig.MetricStatements, 1)
+	metricStatement := transformConfig.MetricStatements[0]
+	require.Len(t, metricStatement.Statements, 2)
+	assert.Equal(t, `set(metric.attributes["processed"], "true")`, metricStatement.Statements[0])
+	assert.Equal(t, `set(metric.description, Concat([metric.description, " (processed)"], ""))`, metricStatement.Statements[1])
+
+	// Check error mode
+	assert.Equal(t, "ignore", string(transformConfig.ErrorMode))
+}
+
+func TestTransformProcessorSingleSignal(t *testing.T) {
+	rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigsFromFile(t, "testdata/transformprocessor_single_signal.yaml")
+
+	assert.Len(t, rulesConfig.Samplers, 1)
+
+	// Should only have traces pipeline since only trace statements are defined
+	tracesPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "traces")
+	assert.Len(t, tracesPipelineNames, 1, "Expected 1 traces pipeline, got %v", tracesPipelineNames)
+
+	// Should not have logs or metrics pipelines
+	logsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "logs")
+	assert.Len(t, logsPipelineNames, 0, "Expected 0 logs pipelines, got %v", logsPipelineNames)
+
+	metricsPipelineNames := collectorprovider.GetPipelinesByType(collectorConfig, "metrics")
+	assert.Len(t, metricsPipelineNames, 0, "Expected 0 metrics pipelines, got %v", metricsPipelineNames)
+
+	transformConfig, findResult := collectorprovider.GetProcessorConfig[transformprocessor.Config](collectorConfig, "transform/transform_1")
+	require.True(t, findResult.Found, "Expected transform processor to be found, found (%v)", findResult.Components)
+
+	// Check trace statements - they are wrapped in statement objects
+	require.Len(t, transformConfig.TraceStatements, 1)
+	traceStatement := transformConfig.TraceStatements[0]
+	require.Len(t, traceStatement.Statements, 2)
+	assert.Equal(t, `set(span.attributes["trace_only"], "true")`, traceStatement.Statements[0])
+	assert.Equal(t, `set(span.name, Concat([span.name, " [transformed]"], ""))`, traceStatement.Statements[1])
+
+	// Should have no log or metric statements
+	assert.Len(t, transformConfig.LogStatements, 0)
+	assert.Len(t, transformConfig.MetricStatements, 0)
+
+	// Check error mode
+	assert.Equal(t, "propagate", string(transformConfig.ErrorMode))
+}
+
+func TestTransformProcessorErrorModeValidation(t *testing.T) {
+	// Test that all error modes are supported
+	errorModes := []string{"ignore", "silent", "propagate"}
+	
+	for _, errorMode := range errorModes {
+		t.Run("ErrorMode_"+errorMode, func(t *testing.T) {
+			// Create a temporary test config
+			testConfig := `
+name: transformprocessor_error_mode_test
+version: v0.1.0
+summary: Test for TransformProcessor error mode validation
+
+components:
+  - name: OTel Receiver 1
+    kind: OTelReceiver
+  - name: transform_1
+    kind: TransformProcessor
+    properties:
+      - name: ErrorMode
+        value: ` + errorMode + `
+      - name: TraceStatements
+        value:
+          - 'set(span.attributes["test"], "true")'
+  - name: OTel HTTP Exporter 1
+    kind: OTelHTTPExporter
+
+connections:
+  - source:
+      component: OTel Receiver 1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: transform_1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: OTel HTTP Exporter 1
+      port: Traces
+      type: OTelTraces`
+
+			rulesConfig, collectorConfig, _ := hpsfprovider.GetParsedConfigs(t, testConfig)
+			assert.Len(t, rulesConfig.Samplers, 1)
+
+			transformConfig, findResult := collectorprovider.GetProcessorConfig[transformprocessor.Config](collectorConfig, "transform/transform_1")
+			require.True(t, findResult.Found, "Expected transform processor to be found, found (%v)", findResult.Components)
+
+			assert.Equal(t, errorMode, string(transformConfig.ErrorMode))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add a new HPSF component that provides a flexible transform processor for OpenTelemetry Collector pipelines supporting traces, metrics, and logs.

## Features
- Supports TraceStatements, LogStatements, and MetricStatements as string arrays
- Configurable error handling modes (ignore, silent, propagate)  
- Works with all three OpenTelemetry signal types
- Uses encodeAsArray for proper collector configuration generation

## Test plan
- [x] Comprehensive test coverage for all functionality
- [x] Tests for default configuration, multi-signal statements, and single signal usage
- [x] Error mode validation tests
- [x] Proper collector configuration generation validation
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)