### PR TITLE
feat: add client feature support

### DIFF
--- a/cmd/hpsf/main.go
+++ b/cmd/hpsf/main.go
@@ -219,7 +219,7 @@ func main() {
 		case "cConfig":
 			ct = hpsftypes.CollectorConfig
 		}
-		cfg, err := tr.GenerateConfig(&hpsf, ct, translator.LatestVersion, userdata)
+		cfg, err := tr.GenerateConfig(&hpsf, ct, translator.LatestVersion, nil, userdata)
 		if err != nil {
 			log.Fatalf("error translating config: %v", err)
 		}

--- a/pkg/hpsftypes/features.go
+++ b/pkg/hpsftypes/features.go
@@ -1,0 +1,70 @@
+package hpsftypes
+
+import "strings"
+
+// Feature represents a client capability that affects config generation behavior.
+// Features are used to maintain backward compatibility with older clients while
+// enabling new functionality for updated clients.
+type Feature string
+
+// Future features will be added here as new capabilities are developed
+// For example:
+// const (
+//     FeatureEnvIDSubstitution Feature = "env_id_substitution"
+// )
+
+// Features represents a collection of client capabilities.
+type Features []Feature
+
+// Contains checks if a specific feature is present in the collection.
+func (f Features) Contains(feature Feature) bool {
+	for _, existing := range f {
+		if existing == feature {
+			return true
+		}
+	}
+	return false
+}
+
+// Strings converts Features to a slice of strings.
+// This is useful for serialization or logging.
+func (f Features) Strings() []string {
+	strs := make([]string, len(f))
+	for i, feature := range f {
+		strs[i] = string(feature)
+	}
+	return strs
+}
+
+// ParseFeaturesFromString parses a comma-separated string of features.
+// Whitespace is trimmed from each feature name. Empty strings and empty
+// features are ignored. This is useful for parsing query parameters.
+//
+// Example:
+//   ParseFeaturesFromString("feature_one, feature_two")
+//   // Returns: Features{Feature("feature_one"), Feature("feature_two")}
+func ParseFeaturesFromString(s string) Features {
+	if s == "" {
+		return Features{}
+	}
+	strs := strings.Split(s, ",")
+	features := make(Features, 0, len(strs))
+	for _, str := range strs {
+		trimmed := strings.TrimSpace(str)
+		if trimmed != "" {
+			features = append(features, Feature(trimmed))
+		}
+	}
+	return features
+}
+
+// ParseFeatures converts a slice of strings into Features.
+// This is useful when you already have a slice of feature strings.
+// Unknown feature strings are kept as-is for forward compatibility.
+func ParseFeatures(strs []string) Features {
+	features := make(Features, 0, len(strs))
+	for _, s := range strs {
+		features = append(features, Feature(s))
+	}
+	return features
+}

