### PR TITLE
fix(poodle, pipelines): Make rules order according to rule index

### DIFF
--- a/pkg/data/components/SamplingSequencer.yaml
+++ b/pkg/data/components/SamplingSequencer.yaml
@@ -31,51 +31,51 @@ ports:
   - name: Rule 1
     direction: output
     type: SampleData
-    index: 0
+    index: 1
   - name: Rule 2
     direction: output
     type: SampleData
-    index: 1
+    index: 2
   - name: Rule 3
     direction: output
     type: SampleData
-    index: 2
+    index: 3
   - name: Rule 4
     direction: output
     type: SampleData
-    index: 3
+    index: 4
   - name: Rule 5
     direction: output
     type: SampleData
-    index: 4
+    index: 5
   - name: Rule 6
     direction: output
     type: SampleData
-    index: 5
+    index: 6
   - name: Rule 7
     direction: output
     type: SampleData
-    index: 6
+    index: 7
   - name: Rule 8
     direction: output
     type: SampleData
-    index: 7
+    index: 8
   - name: Rule 9
     direction: output
     type: SampleData
-    index: 8
+    index: 9
   - name: Rule 10
     direction: output
     type: SampleData
-    index: 9
+    index: 10
   - name: Rule 11
     direction: output
     type: SampleData
-    index: 10
+    index: 11
   - name: Rule 12
     direction: output
     type: SampleData
-    index: 11
+    index: 12
 properties:
   - name: Host
     summary: The hostname or IP address on which to listen.

