### PR TITLE
feat: Make SymbolicatorProcessor prefix property optional

### DIFF
--- a/pkg/data/components/SymbolicatorProcessor.yaml
+++ b/pkg/data/components/SymbolicatorProcessor.yaml
@@ -59,10 +59,8 @@ properties:
       The prefix to use for the source map store. This is optional and can be used to specify a subdirectory within the bucket.
       If not specified, the root of the bucket will be used.
       Examples: `source-maps/`, `my-project/source-maps/`.
-    validations:
-      - noblanks
-      - nonempty
     type: string
+    default: ""
 templates:
   - kind: collector_config
     name: hny_symbolicator_processor
@@ -84,7 +82,7 @@ templates:
         suppress_if: '{{ not (eq "AWSS3" .Values.SourceMapStore) }}'
       - key: "{{ .ComponentName }}.s3_source_maps.prefix"
         value: "{{ .Values.Prefix }}"
-        suppress_if: '{{ not (eq "AWSS3" .Values.SourceMapStore) }}'
+        suppress_if: '{{ or (not (eq "AWSS3" .Values.SourceMapStore)) (eq .Values.Prefix "") }}'
       # GoogleCloudStorage
       - key: "{{ .ComponentName }}.source_map_store"
         value: "gcs_store"
@@ -94,4 +92,4 @@ templates:
         suppress_if: '{{ not (eq "GoogleCloudStorage" .Values.SourceMapStore) }}'
       - key: "{{ .ComponentName }}.gcs_source_maps.prefix"
         value: "{{ .Values.Prefix }}"
-        suppress_if: '{{ not (eq "GoogleCloudStorage" .Values.SourceMapStore) }}'
+        suppress_if: '{{ or (not (eq "GoogleCloudStorage" .Values.SourceMapStore)) (eq .Values.Prefix "") }}'

--- a/pkg/translator/testdata/collector_config/symbolicatorprocessor_defaults.yaml
+++ b/pkg/translator/testdata/collector_config/symbolicatorprocessor_defaults.yaml
@@ -9,7 +9,6 @@ processors:
     symbolicator/symbolicator:
         s3_source_maps:
             bucket: my-bucket
-            prefix: source-maps/
             region: us-west-2
         source_map_store: s3_store
     usage: {}

--- a/pkg/translator/testdata/hpsf/symbolicatorprocessor_defaults.yaml
+++ b/pkg/translator/testdata/hpsf/symbolicatorprocessor_defaults.yaml
@@ -12,8 +12,6 @@ components:
         value: my-bucket
       - name: Region
         value: us-west-2
-      - name: Prefix
-        value: source-maps/
 connections:
   - source:
       component: otlp_in


### PR DESCRIPTION
## Summary
- Made the `Prefix` property optional in SymbolicatorProcessor component
- Removed `noblanks` and `nonempty` validations that were making it required
- Added default empty string value for the prefix property
- Updated template logic to suppress prefix configuration when empty or using wrong store type

## Test plan
- [x] All existing tests pass
- [x] Template logic correctly suppresses prefix when empty
- [x] Works for both AWS S3 and Google Cloud Storage configurations
- [x] Default test cases updated to reflect optional behavior

🤖 Generated with [Claude Code](https://claude.ai/code)