--- a/pkg/hpsftypes/features_test.go
+++ b/pkg/hpsftypes/features_test.go
@@ -1,0 +1,88 @@
+package hpsftypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test-only features for testing the feature infrastructure
+const (
+	testFeature1 Feature = "test_feature_1"
+	testFeature2 Feature = "test_feature_2"
+	testFeature3 Feature = "test_feature_3"
+)
+
+func TestParseFeaturesFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Features
+	}{
+		{
+			name:     "single feature",
+			input:    "test_feature_1",
+			expected: Features{testFeature1},
+		},
+		{
+			name:     "multiple features",
+			input:    "test_feature_1,test_feature_2",
+			expected: Features{testFeature1, testFeature2},
+		},
+		{
+			name:     "features with spaces",
+			input:    "test_feature_1, test_feature_2",
+			expected: Features{testFeature1, testFeature2},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: Features{},
+		},
+		{
+			name:     "whitespace only",
+			input:    "  ,  , ",
+			expected: Features{},
+		},
+		{
+			name:     "mixed with empty",
+			input:    "test_feature_1,,test_feature_2",
+			expected: Features{testFeature1, testFeature2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseFeaturesFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseFeatures(t *testing.T) {
+	input := []string{"test_feature_1", "test_feature_2"}
+	expected := Features{testFeature1, testFeature2}
+
+	result := ParseFeatures(input)
+	assert.Equal(t, expected, result)
+}
+
+func TestFeatures_Strings(t *testing.T) {
+	features := Features{testFeature1, testFeature2}
+	expected := []string{"test_feature_1", "test_feature_2"}
+
+	result := features.Strings()
+	assert.Equal(t, expected, result)
+}
+
+func TestFeatures_Contains(t *testing.T) {
+	features := Features{testFeature1, testFeature2}
+
+	assert.True(t, features.Contains(testFeature1))
+	assert.True(t, features.Contains(testFeature2))
+	assert.False(t, features.Contains(testFeature3))
+
+	// Empty list
+	emptyFeatures := Features{}
+	assert.False(t, emptyFeatures.Contains(testFeature1))
+}

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -606,7 +606,7 @@ func orderPaths(paths []hpsf.PathWithConnections, comps *OrderedComponentMap) {
 	})
 }
 
-func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct hpsftypes.Type, artifactVersion string, userdata map[string]any) (tmpl.TemplateConfig, error) {
+func (t *Translator) GenerateConfig(h *hpsf.HPSF, ct hpsftypes.Type, artifactVersion string, features hpsftypes.Features, userdata map[string]any) (tmpl.TemplateConfig, error) {
 	comps := NewOrderedComponentMap()
 	receiverNames := make(map[string]bool)
 	// make all the components

--- a/pkg/translator/translator_paths_test.go
+++ b/pkg/translator/translator_paths_test.go
@@ -240,7 +240,7 @@ connections:
     }
 
     _ = tr.ValidateConfig(&h)
-    _, _ = tr.GenerateConfig(&h, hpsftypes.CollectorConfig, "latest", nil)
+    _, _ = tr.GenerateConfig(&h, hpsftypes.CollectorConfig, "latest", nil, nil)
 
     paths := h.FindAllPaths(map[string]bool{})
     comps := NewOrderedComponentMap()

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -106,7 +106,7 @@ func TestGenerateConfigForAllComponents(t *testing.T) {
 					h, err := hpsf.FromYAML(inputData)
 					require.NoError(t, err)
 
-					cfg, err := tlater.GenerateConfig(&h, configType, LatestVersion, nil)
+					cfg, err := tlater.GenerateConfig(&h, configType, LatestVersion, nil, nil)
 					require.NoError(t, err)
 					if cfg == nil {
 						continue // skip if no config is generated for this component
@@ -190,7 +190,7 @@ func TestDefaultHPSF(t *testing.T) {
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, tC.ct, LatestVersion, nil)
+			cfg, err := tlater.GenerateConfig(&h, tC.ct, LatestVersion, nil, nil)
 			require.NoError(t, err)
 
 			got, err := cfg.RenderYAML()
@@ -223,7 +223,7 @@ func TestHPSFWithoutSamplerComponentGeneratesValidRefineryRules(t *testing.T) {
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	cfg, err := tlater.GenerateConfig(&hpsf, hpsftypes.RefineryRules, LatestVersion, nil)
+	cfg, err := tlater.GenerateConfig(&hpsf, hpsftypes.RefineryRules, LatestVersion, nil, nil)
 	require.NoError(t, err)
 
 	got, err := cfg.RenderYAML()
@@ -564,7 +564,7 @@ layout:
 	require.NoError(t, err)
 	tlater.InstallComponents(comps)
 
-	x, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
+	x, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, x)
 }
@@ -739,7 +739,7 @@ connections:
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
+			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 		})
@@ -839,7 +839,7 @@ connections:
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
+			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 
@@ -1139,7 +1139,7 @@ connections:
 			require.NoError(t, err)
 			tlater.InstallComponents(comps)
 
-			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil)
+			cfg, err := tlater.GenerateConfig(&h, hpsftypes.RefineryRules, LatestVersion, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 

--- a/tests/providers/hpsf/hpsf_provider.go
+++ b/tests/providers/hpsf/hpsf_provider.go
@@ -58,14 +58,14 @@ func GetParsedConfigs(t *testing.T, hpsfConfig string) (refineryRules *refineryC
 
 	errors := make(map[hpsftypes.Type]ErrorDetails)
 
-	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.RefineryRules, translator.LatestVersion, nil)
+	refineryRulesTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.RefineryRules, translator.LatestVersion, nil, nil)
 	if err != nil {
 		errors[hpsftypes.RefineryConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {
 		refineryRules = refineryConfigProvider.GetParsedRulesConfig(t, refineryRulesTmpl.(*tmpl.RulesConfig))
 	}
 
-	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.CollectorConfig, translator.LatestVersion, nil)
+	collectorConfigTmpl, err := hpsfTranslator.GenerateConfig(&h, hpsftypes.CollectorConfig, translator.LatestVersion, nil, nil)
 	if err != nil {
 		errors[hpsftypes.CollectorConfig] = ErrorDetails{Config: hpsfConfig, Error: err}
 	} else {


### PR DESCRIPTION
## Which problem is this PR solving?

- Need to support backward compatibility with older Beekeeper versions that don't support new features like environment ID substitution
- HPSF needs a way to know what capabilities the requesting client supports so it can generate appropriate configs

## Short description of the changes

- Add `Feature` type and `Features` wrapper type in `pkg/hpsftypes` for representing client capabilities
- Add helper functions `ParseFeaturesFromString()` and `ParseFeatures()` for parsing feature lists
- Update `GenerateConfig()` signature to accept an optional `features` parameter
- Update all call sites to pass `nil` features for backward compatibility
- Add comprehensive tests for the feature infrastructure

This PR lays the foundation for feature-based backward compatibility. No actual features are exposed yet - those will be added in follow-up PRs when the corresponding functionality is implemented.

### Related PRs:

- **#246** - Implements `FeatureEnvIDSubstitution` and environment ID substitution (depends on this PR)

### Design Decision:

See the [decision document](https://github.com/honeycombio/hpsf/pull/248) for details on why we chose feature-based negotiation over version-based inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)