### PR TITLE
maint: Update use of Processor to Component [PIPE-214]

### DIFF
--- a/component-schema.json
+++ b/component-schema.json
@@ -215,7 +215,7 @@
             "type": "string",
             "oneOf": [
               {
-                "enum": ["positive", "noblanks", "nonempty", "url", "duration", "hostorip", "regex"]
+                "enum": ["positive", "noblanks", "nonempty", "url", "duration", "hostorip", "regex", "enhancepartitionformat"]
               },
               {
                 "pattern": "^oneof\\(.+\\)$",

--- a/pkg/data/components/CustomFilterProcessor.yaml
+++ b/pkg/data/components/CustomFilterProcessor.yaml
@@ -4,7 +4,7 @@ style: processor
 type: base
 status: development
 version: v0.0.0
-summary: A processor that can be used to filter telemetry.
+summary: A component that can be used to filter telemetry.
 description: Filters traces, metrics, and logs based on rules defined in the configuration.
 tags:
   - category:processor

--- a/pkg/data/components/LogBodyJSONParsingProcessor.yaml
+++ b/pkg/data/components/LogBodyJSONParsingProcessor.yaml
@@ -7,7 +7,7 @@ version: v0.0.1
 summary: Parses log.body as JSON and flattens it into individual log attributes
 description: |-
   Specifically designed to parse the log.body field as JSON and flatten the parsed JSON into
-  individual log attributes. This processor has no configuration parameters and only works with logs.
+  individual log attributes. This component has no configuration parameters and only works with logs.
 tags:
   - category:processor
   - service:collector

--- a/pkg/data/components/LogDeduplicationProcessor.yaml
+++ b/pkg/data/components/LogDeduplicationProcessor.yaml
@@ -4,9 +4,9 @@ style: processor
 type: base
 status: development
 version: v0.1.0
-summary: A processor that removes duplicate log entries.
+summary: A compoennt that removes duplicate log entries.
 description: |-
-  This processor is used to deduplicate logs by detecting identical logs over a range of time and
+  This component is used to deduplicate logs by detecting identical logs over a range of time and
   emitting a single log with the count of logs that were deduplicated.
 tags:
   - category:processor

--- a/pkg/data/components/MemoryLimiterProcessor.yaml
+++ b/pkg/data/components/MemoryLimiterProcessor.yaml
@@ -6,10 +6,10 @@ status: development
 version: v0.1.0
 summary: Prevents out of memory situations on the collector
 description: |
-  A processor that prevents out-of-memory situations on the collector by monitoring
+  A component that prevents out-of-memory situations on the collector by monitoring
   memory usage and applying backpressure when memory limits are approached. Uses soft 
   and hard memory limits to manage memory consumption effectively. Should be placed as 
-  the first processor in a pipeline for best results.
+  the first component in a pipeline for best results.
 tags:
   - category:processor
   - service:collector

--- a/pkg/data/components/RedactionProcessor.yaml
+++ b/pkg/data/components/RedactionProcessor.yaml
@@ -4,9 +4,9 @@ style: processor
 type: base
 status: development
 version: v0.0.1
-summary: A processor that can be used to redact attribute values in telemetry.
+summary: A component that can be used to redact attribute values in telemetry.
 description: |-
-  This processor allows you to redact attribute values from traces, metrics, and logs based on
+  This component allows you to redact attribute values from traces, metrics, and logs based on
   specified rules.
 tags:
   - category:processor

--- a/pkg/data/components/SymbolicatorProcessor.yaml
+++ b/pkg/data/components/SymbolicatorProcessor.yaml
@@ -4,8 +4,8 @@ style: processor
 type: base
 status: development
 version: v0.1.0
-summary: A processor that will symbolicate JavaScript stack traces using source maps.
-description: This processor is used to symbolicate JavaScript stack traces using source maps.
+summary: A component that will symbolicate JavaScript stack traces using source maps.
+description: This component is used to symbolicate JavaScript stack traces using source maps.
 tags:
   - category:processor
   - service:collector

--- a/pkg/data/components/TransformProcessor.yaml
+++ b/pkg/data/components/TransformProcessor.yaml
@@ -6,7 +6,7 @@ status: development
 version: v0.1.0
 summary: Apply custom transform statements to traces, metrics, and logs
 description: |
-  An advanced processor that allows you to apply custom OpenTelemetry transform statements (OTTL)
+  An advanced component that allows you to apply custom OpenTelemetry transform statements (OTTL)
   to traces, metrics, and logs. You can provide arrays of trace statements, metric statements, 
   and log statements to perform complex data transformations, filtering, and enrichment operations.
 tags:
@@ -50,7 +50,7 @@ properties:
     default: ignore
     summary: How to handle errors during transformation
     description: |
-      Controls how the processor handles errors during transformation:
+      Controls how the component handles errors during transformation:
       - ignore: Log errors but continue processing
       - silent: Ignore errors silently
       - propagate: Stop processing and return the error


### PR DESCRIPTION
## Which problem is this PR solving?

Updates summary and descriptions of components to use "component" instead of "processor".

Note that only the `LogBodyJSONParsingProcessor` component is marked as alpha so is available for users to see.

## Short description of the changes
- Update component name and summary to replace usage of processor
- Add missing enhance partition validator to schema