--- a/pkg/translator/translator_paths_test.go
+++ b/pkg/translator/translator_paths_test.go
@@ -1,0 +1,272 @@
+package translator
+
+import (
+    "fmt"
+    "testing"
+
+    "github.com/honeycombio/hpsf/pkg/config"
+    "github.com/honeycombio/hpsf/pkg/hpsf"
+    "github.com/honeycombio/hpsf/pkg/hpsftypes"
+)
+
+// TestOrderPathsPortIndex ensures that orderPaths sorts by port index when present.
+func TestOrderPathsPortIndex(t *testing.T) {
+    start := config.TemplateComponent{
+        Kind: "StartSamplingFake",
+        Name: "StartSampler",
+        Ports: []config.TemplatePort{
+            {Name: "outB", Direction: "output", Index: 2},
+            {Name: "outA", Direction: "output", Index: 1},
+            {Name: "outC", Direction: "output"}, // unspecified index
+        },
+        Style: "startsampling",
+    }
+    down1 := config.TemplateComponent{Kind: "SamplerA", Name: "SamplerA"}
+    down2 := config.TemplateComponent{Kind: "SamplerB", Name: "SamplerB"}
+    down3 := config.TemplateComponent{Kind: "SamplerC", Name: "SamplerC"}
+
+    comps := NewOrderedComponentMap()
+    comps.Set("StartSampler", &start)
+    comps.Set("SamplerA", &down1)
+    comps.Set("SamplerB", &down2)
+    comps.Set("SamplerC", &down3)
+
+    connB := &hpsf.Connection{Source: hpsf.ConnectionPort{Component: "StartSampler", PortName: "outB"}, Destination: hpsf.ConnectionPort{Component: "SamplerB"}}
+    connA := &hpsf.Connection{Source: hpsf.ConnectionPort{Component: "StartSampler", PortName: "outA"}, Destination: hpsf.ConnectionPort{Component: "SamplerA"}}
+    connC := &hpsf.Connection{Source: hpsf.ConnectionPort{Component: "StartSampler", PortName: "outC"}, Destination: hpsf.ConnectionPort{Component: "SamplerC"}}
+
+    paths := []hpsf.PathWithConnections{
+        {ConnType: hpsf.CTYPE_TRACES, Path: []*hpsf.Component{{Name: "StartSampler"}, {Name: "SamplerB"}}, Connections: []*hpsf.Connection{connB}},
+        {ConnType: hpsf.CTYPE_TRACES, Path: []*hpsf.Component{{Name: "StartSampler"}, {Name: "SamplerA"}}, Connections: []*hpsf.Connection{connA}},
+        {ConnType: hpsf.CTYPE_TRACES, Path: []*hpsf.Component{{Name: "StartSampler"}, {Name: "SamplerC"}}, Connections: []*hpsf.Connection{connC}},
+    }
+
+    orderPaths(paths, comps)
+
+    if paths[0].Connections[0].Source.PortName != "outA" ||
+        paths[1].Connections[0].Source.PortName != "outB" ||
+        paths[2].Connections[0].Source.PortName != "outC" {
+        for i, p := range paths {
+            if len(p.Connections) == 0 { continue }
+            t.Errorf("unexpected order at position %d: %s", i, p.Connections[0].Source.PortName)
+        }
+    }
+}
+
+// TestOrderPathsIndexBeforeComponent verifies index ordering precedes component name ordering.
+func TestOrderPathsIndexBeforeComponent(t *testing.T) {
+    startA := config.TemplateComponent{ // index 2
+        Kind: "StartA", Name: "StartA",
+        Ports: []config.TemplatePort{{Name: "out1", Direction: "output", Index: 2}},
+    }
+    startZ := config.TemplateComponent{ // index 1
+        Kind: "StartZ", Name: "StartZ",
+        Ports: []config.TemplatePort{{Name: "out1", Direction: "output", Index: 1}},
+    }
+    down1 := config.TemplateComponent{Kind: "Down1", Name: "Down1"}
+    down2 := config.TemplateComponent{Kind: "Down2", Name: "Down2"}
+
+    comps := NewOrderedComponentMap()
+    comps.Set("StartA", &startA)
+    comps.Set("StartZ", &startZ)
+    comps.Set("Down1", &down1)
+    comps.Set("Down2", &down2)
+
+    connA := &hpsf.Connection{Source: hpsf.ConnectionPort{Component: "StartA", PortName: "out1"}, Destination: hpsf.ConnectionPort{Component: "Down1"}}
+    connZ := &hpsf.Connection{Source: hpsf.ConnectionPort{Component: "StartZ", PortName: "out1"}, Destination: hpsf.ConnectionPort{Component: "Down2"}}
+
+    paths := []hpsf.PathWithConnections{
+        {ConnType: hpsf.CTYPE_TRACES, Path: []*hpsf.Component{{Name: "StartZ"}, {Name: "Down2"}}, Connections: []*hpsf.Connection{connZ}}, // index 1
+        {ConnType: hpsf.CTYPE_TRACES, Path: []*hpsf.Component{{Name: "StartA"}, {Name: "Down1"}}, Connections: []*hpsf.Connection{connA}}, // index 2
+    }
+
+    orderPaths(paths, comps)
+
+    if paths[0].Connections[0].Source.Component != "StartZ" { // lower index should come first
+        for i, p := range paths {
+            if len(p.Connections) == 0 { continue }
+            t.Errorf("unexpected order at %d: %s", i, p.Connections[0].Source.Component)
+        }
+    }
+}
+
+// TestSamplingSequencerRuleOrdering ensures that the path ordering logic yields the
+// rule output ports in strict numeric order (Rule 1 .. Rule 12) when each rule
+// output of the SamplingSequencer fans out into a distinct SampleData path.
+func TestSamplingSequencerRuleOrdering(t *testing.T) {
+    hpsfYAML := `kind: Test
+components:
+  - name: Receive OTel
+    kind: OTelReceiver
+    version: v0.1.0
+  - name: Start Sampling
+    kind: SamplingSequencer
+    version: v0.1.0
+  - name: Send to Honeycomb
+    kind: HoneycombExporter
+    version: v0.1.0
+  - name: Keep All
+    kind: KeepAllSampler
+    version: v0.1.0
+  - name: Check Duration_1
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_1
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_2
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_2
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_3
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_3
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_4
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_4
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_5
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_5
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_6
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_6
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_7
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_7
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_8
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_8
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_9
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_9
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_10
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_10
+    kind: Dropper
+    version: v0.1.0
+  - name: Check Duration_11
+    kind: LongDurationCondition
+    version: v0.1.0
+  - name: Drop_11
+    kind: Dropper
+    version: v0.1.0
+connections:
+  - source: { component: Receive OTel, port: Traces, type: OTelTraces }
+    destination: { component: Start Sampling, port: Traces, type: OTelTraces }
+  - source: { component: Receive OTel, port: Logs, type: OTelLogs }
+    destination: { component: Start Sampling, port: Logs, type: OTelLogs }
+  - source: { component: Start Sampling, port: Rule 1, type: SampleData }
+    destination: { component: Check Duration_1, port: Match, type: SampleData }
+  - source: { component: Check Duration_1, port: And, type: SampleData }
+    destination: { component: Drop_1, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 2, type: SampleData }
+    destination: { component: Check Duration_2, port: Match, type: SampleData }
+  - source: { component: Check Duration_2, port: And, type: SampleData }
+    destination: { component: Drop_2, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 3, type: SampleData }
+    destination: { component: Check Duration_3, port: Match, type: SampleData }
+  - source: { component: Check Duration_3, port: And, type: SampleData }
+    destination: { component: Drop_3, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 4, type: SampleData }
+    destination: { component: Check Duration_4, port: Match, type: SampleData }
+  - source: { component: Check Duration_4, port: And, type: SampleData }
+    destination: { component: Drop_4, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 5, type: SampleData }
+    destination: { component: Check Duration_5, port: Match, type: SampleData }
+  - source: { component: Check Duration_5, port: And, type: SampleData }
+    destination: { component: Drop_5, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 6, type: SampleData }
+    destination: { component: Check Duration_6, port: Match, type: SampleData }
+  - source: { component: Check Duration_6, port: And, type: SampleData }
+    destination: { component: Drop_6, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 7, type: SampleData }
+    destination: { component: Check Duration_7, port: Match, type: SampleData }
+  - source: { component: Check Duration_7, port: And, type: SampleData }
+    destination: { component: Drop_7, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 8, type: SampleData }
+    destination: { component: Check Duration_8, port: Match, type: SampleData }
+  - source: { component: Check Duration_8, port: And, type: SampleData }
+    destination: { component: Drop_8, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 9, type: SampleData }
+    destination: { component: Check Duration_9, port: Match, type: SampleData }
+  - source: { component: Check Duration_9, port: And, type: SampleData }
+    destination: { component: Drop_9, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 10, type: SampleData }
+    destination: { component: Check Duration_10, port: Match, type: SampleData }
+  - source: { component: Check Duration_10, port: And, type: SampleData }
+    destination: { component: Drop_10, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 11, type: SampleData }
+    destination: { component: Check Duration_11, port: Match, type: SampleData }
+  - source: { component: Check Duration_11, port: And, type: SampleData }
+    destination: { component: Drop_11, port: Sample, type: SampleData }
+  - source: { component: Start Sampling, port: Rule 12, type: SampleData }
+    destination: { component: Keep All, port: Sample, type: SampleData }
+  - source: { component: Keep All, port: Events, type: HoneycombEvents }
+    destination: { component: Send to Honeycomb, port: Events, type: HoneycombEvents }
+`
+
+    h, err := hpsf.FromYAML(hpsfYAML)
+    if err != nil {
+        t.Fatalf("failed to parse HPSF yaml: %v", err)
+    }
+
+    tr := NewEmptyTranslator()
+    if err := tr.LoadEmbeddedComponents(); err != nil {
+        t.Fatalf("failed to load embedded components: %v", err)
+    }
+
+    _ = tr.ValidateConfig(&h)
+    _, _ = tr.GenerateConfig(&h, hpsftypes.CollectorConfig, "latest", nil)
+
+    paths := h.FindAllPaths(map[string]bool{})
+    comps := NewOrderedComponentMap()
+    for _, c := range h.Components {
+        cc, err2 := tr.MakeConfigComponent(c, "latest")
+        if err2 != nil { continue }
+        comps.Set(c.GetSafeName(), cc)
+    }
+    orderPaths(paths, comps)
+
+    rulePorts := make([]string, 0, 12)
+    for _, p := range paths {
+        if p.ConnType != hpsf.CTYPE_SAMPLE || len(p.Connections) == 0 { continue }
+        first := p.Connections[0]
+        if first.Source.Component == "Start Sampling" {
+            rulePorts = append(rulePorts, first.Source.PortName)
+        }
+    }
+
+    if len(rulePorts) != 12 {
+        t.Fatalf("expected %d rule paths, got %d (%v)", 12, len(rulePorts), rulePorts)
+    }
+    for i, rp := range rulePorts {
+        expected := fmt.Sprintf("Rule %d", i+1)
+        if rp != expected {
+            t.Fatalf("rule ordering mismatch at %d: got %s expected %s full=%v", i, rp, expected, rulePorts)
+        }
+    }
+}


### PR DESCRIPTION

## Which problem is this PR solving?

- A user noticed that rules connected past rule 9 in the SamplingSequencer were being ordered after rule 1. In other words, the rules were being ordered by rule name instead of rule index. To fix this, we needed to extract the index information from the template component and make that available at the point where we order the rules.

## Short description of the changes

- Implemented index‑aware path ordering: added helper and orderPaths logic so SampleData (and other) paths sort first by port index, then existing tie‑breakers.
- Updated SamplingSequencer component definition so its 12 rule output ports use explicit sequential indexes 1–12 (was including 0/unspecified before), ensuring “Rule 12” reliably sorts last.
- Added a comprehensive ordering test that builds a full SamplingSequencer topology with 12 distinct rule paths and asserts exact ordered slice: Rule 1 … Rule 12.
- Added a test that checks that any component specifying a port index always has sequential port indices starting with 1

This will be followed up with a release and an update to hound.
