### PR TITLE
fix: enforce collector pipelines have a receiver and exporter

### DIFF
--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -1,6 +1,7 @@
 package tmpl
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -111,16 +112,17 @@ func (f *collectorConfigFormat) validatePipelines() error {
 		return nil
 	}
 
+	var errs []error
 	for pipelineName, pipeline := range f.Service.Pipelines {
 		if len(pipeline.Receivers) == 0 {
-			return fmt.Errorf("pipeline '%s' must have at least one receiver", pipelineName)
+			errs = append(errs, fmt.Errorf("pipeline '%s' must have at least one receiver", pipelineName))
 		}
 		if len(pipeline.Exporters) == 0 {
-			return fmt.Errorf("pipeline '%s' must have at least one exporter", pipelineName)
+			errs = append(errs, fmt.Errorf("pipeline '%s' must have at least one exporter", pipelineName))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // Set sets a key in the config to a value. If the key already exists, it will

--- a/pkg/config/tmpl/collectorconfig.go
+++ b/pkg/config/tmpl/collectorconfig.go
@@ -105,6 +105,24 @@ func dedup[T comparable](slice []T) []T {
 	return list
 }
 
+// validatePipelines checks that all collector pipelines have at least one receiver and one exporter
+func (f *collectorConfigFormat) validatePipelines() error {
+	if f.Service == nil {
+		return nil
+	}
+
+	for pipelineName, pipeline := range f.Service.Pipelines {
+		if len(pipeline.Receivers) == 0 {
+			return fmt.Errorf("pipeline '%s' must have at least one receiver", pipelineName)
+		}
+		if len(pipeline.Exporters) == 0 {
+			return fmt.Errorf("pipeline '%s' must have at least one exporter", pipelineName)
+		}
+	}
+
+	return nil
+}
+
 // Set sets a key in the config to a value. If the key already exists, it will
 // append the value to the existing value if it's a slice, or overwrite it if
 // it's not a slice.
@@ -184,6 +202,11 @@ func (cc *CollectorConfig) RenderYAML() ([]byte, error) {
 	}
 
 	f.injectHoneycombUsageComponents()
+
+	// Validate that all pipelines have receivers and exporters
+	if err = f.validatePipelines(); err != nil {
+		return nil, err
+	}
 
 	// now marshal from the struct to yaml
 	data, err = y.Marshal(f)

--- a/pkg/config/tmpl/collectorconfig_test.go
+++ b/pkg/config/tmpl/collectorconfig_test.go
@@ -82,3 +82,35 @@ service:
 		t.Errorf("CollectorConfig.RenderYAML() got = \n%s, want \n%v", got, want)
 	}
 }
+
+func TestCollectorConfig_ValidatePipelinesWithMultipleErrors(t *testing.T) {
+	cc := NewCollectorConfig()
+	cc.Set("receivers", "otlp.port", "4317")
+	cc.Set("exporters", "otlphttp.endpoint", "http://localhost:4318")
+	// Create multiple pipelines with missing receivers and exporters
+	cc.Set("service", "pipelines.traces.processors", []string{"custom/foo"})
+	cc.Set("service", "pipelines.metrics.receivers", []string{"otlp"})
+	cc.Set("service", "pipelines.logs.processors", []string{"custom/bar"})
+
+	_, err := cc.RenderYAML()
+	if err == nil {
+		t.Error("CollectorConfig.RenderYAML() expected error, got nil")
+		return
+	}
+
+	// Verify that the error contains messages for all invalid pipelines
+	errStr := err.Error()
+	expectedErrors := []string{
+		"pipeline 'traces' must have at least one receiver",
+		"pipeline 'traces' must have at least one exporter",
+		"pipeline 'metrics' must have at least one exporter",
+		"pipeline 'logs' must have at least one receiver",
+		"pipeline 'logs' must have at least one exporter",
+	}
+
+	for _, expectedErr := range expectedErrors {
+		if !strings.Contains(errStr, expectedErr) {
+			t.Errorf("Expected error to contain %q, but got: %s", expectedErr, errStr)
+		}
+	}
+}

--- a/pkg/config/tmpl/collectorconfig_test.go
+++ b/pkg/config/tmpl/collectorconfig_test.go
@@ -9,8 +9,10 @@ func TestCollectorConfig_RenderYAML(t *testing.T) {
 	cc := NewCollectorConfig()
 	cc.Set("receivers", "otlp.port", "4317")
 	cc.Set("receivers", "otlp.endpoint", "localhost")
+	cc.Set("exporters", "otlphttp.endpoint", "http://localhost:4318")
 	cc.Set("service", "pipelines.traces.receivers", []string{"otlp"})
 	cc.Set("service", "pipelines.traces.processors", []string{})
+	cc.Set("service", "pipelines.traces.exporters", []string{"otlphttp"})
 	// NOTE: this "want" string is indented with spaces, not tabs; the YAML renderer uses spaces.
 	want := `
 receivers:
@@ -19,6 +21,9 @@ receivers:
         port: "4317"
 processors:
     usage: {}
+exporters:
+    otlphttp:
+        endpoint: http://localhost:4318
 extensions:
     honeycomb: {}
 service:
@@ -27,7 +32,7 @@ service:
         traces:
             receivers: [otlp]
             processors: [usage]
-            exporters: []
+            exporters: [otlphttp]
 `
 	got, err := cc.RenderYAML()
 	if err != nil {
@@ -43,8 +48,10 @@ service:
 func TestCollectorConfig_ProcessorOrdering(t *testing.T) {
 	cc := NewCollectorConfig()
 	cc.Set("receivers", "otlp.port", "4317")
+	cc.Set("exporters", "otlphttp.endpoint", "http://localhost:4318")
 	cc.Set("service", "pipelines.traces.receivers", []string{"otlp"})
 	cc.Set("service", "pipelines.traces.processors", []string{"memory_limiter/otlp", "custom/foo"})
+	cc.Set("service", "pipelines.traces.exporters", []string{"otlphttp"})
 	// NOTE: this "want" string is indented with spaces, not tabs; the YAML renderer uses spaces.
 	want := `
 receivers:
@@ -52,6 +59,9 @@ receivers:
         port: "4317"
 processors:
     usage: {}
+exporters:
+    otlphttp:
+        endpoint: http://localhost:4318
 extensions:
     honeycomb: {}
 service:
@@ -60,7 +70,7 @@ service:
         traces:
             receivers: [otlp]
             processors: [memory_limiter/otlp, usage, custom/foo]
-            exporters: []
+            exporters: [otlphttp]
 `
 	got, err := cc.RenderYAML()
 	if err != nil {

--- a/pkg/translator/testdata/bad_hpsf/branching_paths.yaml
+++ b/pkg/translator/testdata/bad_hpsf/branching_paths.yaml
@@ -1,0 +1,36 @@
+components:
+  - name: OTel Receiver
+    kind: OTelReceiver
+  - name: Processor Valid
+    kind: RedactionProcessor
+  - name: Processor Invalid
+    kind: RedactionProcessor
+  - name: Honeycomb Exporter
+    kind: HoneycombExporter
+connections:
+  # Valid path 1: receiver -> processor -> exporter (traces)
+  - source:
+      component: OTel Receiver
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Processor Valid
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Processor Valid
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Honeycomb Exporter
+      port: Traces
+      type: OTelTraces
+  # Invalid path 2: receiver -> processor (no exporter) (metrics)
+  - source:
+      component: OTel Receiver
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: Processor Invalid
+      port: Metrics
+      type: OTelMetrics

--- a/pkg/translator/testdata/bad_hpsf/mixed_collector_sampling.yaml
+++ b/pkg/translator/testdata/bad_hpsf/mixed_collector_sampling.yaml
@@ -1,0 +1,63 @@
+components:
+  - name: OTel Receiver
+    kind: OTelReceiver
+  - name: Redaction Processor
+    kind: RedactionProcessor
+  - name: Start Sampling
+    kind: SamplingSequencer
+  - name: Keep All Sampler
+    kind: KeepAllSampler
+  - name: Honeycomb Exporter
+    kind: HoneycombExporter
+connections:
+  # Valid collector path: receiver -> processor -> exporter (traces)
+  - source:
+      component: OTel Receiver
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Redaction Processor
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Redaction Processor
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Honeycomb Exporter
+      port: Traces
+      type: OTelTraces
+  # Invalid collector path: processor -> exporter without receiver (metrics)
+  - source:
+      component: Redaction Processor
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: Honeycomb Exporter
+      port: Metrics
+      type: OTelMetrics
+  # Sampling path
+  - source:
+      component: OTel Receiver
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Start Sampling
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Start Sampling
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Keep All Sampler
+      port: Sample
+      type: SampleData
+  - source:
+      component: Keep All Sampler
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Honeycomb Exporter
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/bad_hpsf/multi_signal_no_exporters.yaml
+++ b/pkg/translator/testdata/bad_hpsf/multi_signal_no_exporters.yaml
@@ -1,0 +1,26 @@
+components:
+  - name: OTel Receiver
+    kind: OTelReceiver
+  - name: Processor Traces
+    kind: RedactionProcessor
+  - name: Processor Metrics
+    kind: RedactionProcessor
+connections:
+  # Invalid traces path: receiver -> processor (no exporter)
+  - source:
+      component: OTel Receiver
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Processor Traces
+      port: Traces
+      type: OTelTraces
+  # Invalid metrics path: receiver -> processor (no exporter)
+  - source:
+      component: OTel Receiver
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: Processor Metrics
+      port: Metrics
+      type: OTelMetrics

--- a/pkg/translator/testdata/bad_hpsf/multi_signal_no_receivers.yaml
+++ b/pkg/translator/testdata/bad_hpsf/multi_signal_no_receivers.yaml
@@ -1,0 +1,47 @@
+components:
+  - name: OTel Receiver
+    kind: OTelReceiver
+  - name: Valid Processor
+    kind: RedactionProcessor
+  - name: Invalid Processor Traces
+    kind: RedactionProcessor
+  - name: Invalid Processor Metrics
+    kind: RedactionProcessor
+  - name: Honeycomb Exporter
+    kind: HoneycombExporter
+connections:
+  # Valid logs path: receiver -> processor -> exporter
+  - source:
+      component: OTel Receiver
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Valid Processor
+      port: Logs
+      type: OTelLogs
+  - source:
+      component: Valid Processor
+      port: Logs
+      type: OTelLogs
+    destination:
+      component: Honeycomb Exporter
+      port: Logs
+      type: OTelLogs
+  # Invalid traces path: processor -> exporter (no receiver)
+  - source:
+      component: Invalid Processor Traces
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Honeycomb Exporter
+      port: Traces
+      type: OTelTraces
+  # Invalid metrics path: processor -> exporter (no receiver)
+  - source:
+      component: Invalid Processor Metrics
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: Honeycomb Exporter
+      port: Metrics
+      type: OTelMetrics

--- a/pkg/translator/testdata/bad_hpsf/path_to_startsampling_no_receiver.yaml
+++ b/pkg/translator/testdata/bad_hpsf/path_to_startsampling_no_receiver.yaml
@@ -1,0 +1,40 @@
+components:
+  - name: Redaction Processor
+    kind: RedactionProcessor
+    version: v0.1.0
+  - name: Start Sampling
+    kind: SamplingSequencer
+    version: v0.1.0
+  - name: Deterministic Sampler
+    kind: DeterministicSampler
+    version: v0.1.0
+  - name: Honeycomb Exporter
+    kind: HoneycombExporter
+    version: v0.1.0
+connections:
+  # Invalid OTel path: processor -> startsampling (missing receiver)
+  - source:
+      component: Redaction Processor
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling
+      port: Traces
+      type: OTelTraces
+  # Sampling configuration: startsampling -> sampler -> exporter
+  - source:
+      component: Start Sampling
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Deterministic Sampler
+      port: Sample
+      type: SampleData
+  - source:
+      component: Deterministic Sampler
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Honeycomb Exporter
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/bad_hpsf/pipeline_no_exporter.yaml
+++ b/pkg/translator/testdata/bad_hpsf/pipeline_no_exporter.yaml
@@ -1,0 +1,16 @@
+components:
+  - name: Receive OTel
+    kind: OTelReceiver
+    version: v0.1.0
+  - name: Mask sensitive values
+    kind: RedactionProcessor
+    version: v0.1.0
+connections:
+  - source:
+      component: Receive OTel
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Mask sensitive values
+      port: Traces
+      type: OTelTraces

--- a/pkg/translator/testdata/bad_hpsf/pipeline_no_receiver.yaml
+++ b/pkg/translator/testdata/bad_hpsf/pipeline_no_receiver.yaml
@@ -1,0 +1,35 @@
+components:
+  - name: Receive OTel
+    kind: OTelReceiver
+    version: v0.1.0
+  - name: Mask sensitive values
+    kind: RedactionProcessor
+    version: v0.1.0
+  - name: Send to Honeycomb
+    kind: HoneycombExporter
+    version: v0.1.0
+connections:
+  - source:
+      component: Receive OTel
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Mask sensitive values
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Mask sensitive values
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Send to Honeycomb
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Mask sensitive values
+      port: Metrics
+      type: OTelMetrics
+    destination:
+      component: Send to Honeycomb
+      port: Metrics
+      type: OTelMetrics

--- a/pkg/translator/testdata/bad_hpsf/processor_chain_only.yaml
+++ b/pkg/translator/testdata/bad_hpsf/processor_chain_only.yaml
@@ -1,0 +1,15 @@
+components:
+  - name: Processor 1
+    kind: RedactionProcessor
+  - name: Processor 2
+    kind: RedactionProcessor
+connections:
+  # Invalid: processor chain with no receiver or exporter
+  - source:
+      component: Processor 1
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Processor 2
+      port: Traces
+      type: OTelTraces

--- a/pkg/translator/testdata/bad_hpsf/valid_path_to_startsampling.yaml
+++ b/pkg/translator/testdata/bad_hpsf/valid_path_to_startsampling.yaml
@@ -1,0 +1,51 @@
+components:
+  - name: OTel Receiver
+    kind: OTelReceiver
+    version: v0.1.0
+  - name: Redaction Processor
+    kind: RedactionProcessor
+    version: v0.1.0
+  - name: Start Sampling
+    kind: SamplingSequencer
+    version: v0.1.0
+  - name: Deterministic Sampler
+    kind: DeterministicSampler
+    version: v0.1.0
+  - name: Honeycomb Exporter
+    kind: HoneycombExporter
+    version: v0.1.0
+connections:
+  # Valid OTel path: receiver -> processor -> startsampling
+  - source:
+      component: OTel Receiver
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Redaction Processor
+      port: Traces
+      type: OTelTraces
+  - source:
+      component: Redaction Processor
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Start Sampling
+      port: Traces
+      type: OTelTraces
+  # Sampling configuration: startsampling -> sampler -> exporter
+  - source:
+      component: Start Sampling
+      port: Rule 1
+      type: SampleData
+    destination:
+      component: Deterministic Sampler
+      port: Sample
+      type: SampleData
+  - source:
+      component: Deterministic Sampler
+      port: Events
+      type: HoneycombEvents
+    destination:
+      component: Honeycomb Exporter
+      port: Events
+      type: HoneycombEvents

--- a/pkg/translator/testdata/bad_hpsf/valid_pipeline_direct.yaml
+++ b/pkg/translator/testdata/bad_hpsf/valid_pipeline_direct.yaml
@@ -1,0 +1,16 @@
+components:
+  - name: Receive OTel
+    kind: OTelReceiver
+    version: v0.1.0
+  - name: Send to Honeycomb
+    kind: HoneycombExporter
+    version: v0.1.0
+connections:
+  - source:
+      component: Receive OTel
+      port: Traces
+      type: OTelTraces
+    destination:
+      component: Send to Honeycomb
+      port: Traces
+      type: OTelTraces

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -481,6 +482,50 @@ func (t *Translator) validateStartSampling(h *hpsf.HPSF, templateComps map[strin
 	return result
 }
 
+func (t *Translator) validateCollectorPipelines(h *hpsf.HPSF, templateComps map[string]config.TemplateComponent) validator.Result {
+	result := validator.NewResult("HPSF collector pipeline validation errors")
+
+	paths := h.FindAllPaths(nil)
+
+	for _, path := range paths {
+		// Only validate OTel signal paths (logs, metrics, traces)
+		// Skip non-collector paths
+		if !slices.Contains(hpsf.CollectorSignalTypes, path.ConnType) {
+			continue
+		}
+
+		if len(path.Path) == 0 {
+			continue
+		}
+
+		// Check first component is a receiver
+		firstComp := path.Path[0]
+		firstTemplate, ok := templateComps[firstComp.GetSafeName()]
+		if !ok {
+			continue
+		}
+		if firstTemplate.Style != "receiver" {
+			err := hpsf.NewErrorf("pipeline must start with a receiver component, but starts with %s component '%s'", firstTemplate.Style, firstComp.Name).
+				WithComponent(firstComp.Name)
+			result.Add(err)
+		}
+
+		// Check last component is an exporter or startsampling
+		lastComp := path.Path[len(path.Path)-1]
+		lastTemplate, ok := templateComps[lastComp.GetSafeName()]
+		if !ok {
+			continue
+		}
+		if lastTemplate.Style != "exporter" && lastTemplate.Style != "startsampling" {
+			err := hpsf.NewErrorf("pipeline must end with an exporter or startsampling component, but ends with %s component '%s'", lastTemplate.Style, lastComp.Name).
+				WithComponent(lastComp.Name)
+			result.Add(err)
+		}
+	}
+
+	return result
+}
+
 // ValidateConfig validates the configuration of the HPSF document as it stands with respect to the
 // components and templates installed in the translator.
 // Note that it returns a validation.Result so that the errors can be collected and reported in a
@@ -514,6 +559,7 @@ func (t *Translator) ValidateConfig(h *hpsf.HPSF) error {
 	result.Add(t.validateConnectionPorts(h, templateComps))
 	result.Add(t.validateStartSampling(h, templateComps))
 	result.Add(t.validateSamplerConnections(h, templateComps))
+	result.Add(t.validateCollectorPipelines(h, templateComps))
 
 	return result.ErrOrNil()
 }

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -401,6 +401,14 @@ func TestTranslator_ValidateBadConfigs(t *testing.T) {
 		{"missing port", "testdata/bad_hpsf/missing_port.yaml", "source component does not have a port,destination component does not have a port"},
 		{"missing condition on lower index", "testdata/bad_hpsf/missing_condition_on_lower_index.yaml", "Every path on a startsampler except the one with the highest index must connect to a condition"},
 		{"missing component for specified version", "testdata/bad_hpsf/invalid_component_version.yaml", "failed to locate corresponding template component for HoneycombExporter@v999999.1.0"},
+		{"pipeline without receiver", "testdata/bad_hpsf/pipeline_no_receiver.yaml", "pipeline must start with a receiver component"},
+		{"pipeline without exporter", "testdata/bad_hpsf/pipeline_no_exporter.yaml", "pipeline must end with an exporter or startsampling component"},
+		{"mixed collector and sampling with invalid metrics path", "testdata/bad_hpsf/mixed_collector_sampling.yaml", "pipeline must start with a receiver component"},
+		{"multiple signal types missing receivers", "testdata/bad_hpsf/multi_signal_no_receivers.yaml", "pipeline must start with a receiver component,pipeline must start with a receiver component"},
+		{"multiple signal types missing exporters", "testdata/bad_hpsf/multi_signal_no_exporters.yaml", "pipeline must end with an exporter or startsampling component,pipeline must end with an exporter or startsampling component"},
+		{"branching paths with one invalid", "testdata/bad_hpsf/branching_paths.yaml", "pipeline must end with an exporter or startsampling component"},
+		{"processor chain only", "testdata/bad_hpsf/processor_chain_only.yaml", "pipeline must start with a receiver component,pipeline must end with an exporter or startsampling component"},
+		{"path to startsampling without receiver", "testdata/bad_hpsf/path_to_startsampling_no_receiver.yaml", "pipeline must start with a receiver component"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -449,6 +457,8 @@ func TestTranslator_ValidateValidConfigs(t *testing.T) {
 		file string
 	}{
 		{"valid condition on lower index", "testdata/bad_hpsf/valid_condition_on_lower_index.yaml"},
+		{"valid direct receiver to exporter", "testdata/bad_hpsf/valid_pipeline_direct.yaml"},
+		{"valid path ending with startsampling", "testdata/bad_hpsf/valid_path_to_startsampling.yaml"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes an issue where HPSF could render collector config that contained a pipeline without a receiver or exporter. Such a config would not start

Closes PIPE-343

## Short description of the changes

- Add error when rendering the collector config if a pipeline has no receivers or exporters
- Add new function to Validate to enforce OTEL paths starting with a receiver and ending with a exporter or startsampler.
- Add test cases

